### PR TITLE
Update op.rs to check for valid arguments

### DIFF
--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -238,7 +238,7 @@ pub fn simplify<'c>(ast: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
         AstOp::FpGeq(_, _) => todo!(),
         AstOp::FpIsNan(_) => todo!(),
         AstOp::FpIsInf(_) => todo!(),
-        AstOp::StrLen(_) => todo!(),
+        AstOp::StrLen(_, _) => todo!(),
         AstOp::StrConcat(_, _) => todo!(),
         AstOp::StrSubstr(_, _, _) => todo!(),
         AstOp::StrContains(_, _) => todo!(),

--- a/crates/clarirs_core/src/ast/factory.rs
+++ b/crates/clarirs_core/src/ast/factory.rs
@@ -341,8 +341,12 @@ where {
         self.make_ast(AstOp::FpIsInf(lhs.clone()))
     }
 
-    fn strlen(&'c self, lhs: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
-        self.make_ast(AstOp::StrLen(lhs.clone()))
+    fn strlen(
+        &'c self,
+        lhs: &AstRef<'c>,
+        bitlength: &AstRef<'c>,
+    ) -> Result<AstRef<'c>, ClarirsError> {
+        self.make_ast(AstOp::StrLen(lhs.clone(), bitlength.clone()))
     }
 
     fn strconcat(&'c self, lhs: &AstRef<'c>, rhs: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
@@ -399,8 +403,8 @@ where {
         self.make_ast(AstOp::StrSuffixOf(lhs.clone(), rhs.clone()))
     }
 
-    fn strtobv(&'c self, lhs: &AstRef<'c>, width: u32) -> Result<AstRef<'c>, ClarirsError> {
-        self.make_ast(AstOp::StrToBV(lhs.clone(), width))
+    fn strtobv(&'c self, lhs: &AstRef<'c>, width: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
+        self.make_ast(AstOp::StrToBV(lhs.clone(), width.clone()))
     }
 
     fn bvtostr(&'c self, lhs: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {

--- a/crates/clarirs_core/src/ast/op.rs
+++ b/crates/clarirs_core/src/ast/op.rs
@@ -144,29 +144,72 @@ impl<'c> AstOp<'c> {
             | AstOp::SLE(lhs, rhs)
             | AstOp::SGT(lhs, rhs)
             | AstOp::SGE(lhs, rhs) => lhs.kind().is_bitvec() && rhs.kind().is_bitvec(),
-            AstOp::ZeroExt(_, _) => todo!(),
-            AstOp::SignExt(_, _) => todo!(),
-            AstOp::Extract(_, _, _) => todo!(),
-            AstOp::Reverse(_) => todo!(),
-            AstOp::FpToFp(_, _) => todo!(),
-            AstOp::BvToFpUnsigned(_, _, _) => todo!(),
-            AstOp::FpToIEEEBV(_) => todo!(),
-            AstOp::FpToUBV(_, _, _) => todo!(),
-            AstOp::FpToSBV(_, _, _) => todo!(),
+            AstOp::ZeroExt(input_bitvec, _num_of_zeroes) => input_bitvec.kind().is_bitvec(),
+            AstOp::SignExt(input_bitvec, _num_of_zeroes) => input_bitvec.kind().is_bitvec(),
+            AstOp::Extract(input_bitvec, _from, _to) => input_bitvec.kind().is_bitvec(),
+            AstOp::Reverse(input_bitvec) => input_bitvec.kind().is_bitvec(),
+            AstOp::FpToFp(floating_point, sort) => {
+                floating_point.kind().is_float() && matches!(sort, FSort { .. })
+            }
+            AstOp::BvToFpUnsigned(floating_point, sort, rounding_mode) => {
+                floating_point.kind().is_float()
+                    && matches!(sort, FSort { .. })
+                    && matches!(
+                        rounding_mode,
+                        FPRM::NearestTiesToEven
+                            | FPRM::TowardPositive
+                            | FPRM::TowardNegative
+                            | FPRM::TowardZero
+                            | FPRM::NearestTiesToAway
+                    )
+            }
+            AstOp::FpToIEEEBV(floating_point) => floating_point.kind().is_float(),
+            AstOp::FpToUBV(floating_point, _size, rounding_mode) => {
+                floating_point.kind().is_float()
+                    && matches!(
+                        rounding_mode,
+                        FPRM::NearestTiesToEven
+                            | FPRM::TowardPositive
+                            | FPRM::TowardNegative
+                            | FPRM::TowardZero
+                            | FPRM::NearestTiesToAway
+                    )
+            }
+            AstOp::FpToSBV(floating_point, _size, rounding_mode) => {
+                floating_point.kind().is_float()
+                    && matches!(
+                        rounding_mode,
+                        FPRM::NearestTiesToEven
+                            | FPRM::TowardPositive
+                            | FPRM::TowardNegative
+                            | FPRM::TowardZero
+                            | FPRM::NearestTiesToAway
+                    )
+            }
             AstOp::FpNeg(ast, _) | AstOp::FpAbs(ast, _) => ast.kind().is_float(),
             AstOp::FpAdd(lhs, rhs, _)
             | AstOp::FpSub(lhs, rhs, _)
             | AstOp::FpMul(lhs, rhs, _)
             | AstOp::FpDiv(lhs, rhs, _) => lhs.kind().is_float() && rhs.kind().is_float(),
-            AstOp::FpSqrt(_, _) => todo!(),
-            AstOp::FpEq(_, _) => todo!(),
-            AstOp::FpNeq(_, _) => todo!(),
-            AstOp::FpLt(_, _) => todo!(),
-            AstOp::FpLeq(_, _) => todo!(),
-            AstOp::FpGt(_, _) => todo!(),
-            AstOp::FpGeq(_, _) => todo!(),
-            AstOp::FpIsNan(_) => todo!(),
-            AstOp::FpIsInf(_) => todo!(),
+            AstOp::FpSqrt(a, arg_1) => {
+                a.kind().is_float()
+                    && matches!(
+                        arg_1,
+                        FPRM::NearestTiesToEven
+                            | FPRM::TowardPositive
+                            | FPRM::TowardNegative
+                            | FPRM::TowardZero
+                            | FPRM::NearestTiesToAway
+                    )
+            }
+            AstOp::FpEq(a, b) => a.kind().is_float() && b.kind().is_float(),
+            AstOp::FpNeq(a, b) => a.kind().is_float() && b.kind().is_float(),
+            AstOp::FpLt(a, b) => a.kind().is_float() && b.kind().is_float(),
+            AstOp::FpLeq(a, b) => a.kind().is_float() && b.kind().is_float(),
+            AstOp::FpGt(a, b) => a.kind().is_float() && b.kind().is_float(),
+            AstOp::FpGeq(a, b) => a.kind().is_float() && b.kind().is_float(),
+            AstOp::FpIsNan(a) => a.kind().is_float(),
+            AstOp::FpIsInf(a) => a.kind().is_float(),
             AstOp::StrLen(input_string, bitlength) => {
                 input_string.kind().is_string() && bitlength.kind().is_bitvec()
             }

--- a/crates/clarirs_core/src/ast/op.rs
+++ b/crates/clarirs_core/src/ast/op.rs
@@ -57,9 +57,9 @@ pub enum AstOp<'c> {
     SGE(AstRef<'c>, AstRef<'c>),
 
     // Floating point ops
-    FpToFp(AstRef<'c>, FSort),
-    BvToFpUnsigned(AstRef<'c>, FSort, FPRM),
-    FpToIEEEBV(AstRef<'c>),
+    FpToFp(AstRef<'c>, FSort), // FpToFp(AstRef<'c>, FSort, FPRM is optional)
+    BvToFpUnsigned(AstRef<'c>, FSort, FPRM), //Check is this is correct
+    FpToIEEEBV(AstRef<'c>),    //Check is this is correct
     FpToUBV(AstRef<'c>, u32, FPRM),
     FpToSBV(AstRef<'c>, u32, FPRM),
 
@@ -119,6 +119,8 @@ impl<'c> AstOp<'c> {
             AstOp::And(lhs, rhs) | AstOp::Or(lhs, rhs) | AstOp::Xor(lhs, rhs) => {
                 (lhs.kind().is_bool() || lhs.kind().is_bitvec()) && lhs.kind() == rhs.kind()
             }
+
+            // Bitvector ops and Bitvector comparison ops
             AstOp::Add(lhs, rhs)
             | AstOp::Sub(lhs, rhs)
             | AstOp::Mul(lhs, rhs)
@@ -144,111 +146,58 @@ impl<'c> AstOp<'c> {
             | AstOp::SLE(lhs, rhs)
             | AstOp::SGT(lhs, rhs)
             | AstOp::SGE(lhs, rhs) => lhs.kind().is_bitvec() && rhs.kind().is_bitvec(),
-            AstOp::ZeroExt(input_bitvec, _num_of_zeroes) => input_bitvec.kind().is_bitvec(),
-            AstOp::SignExt(input_bitvec, _num_of_zeroes) => input_bitvec.kind().is_bitvec(),
-            AstOp::Extract(input_bitvec, _from, _to) => input_bitvec.kind().is_bitvec(),
-            AstOp::Reverse(input_bitvec) => input_bitvec.kind().is_bitvec(),
-            AstOp::FpToFp(floating_point, sort) => {
-                floating_point.kind().is_float() && matches!(sort, FSort { .. })
+            AstOp::ZeroExt(ast, _)
+            | AstOp::SignExt(ast, _)
+            | AstOp::Extract(ast, _, _)
+            | AstOp::Reverse(ast) => ast.kind().is_bitvec(),
+
+            // Floating point ops
+            AstOp::FpToFp(ast, _)
+            | AstOp::BvToFpUnsigned(ast, _, _)
+            | AstOp::FpToIEEEBV(ast)
+            | AstOp::FpToUBV(ast, _, _)
+            | AstOp::FpToSBV(ast, _, _) => ast.kind().is_float(),
+
+            // Floating point arithmetic ops
+            AstOp::FpNeg(ast, _) | AstOp::FpAbs(ast, _) | AstOp::FpSqrt(ast, _) => {
+                ast.kind().is_float()
             }
-            AstOp::BvToFpUnsigned(floating_point, sort, rounding_mode) => {
-                floating_point.kind().is_float()
-                    && matches!(sort, FSort { .. })
-                    && matches!(
-                        rounding_mode,
-                        FPRM::NearestTiesToEven
-                            | FPRM::TowardPositive
-                            | FPRM::TowardNegative
-                            | FPRM::TowardZero
-                            | FPRM::NearestTiesToAway
-                    )
-            }
-            AstOp::FpToIEEEBV(floating_point) => floating_point.kind().is_float(),
-            AstOp::FpToUBV(floating_point, _size, rounding_mode) => {
-                floating_point.kind().is_float()
-                    && matches!(
-                        rounding_mode,
-                        FPRM::NearestTiesToEven
-                            | FPRM::TowardPositive
-                            | FPRM::TowardNegative
-                            | FPRM::TowardZero
-                            | FPRM::NearestTiesToAway
-                    )
-            }
-            AstOp::FpToSBV(floating_point, _size, rounding_mode) => {
-                floating_point.kind().is_float()
-                    && matches!(
-                        rounding_mode,
-                        FPRM::NearestTiesToEven
-                            | FPRM::TowardPositive
-                            | FPRM::TowardNegative
-                            | FPRM::TowardZero
-                            | FPRM::NearestTiesToAway
-                    )
-            }
-            AstOp::FpNeg(ast, _) | AstOp::FpAbs(ast, _) => ast.kind().is_float(),
             AstOp::FpAdd(lhs, rhs, _)
             | AstOp::FpSub(lhs, rhs, _)
             | AstOp::FpMul(lhs, rhs, _)
             | AstOp::FpDiv(lhs, rhs, _) => lhs.kind().is_float() && rhs.kind().is_float(),
-            AstOp::FpSqrt(a, arg_1) => {
-                a.kind().is_float()
-                    && matches!(
-                        arg_1,
-                        FPRM::NearestTiesToEven
-                            | FPRM::TowardPositive
-                            | FPRM::TowardNegative
-                            | FPRM::TowardZero
-                            | FPRM::NearestTiesToAway
-                    )
+
+            // Floating point comparison ops
+            AstOp::FpEq(lhs, rhs)
+            | AstOp::FpNeq(lhs, rhs)
+            | AstOp::FpLt(lhs, rhs)
+            | AstOp::FpLeq(lhs, rhs)
+            | AstOp::FpGt(lhs, rhs)
+            | AstOp::FpGeq(lhs, rhs) => lhs.kind().is_float() && rhs.kind().is_float(),
+            AstOp::FpIsNan(ast) | AstOp::FpIsInf(ast) => ast.kind().is_float(),
+
+            // String ops
+            AstOp::StrLen(lhs, rhs) => lhs.kind().is_string() && rhs.kind().is_bitvec(),
+            AstOp::StrConcat(lhs, rhs) => lhs.kind().is_string() && rhs.kind().is_string(),
+            AstOp::StrSubstr(lhs, rhs, str) => {
+                lhs.kind().is_bitvec() && rhs.kind().is_bitvec() && str.kind().is_string()
             }
-            AstOp::FpEq(a, b) => a.kind().is_float() && b.kind().is_float(),
-            AstOp::FpNeq(a, b) => a.kind().is_float() && b.kind().is_float(),
-            AstOp::FpLt(a, b) => a.kind().is_float() && b.kind().is_float(),
-            AstOp::FpLeq(a, b) => a.kind().is_float() && b.kind().is_float(),
-            AstOp::FpGt(a, b) => a.kind().is_float() && b.kind().is_float(),
-            AstOp::FpGeq(a, b) => a.kind().is_float() && b.kind().is_float(),
-            AstOp::FpIsNan(a) => a.kind().is_float(),
-            AstOp::FpIsInf(a) => a.kind().is_float(),
-            AstOp::StrLen(input_string, bitlength) => {
-                input_string.kind().is_string() && bitlength.kind().is_bitvec()
+            AstOp::StrReplace(lhs, rhs, str) => {
+                lhs.kind().is_string() && rhs.kind().is_string() && str.kind().is_string()
             }
-            AstOp::StrConcat(first_string, second_string) => {
-                first_string.kind().is_string() && second_string.kind().is_string()
+            AstOp::StrContains(lhs, rhs)
+            | AstOp::StrIndexOf(lhs, rhs)
+            | AstOp::StrPrefixOf(lhs, rhs)
+            | AstOp::StrSuffixOf(lhs, rhs) => lhs.kind().is_string() && rhs.kind().is_string(),
+            AstOp::StrToBV(lhs, rhs) => lhs.kind().is_string() && rhs.kind().is_bitvec(),
+            AstOp::BVToStr(ast) => ast.kind().is_bitvec(),
+            AstOp::StrIsDigit(ast) => ast.kind().is_string(),
+
+            // String comparison ops
+            AstOp::StrEq(lhs, rhs) | AstOp::StrNeq(lhs, rhs) => {
+                lhs.kind().is_string() && rhs.kind().is_string()
             }
-            AstOp::StrSubstr(start_idx, count, initial_string) => {
-                start_idx.kind().is_bitvec()
-                    && count.kind().is_bitvec()
-                    && initial_string.kind().is_string()
-            }
-            AstOp::StrContains(input_string, substring) => {
-                input_string.kind().is_string() && substring.kind().is_string()
-            }
-            AstOp::StrIndexOf(input_string, substring) => {
-                input_string.kind().is_string() && substring.kind().is_string()
-            }
-            AstOp::StrReplace(initial_string, pattern_to_be_replaced, replacement_pattern) => {
-                initial_string.kind().is_string()
-                    && pattern_to_be_replaced.kind().is_string()
-                    && replacement_pattern.kind().is_string()
-            }
-            AstOp::StrPrefixOf(prefix, input_string) => {
-                prefix.kind().is_string() && input_string.kind().is_string()
-            }
-            AstOp::StrSuffixOf(suffix, input_string) => {
-                suffix.kind().is_string() && input_string.kind().is_string()
-            }
-            AstOp::StrToBV(input_string, bitlength) => {
-                input_string.kind().is_string() && bitlength.kind().is_bitvec()
-            }
-            AstOp::BVToStr(input_bitvector) => input_bitvector.kind().is_bitvec(),
-            AstOp::StrIsDigit(input_string) => input_string.kind().is_string(),
-            AstOp::StrEq(first_string, second_string) => {
-                first_string.kind().is_string() && second_string.kind().is_string()
-            }
-            AstOp::StrNeq(first_string, second_string) => {
-                first_string.kind().is_string() && second_string.kind().is_string()
-            }
+
             AstOp::If(_, _, _) => todo!(),
             AstOp::Annotated(_, _) => todo!(),
         }

--- a/crates/clarirs_core/src/ast/op.rs
+++ b/crates/clarirs_core/src/ast/op.rs
@@ -155,8 +155,8 @@ impl<'c> AstOp<'c> {
             AstOp::FpToFp(ast, _)
             | AstOp::BvToFpUnsigned(ast, _, _)
             | AstOp::FpToIEEEBV(ast)
-            | AstOp::FpToUBV(ast, _, _)
             | AstOp::FpToSBV(ast, _, _) => ast.kind().is_float(),
+            AstOp::FpToUBV(ast, size, _) => ast.kind().is_float() && *size > 0,
 
             // Floating point arithmetic ops
             AstOp::FpNeg(ast, _) | AstOp::FpAbs(ast, _) | AstOp::FpSqrt(ast, _) => {

--- a/crates/clarirs_core/src/ast/op.rs
+++ b/crates/clarirs_core/src/ast/op.rs
@@ -83,15 +83,15 @@ pub enum AstOp<'c> {
     FpIsInf(AstRef<'c>),
 
     // String ops
-    StrLen(AstRef<'c>),
-    StrConcat(AstRef<'c>, AstRef<'c>),
+    StrLen(AstRef<'c>, AstRef<'c>),    // or StrLen(AstRef<'c>, u32),
+    StrConcat(AstRef<'c>, AstRef<'c>), // StrConcat(Vec<AstRef<'c>>) To allow for any number of args,
     StrSubstr(AstRef<'c>, AstRef<'c>, AstRef<'c>),
     StrContains(AstRef<'c>, AstRef<'c>),
     StrIndexOf(AstRef<'c>, AstRef<'c>),
     StrReplace(AstRef<'c>, AstRef<'c>, AstRef<'c>),
     StrPrefixOf(AstRef<'c>, AstRef<'c>),
     StrSuffixOf(AstRef<'c>, AstRef<'c>),
-    StrToBV(AstRef<'c>, u32),
+    StrToBV(AstRef<'c>, AstRef<'c>), // StrToBV(AstRef<'c>, u32)
     BVToStr(AstRef<'c>),
     StrIsDigit(AstRef<'c>),
 
@@ -167,19 +167,45 @@ impl<'c> AstOp<'c> {
             AstOp::FpGeq(_, _) => todo!(),
             AstOp::FpIsNan(_) => todo!(),
             AstOp::FpIsInf(_) => todo!(),
-            AstOp::StrLen(_) => todo!(),
-            AstOp::StrConcat(_, _) => todo!(),
-            AstOp::StrSubstr(_, _, _) => todo!(),
-            AstOp::StrContains(_, _) => todo!(),
-            AstOp::StrIndexOf(_, _) => todo!(),
-            AstOp::StrReplace(_, _, _) => todo!(),
-            AstOp::StrPrefixOf(_, _) => todo!(),
-            AstOp::StrSuffixOf(_, _) => todo!(),
-            AstOp::StrToBV(_, _) => todo!(),
-            AstOp::BVToStr(_) => todo!(),
-            AstOp::StrIsDigit(_) => todo!(),
-            AstOp::StrEq(_, _) => todo!(),
-            AstOp::StrNeq(_, _) => todo!(),
+            AstOp::StrLen(input_string, bitlength) => {
+                input_string.kind().is_string() && bitlength.kind().is_bitvec()
+            }
+            AstOp::StrConcat(first_string, second_string) => {
+                first_string.kind().is_string() && second_string.kind().is_string()
+            }
+            AstOp::StrSubstr(start_idx, count, initial_string) => {
+                start_idx.kind().is_bitvec()
+                    && count.kind().is_bitvec()
+                    && initial_string.kind().is_string()
+            }
+            AstOp::StrContains(input_string, substring) => {
+                input_string.kind().is_string() && substring.kind().is_string()
+            }
+            AstOp::StrIndexOf(input_string, substring) => {
+                input_string.kind().is_string() && substring.kind().is_string()
+            }
+            AstOp::StrReplace(initial_string, pattern_to_be_replaced, replacement_pattern) => {
+                initial_string.kind().is_string()
+                    && pattern_to_be_replaced.kind().is_string()
+                    && replacement_pattern.kind().is_string()
+            }
+            AstOp::StrPrefixOf(prefix, input_string) => {
+                prefix.kind().is_string() && input_string.kind().is_string()
+            }
+            AstOp::StrSuffixOf(suffix, input_string) => {
+                suffix.kind().is_string() && input_string.kind().is_string()
+            }
+            AstOp::StrToBV(input_string, bitlength) => {
+                input_string.kind().is_string() && bitlength.kind().is_bitvec()
+            }
+            AstOp::BVToStr(input_bitvector) => input_bitvector.kind().is_bitvec(),
+            AstOp::StrIsDigit(input_string) => input_string.kind().is_string(),
+            AstOp::StrEq(first_string, second_string) => {
+                first_string.kind().is_string() && second_string.kind().is_string()
+            }
+            AstOp::StrNeq(first_string, second_string) => {
+                first_string.kind().is_string() && second_string.kind().is_string()
+            }
             AstOp::If(_, _, _) => todo!(),
             AstOp::Annotated(_, _) => todo!(),
         }
@@ -281,7 +307,7 @@ impl<'c> AstOp<'c> {
             | AstOp::FpSqrt(a, ..)
             | AstOp::FpIsNan(a)
             | AstOp::FpIsInf(a)
-            | AstOp::StrLen(a)
+            | AstOp::StrLen(a, ..)
             | AstOp::StrToBV(a, ..)
             | AstOp::BVToStr(a)
             | AstOp::StrIsDigit(a)


### PR DESCRIPTION
- Updated AstOp Enum to accept appropriate number and type of arguments
- Ensured correct data types of arguments in the match arms of function valid_args
- Checked valid arguments for String, Floating Points and Bit Vectors