### PR TITLE
Use dashmap for AST cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "clarirs_num",
+ "dashmap",
  "num-bigint",
  "paste",
  "petgraph",

--- a/crates/clarirs_core/Cargo.toml
+++ b/crates/clarirs_core/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 ahash = "0.8.11"
 anyhow = "1.0.86"
 clarirs_num = { path = "../clarirs_num" }
+dashmap = "6.1.0"
 num-bigint = { version = "0.4.6", features = ["serde"] }
 paste = "1.0.15"
 petgraph = "0.6.5"

--- a/crates/clarirs_core/src/ast/astcache.rs
+++ b/crates/clarirs_core/src/ast/astcache.rs
@@ -13,30 +13,30 @@ enum AstCacheValue<'c> {
 }
 
 impl<'c> AstCacheValue<'c> {
-    fn as_bool(&self) -> Option<&Weak<AstNode<'c, BooleanOp<'c>>>> {
+    fn as_bool(&self) -> Option<BoolAst<'c>> {
         match self {
-            AstCacheValue::Boolean(weak) => Some(weak),
+            AstCacheValue::Boolean(weak) => weak.upgrade(),
             _ => None,
         }
     }
 
-    fn as_bv(&self) -> Option<&Weak<AstNode<'c, BitVecOp<'c>>>> {
+    fn as_bv(&self) -> Option<BitVecAst<'c>> {
         match self {
-            AstCacheValue::BitVec(weak) => Some(weak),
+            AstCacheValue::BitVec(weak) => weak.upgrade(),
             _ => None,
         }
     }
 
-    fn as_float(&self) -> Option<&Weak<AstNode<'c, FloatOp<'c>>>> {
+    fn as_float(&self) -> Option<FloatAst<'c>> {
         match self {
-            AstCacheValue::Float(weak) => Some(weak),
+            AstCacheValue::Float(weak) => weak.upgrade(),
             _ => None,
         }
     }
 
-    fn as_string(&self) -> Option<&Weak<AstNode<'c, StringOp<'c>>>> {
+    fn as_string(&self) -> Option<StringAst<'c>> {
         match self {
-            AstCacheValue::String(weak) => Some(weak),
+            AstCacheValue::String(weak) => weak.upgrade(),
             _ => None,
         }
     }
@@ -53,11 +53,7 @@ impl<'c> AstCache<'c> {
         hash: u64,
         f: F,
     ) -> BoolAst<'c> {
-        match self
-            .inner
-            .get(&hash)
-            .and_then(|e| e.value().as_bool().and_then(|weak| weak.upgrade()))
-        {
+        match self.inner.get(&hash).and_then(|e| e.value().as_bool()) {
             Some(e) => e,
             None => {
                 let this = f();
@@ -73,11 +69,7 @@ impl<'c> AstCache<'c> {
         hash: u64,
         f: F,
     ) -> BitVecAst<'c> {
-        match self
-            .inner
-            .get(&hash)
-            .and_then(|e| e.value().as_bv().and_then(|weak| weak.upgrade()))
-        {
+        match self.inner.get(&hash).and_then(|e| e.value().as_bv()) {
             Some(e) => e,
             None => {
                 let this = f();
@@ -93,11 +85,7 @@ impl<'c> AstCache<'c> {
         hash: u64,
         f: F,
     ) -> FloatAst<'c> {
-        match self
-            .inner
-            .get(&hash)
-            .and_then(|e| e.value().as_float().and_then(|weak| weak.upgrade()))
-        {
+        match self.inner.get(&hash).and_then(|e| e.value().as_float()) {
             Some(e) => e,
             None => {
                 let this = f();
@@ -113,11 +101,7 @@ impl<'c> AstCache<'c> {
         hash: u64,
         f: F,
     ) -> StringAst<'c> {
-        match self
-            .inner
-            .get(&hash)
-            .and_then(|e| e.value().as_string().and_then(|weak| weak.upgrade()))
-        {
+        match self.inner.get(&hash).and_then(|e| e.value().as_string()) {
             Some(e) => e,
             None => {
                 let this = f();

--- a/crates/clarirs_core/src/ast/astcache.rs
+++ b/crates/clarirs_core/src/ast/astcache.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Weak};
 
-use dashmap::{mapref::entry, DashMap};
+use dashmap::DashMap;
 
 use crate::prelude::*;
 

--- a/crates/clarirs_core/src/ast/astcache.rs
+++ b/crates/clarirs_core/src/ast/astcache.rs
@@ -1,6 +1,6 @@
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::{Arc, Weak};
 
-use ahash::HashMap;
+use dashmap::{mapref::entry, DashMap};
 
 use crate::prelude::*;
 
@@ -12,9 +12,39 @@ enum AstCacheValue<'c> {
     String(Weak<AstNode<'c, StringOp<'c>>>),
 }
 
+impl<'c> AstCacheValue<'c> {
+    fn as_bool(&self) -> Option<&Weak<AstNode<'c, BooleanOp<'c>>>> {
+        match self {
+            AstCacheValue::Boolean(weak) => Some(weak),
+            _ => None,
+        }
+    }
+
+    fn as_bv(&self) -> Option<&Weak<AstNode<'c, BitVecOp<'c>>>> {
+        match self {
+            AstCacheValue::BitVec(weak) => Some(weak),
+            _ => None,
+        }
+    }
+
+    fn as_float(&self) -> Option<&Weak<AstNode<'c, FloatOp<'c>>>> {
+        match self {
+            AstCacheValue::Float(weak) => Some(weak),
+            _ => None,
+        }
+    }
+
+    fn as_string(&self) -> Option<&Weak<AstNode<'c, StringOp<'c>>>> {
+        match self {
+            AstCacheValue::String(weak) => Some(weak),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct AstCache<'c> {
-    inner: RwLock<HashMap<u64, AstCacheValue<'c>>>,
+    inner: DashMap<u64, AstCacheValue<'c>, ahash::RandomState>,
 }
 
 impl<'c> AstCache<'c> {
@@ -23,21 +53,18 @@ impl<'c> AstCache<'c> {
         hash: u64,
         f: F,
     ) -> BoolAst<'c> {
-        let mut inner = self.inner.write().unwrap();
-        let entry = inner
-            .entry(hash)
-            .or_insert_with(|| AstCacheValue::Boolean(Weak::new()));
-        match entry {
-            AstCacheValue::Boolean(weak) => {
-                if let Some(arc) = weak.upgrade() {
-                    arc
-                } else {
-                    let arc = f();
-                    *entry = AstCacheValue::Boolean(Arc::downgrade(&arc));
-                    arc
-                }
+        match self
+            .inner
+            .get(&hash)
+            .and_then(|e| e.value().as_bool().and_then(|weak| weak.upgrade()))
+        {
+            Some(e) => e,
+            None => {
+                let this = f();
+                self.inner
+                    .insert(hash, AstCacheValue::Boolean(Arc::downgrade(&this)));
+                this
             }
-            _ => unreachable!(),
         }
     }
 
@@ -46,21 +73,18 @@ impl<'c> AstCache<'c> {
         hash: u64,
         f: F,
     ) -> BitVecAst<'c> {
-        let mut inner = self.inner.write().unwrap();
-        let entry = inner
-            .entry(hash)
-            .or_insert_with(|| AstCacheValue::BitVec(Weak::new()));
-        match entry {
-            AstCacheValue::BitVec(weak) => {
-                if let Some(arc) = weak.upgrade() {
-                    arc
-                } else {
-                    let arc = f();
-                    *entry = AstCacheValue::BitVec(Arc::downgrade(&arc));
-                    arc
-                }
+        match self
+            .inner
+            .get(&hash)
+            .and_then(|e| e.value().as_bv().and_then(|weak| weak.upgrade()))
+        {
+            Some(e) => e,
+            None => {
+                let this = f();
+                self.inner
+                    .insert(hash, AstCacheValue::BitVec(Arc::downgrade(&this)));
+                this
             }
-            _ => unreachable!(),
         }
     }
 
@@ -69,21 +93,18 @@ impl<'c> AstCache<'c> {
         hash: u64,
         f: F,
     ) -> FloatAst<'c> {
-        let mut inner = self.inner.write().unwrap();
-        let entry = inner
-            .entry(hash)
-            .or_insert_with(|| AstCacheValue::Float(Weak::new()));
-        match entry {
-            AstCacheValue::Float(weak) => {
-                if let Some(arc) = weak.upgrade() {
-                    arc
-                } else {
-                    let arc = f();
-                    *entry = AstCacheValue::Float(Arc::downgrade(&arc));
-                    arc
-                }
+        match self
+            .inner
+            .get(&hash)
+            .and_then(|e| e.value().as_float().and_then(|weak| weak.upgrade()))
+        {
+            Some(e) => e,
+            None => {
+                let this = f();
+                self.inner
+                    .insert(hash, AstCacheValue::Float(Arc::downgrade(&this)));
+                this
             }
-            _ => unreachable!(),
         }
     }
 
@@ -92,21 +113,18 @@ impl<'c> AstCache<'c> {
         hash: u64,
         f: F,
     ) -> StringAst<'c> {
-        let mut inner = self.inner.write().unwrap();
-        let entry = inner
-            .entry(hash)
-            .or_insert_with(|| AstCacheValue::String(Weak::new()));
-        match entry {
-            AstCacheValue::String(weak) => {
-                if let Some(arc) = weak.upgrade() {
-                    arc
-                } else {
-                    let arc = f();
-                    *entry = AstCacheValue::String(Arc::downgrade(&arc));
-                    arc
-                }
+        match self
+            .inner
+            .get(&hash)
+            .and_then(|e| e.value().as_string().and_then(|weak| weak.upgrade()))
+        {
+            Some(e) => e,
+            None => {
+                let this = f();
+                self.inner
+                    .insert(hash, AstCacheValue::String(Arc::downgrade(&this)));
+                this
             }
-            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
Dashmap's map uses interior mutability, so we don't have to manage the locks ourselves. reducing chance of error.