### PR TITLE
Add constructors for python AST types

### DIFF
--- a/crates/clarirs_py/src/ast/bool.rs
+++ b/crates/clarirs_py/src/ast/bool.rs
@@ -57,11 +57,7 @@ impl Bool {
 #[pymethods]
 impl Bool {
     #[new]
-    pub fn py_new(
-        py: Python,
-        op: &str,
-        args: Vec<PyObject>,
-    ) -> Result<Py<Bool>, ClaripyError> {
+    pub fn py_new(py: Python, op: &str, args: Vec<PyObject>) -> Result<Py<Bool>, ClaripyError> {
         Bool::new(
             py,
             &match op {
@@ -97,7 +93,7 @@ impl Bool {
                             &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
                         )?
                     }
-                },
+                }
                 "__ne__" => {
                     if args[0].downcast_bound::<Bool>(py).is_ok() {
                         GLOBAL_CONTEXT.neq(
@@ -172,8 +168,12 @@ impl Bool {
                     &args[0].downcast_bound::<FP>(py)?.get().inner,
                     &args[1].downcast_bound::<FP>(py)?.get().inner,
                 )?,
-                "fpIsNan" => GLOBAL_CONTEXT.fp_is_nan(&args[0].downcast_bound::<FP>(py)?.get().inner)?,
-                "fpIsInf" => GLOBAL_CONTEXT.fp_is_inf(&args[0].downcast_bound::<FP>(py)?.get().inner)?,
+                "fpIsNan" => {
+                    GLOBAL_CONTEXT.fp_is_nan(&args[0].downcast_bound::<FP>(py)?.get().inner)?
+                }
+                "fpIsInf" => {
+                    GLOBAL_CONTEXT.fp_is_inf(&args[0].downcast_bound::<FP>(py)?.get().inner)?
+                }
                 "StrContains" => GLOBAL_CONTEXT.strcontains(
                     &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
                     &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
@@ -186,7 +186,8 @@ impl Bool {
                     &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
                     &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
                 )?,
-                "StrIsDigit" => GLOBAL_CONTEXT.strisdigit(&args[0].downcast_bound::<PyAstString>(py)?.get().inner)?,
+                "StrIsDigit" => GLOBAL_CONTEXT
+                    .strisdigit(&args[0].downcast_bound::<PyAstString>(py)?.get().inner)?,
                 "If" => GLOBAL_CONTEXT.if_(
                     &args[0].downcast_bound::<Bool>(py)?.get().inner,
                     &args[1].downcast_bound::<Bool>(py)?.get().inner,

--- a/crates/clarirs_py/src/ast/bool.rs
+++ b/crates/clarirs_py/src/ast/bool.rs
@@ -56,6 +56,147 @@ impl Bool {
 
 #[pymethods]
 impl Bool {
+    #[new]
+    pub fn py_new(
+        py: Python,
+        op: &str,
+        args: Vec<PyObject>,
+    ) -> Result<Py<Bool>, ClaripyError> {
+        Bool::new(
+            py,
+            &match op {
+                "BoolS" => GLOBAL_CONTEXT.bools(&args[0].extract::<String>(py)?)?,
+                "BoolV" => GLOBAL_CONTEXT.boolv(args[0].extract::<bool>(py)?)?,
+                "Not" => GLOBAL_CONTEXT.not(&args[0].downcast_bound::<Bool>(py)?.get().inner)?,
+                "And" => GLOBAL_CONTEXT.and(
+                    &args[0].downcast_bound::<Bool>(py)?.get().inner,
+                    &args[1].downcast_bound::<Bool>(py)?.get().inner,
+                )?,
+                "Or" => GLOBAL_CONTEXT.or(
+                    &args[0].downcast_bound::<Bool>(py)?.get().inner,
+                    &args[1].downcast_bound::<Bool>(py)?.get().inner,
+                )?,
+                "Xor" => GLOBAL_CONTEXT.xor(
+                    &args[0].downcast_bound::<Bool>(py)?.get().inner,
+                    &args[1].downcast_bound::<Bool>(py)?.get().inner,
+                )?,
+                "__eq__" => {
+                    if args[0].downcast_bound::<Bool>(py).is_ok() {
+                        GLOBAL_CONTEXT.eq_(
+                            &args[0].downcast_bound::<Bool>(py)?.get().inner,
+                            &args[1].downcast_bound::<Bool>(py)?.get().inner,
+                        )?
+                    } else if args[0].downcast_bound::<BV>(py).is_ok() {
+                        GLOBAL_CONTEXT.eq_(
+                            &args[0].downcast_bound::<BV>(py)?.get().inner,
+                            &args[1].downcast_bound::<BV>(py)?.get().inner,
+                        )?
+                    } else {
+                        GLOBAL_CONTEXT.eq_(
+                            &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                            &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                        )?
+                    }
+                },
+                "__ne__" => {
+                    if args[0].downcast_bound::<Bool>(py).is_ok() {
+                        GLOBAL_CONTEXT.neq(
+                            &args[0].downcast_bound::<Bool>(py)?.get().inner,
+                            &args[1].downcast_bound::<Bool>(py)?.get().inner,
+                        )?
+                    } else if args[0].downcast_bound::<BV>(py).is_ok() {
+                        GLOBAL_CONTEXT.neq(
+                            &args[0].downcast_bound::<BV>(py)?.get().inner,
+                            &args[1].downcast_bound::<BV>(py)?.get().inner,
+                        )?
+                    } else {
+                        GLOBAL_CONTEXT.neq(
+                            &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                            &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                        )?
+                    }
+                }
+                "ULE" | "__le__" => GLOBAL_CONTEXT.ule(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "ULT" | "__lt__" => GLOBAL_CONTEXT.ult(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "UGE" | "__ge__" => GLOBAL_CONTEXT.uge(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "UGT" | "__gt__" => GLOBAL_CONTEXT.ugt(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "SLT" => GLOBAL_CONTEXT.slt(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "SLE" => GLOBAL_CONTEXT.sle(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "SGT" => GLOBAL_CONTEXT.sgt(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "SGE" => GLOBAL_CONTEXT.sge(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "fpEQ" => GLOBAL_CONTEXT.fp_eq(
+                    &args[0].downcast_bound::<FP>(py)?.get().inner,
+                    &args[1].downcast_bound::<FP>(py)?.get().inner,
+                )?,
+                "fpNEQ" => GLOBAL_CONTEXT.fp_neq(
+                    &args[0].downcast_bound::<FP>(py)?.get().inner,
+                    &args[1].downcast_bound::<FP>(py)?.get().inner,
+                )?,
+                "fpLT" => GLOBAL_CONTEXT.fp_lt(
+                    &args[0].downcast_bound::<FP>(py)?.get().inner,
+                    &args[1].downcast_bound::<FP>(py)?.get().inner,
+                )?,
+                "fpLEQ" => GLOBAL_CONTEXT.fp_leq(
+                    &args[0].downcast_bound::<FP>(py)?.get().inner,
+                    &args[1].downcast_bound::<FP>(py)?.get().inner,
+                )?,
+                "fpGT" => GLOBAL_CONTEXT.fp_gt(
+                    &args[0].downcast_bound::<FP>(py)?.get().inner,
+                    &args[1].downcast_bound::<FP>(py)?.get().inner,
+                )?,
+                "fpGEQ" => GLOBAL_CONTEXT.fp_geq(
+                    &args[0].downcast_bound::<FP>(py)?.get().inner,
+                    &args[1].downcast_bound::<FP>(py)?.get().inner,
+                )?,
+                "fpIsNan" => GLOBAL_CONTEXT.fp_is_nan(&args[0].downcast_bound::<FP>(py)?.get().inner)?,
+                "fpIsInf" => GLOBAL_CONTEXT.fp_is_inf(&args[0].downcast_bound::<FP>(py)?.get().inner)?,
+                "StrContains" => GLOBAL_CONTEXT.strcontains(
+                    &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                )?,
+                "StrPrefixOf" => GLOBAL_CONTEXT.strprefixof(
+                    &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                )?,
+                "StrSuffixOf" => GLOBAL_CONTEXT.strsuffixof(
+                    &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                )?,
+                "StrIsDigit" => GLOBAL_CONTEXT.strisdigit(&args[0].downcast_bound::<PyAstString>(py)?.get().inner)?,
+                "If" => GLOBAL_CONTEXT.if_(
+                    &args[0].downcast_bound::<Bool>(py)?.get().inner,
+                    &args[1].downcast_bound::<Bool>(py)?.get().inner,
+                    &args[2].downcast_bound::<Bool>(py)?.get().inner,
+                )?,
+                _ => return Err(ClaripyError::InvalidOp(op.to_string())),
+            },
+        )
+    }
+
     #[getter]
     pub fn op(&self) -> String {
         self.inner.op().to_opstring()

--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -56,6 +56,130 @@ impl BV {
 
 #[pymethods]
 impl BV {
+    #[new]
+    pub fn py_new(py: Python, op: &str, args: Vec<PyObject>) -> Result<Py<BV>, ClaripyError> {
+        BV::new(
+            py,
+            &match op {
+                "BVS" => {
+                    GLOBAL_CONTEXT.bvs(args[0].extract::<String>(py)?, args[1].extract(py)?)?
+                }
+                "BVV" => GLOBAL_CONTEXT
+                    .bvv_from_biguint_with_size(&args[0].extract(py)?, args[1].extract(py)?)?,
+                "__neg__" => GLOBAL_CONTEXT.not(&args[0].downcast_bound::<BV>(py)?.get().inner)?,
+                "__and__" => GLOBAL_CONTEXT.and(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__or__" => GLOBAL_CONTEXT.or(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__xor__" => GLOBAL_CONTEXT.xor(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__abs__" => GLOBAL_CONTEXT.abs(&args[0].downcast_bound::<BV>(py)?.get().inner)?,
+                "__add__" => GLOBAL_CONTEXT.add(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__sub__" => GLOBAL_CONTEXT.sub(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__mul__" => GLOBAL_CONTEXT.mul(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__floordiv__" => GLOBAL_CONTEXT.udiv(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "SDiv" => GLOBAL_CONTEXT.sdiv(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__mod__" => GLOBAL_CONTEXT.urem(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "SMod" => GLOBAL_CONTEXT.srem(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__pow__" => GLOBAL_CONTEXT.pow(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__lshift__" => GLOBAL_CONTEXT.shl(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "LShR" => GLOBAL_CONTEXT.lshr(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "__rshift__" => GLOBAL_CONTEXT.ashr(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "RotateLeft" => GLOBAL_CONTEXT.rotate_left(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "RotateRight" => GLOBAL_CONTEXT.rotate_right(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "ZeroExt" => GLOBAL_CONTEXT.zero_ext(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    args[1].extract(py)?,
+                )?,
+                "SignExt" => GLOBAL_CONTEXT.sign_ext(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    args[1].extract(py)?,
+                )?,
+                "Extract" => GLOBAL_CONTEXT.extract(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    args[1].extract(py)?,
+                    args[2].extract(py)?,
+                )?,
+                "Concat" => GLOBAL_CONTEXT.concat(
+                    &args[0].downcast_bound::<BV>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "Reverse" => {
+                    GLOBAL_CONTEXT.reverse(&args[0].downcast_bound::<BV>(py)?.get().inner)?
+                }
+                "fpToIEEEBV" => {
+                    GLOBAL_CONTEXT.fp_to_ieeebv(&args[0].downcast_bound::<FP>(py)?.get().inner)?
+                }
+                // "fpToUBV" => GLOBAL_CONTEXT.fp_to_ubv(
+                //     &args[0].downcast_bound::<FP>(py)?.get().inner,
+                // )?,
+                // "fpToSBV" => GLOBAL_CONTEXT.fp_to_sbv(
+                //     &args[0].downcast_bound::<FP>(py)?.get().inner,
+                // )?,
+                "StrLen" => GLOBAL_CONTEXT
+                    .strlen(&args[0].downcast_bound::<PyAstString>(py)?.get().inner)?,
+                "StrIndexOf" => GLOBAL_CONTEXT.strindexof(
+                    &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[2].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "StrToBV" => GLOBAL_CONTEXT
+                    .strtobv(&args[0].downcast_bound::<PyAstString>(py)?.get().inner)?,
+                "If" => GLOBAL_CONTEXT.if_(
+                    &args[0].downcast_bound::<Bool>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                    &args[2].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                _ => return Err(ClaripyError::InvalidOperation(op.to_string())),
+            },
+        )
+    }
+
     #[getter]
     pub fn op(&self) -> String {
         self.inner.op().to_opstring()

--- a/crates/clarirs_py/src/ast/string.rs
+++ b/crates/clarirs_py/src/ast/string.rs
@@ -53,6 +53,38 @@ impl PyAstString {
 
 #[pymethods]
 impl PyAstString {
+    #[new]
+    pub fn py_new(py: Python, op: &str, args: Vec<PyObject>) -> Result<Py<PyAstString>, ClaripyError> {
+        PyAstString::new(
+            py,
+            &match op {
+                "StringS" => GLOBAL_CONTEXT.strings(&args[0].extract::<String>(py)?)?,
+                "StringV" => GLOBAL_CONTEXT.stringv(&args[0].extract::<String>(py)?)?,
+                "StrConcat" => GLOBAL_CONTEXT.strconcat(
+                    &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                )?,
+                "StrSubstr" => GLOBAL_CONTEXT.strsubstr(
+                    &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[1].downcast_bound::<BV>(py)?.get().inner,
+                    &args[2].downcast_bound::<BV>(py)?.get().inner,
+                )?,
+                "StrReplace" => GLOBAL_CONTEXT.strreplace(
+                    &args[0].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[2].downcast_bound::<PyAstString>(py)?.get().inner,
+                )?,
+                "IntToStr" => GLOBAL_CONTEXT.bvtostr(&args[0].downcast_bound::<BV>(py)?.get().inner)?,
+                "If" => GLOBAL_CONTEXT.if_(
+                    &args[0].downcast_bound::<Bool>(py)?.get().inner,
+                    &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
+                    &args[2].downcast_bound::<PyAstString>(py)?.get().inner,
+                )?,
+                _ => return Err(ClaripyError::InvalidOperation(op.to_string())),
+            }
+        )
+    }
+
     #[getter]
     pub fn op(&self) -> String {
         self.inner.op().to_opstring()

--- a/crates/clarirs_py/src/ast/string.rs
+++ b/crates/clarirs_py/src/ast/string.rs
@@ -54,7 +54,11 @@ impl PyAstString {
 #[pymethods]
 impl PyAstString {
     #[new]
-    pub fn py_new(py: Python, op: &str, args: Vec<PyObject>) -> Result<Py<PyAstString>, ClaripyError> {
+    pub fn py_new(
+        py: Python,
+        op: &str,
+        args: Vec<PyObject>,
+    ) -> Result<Py<PyAstString>, ClaripyError> {
         PyAstString::new(
             py,
             &match op {
@@ -74,14 +78,16 @@ impl PyAstString {
                     &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
                     &args[2].downcast_bound::<PyAstString>(py)?.get().inner,
                 )?,
-                "IntToStr" => GLOBAL_CONTEXT.bvtostr(&args[0].downcast_bound::<BV>(py)?.get().inner)?,
+                "IntToStr" => {
+                    GLOBAL_CONTEXT.bvtostr(&args[0].downcast_bound::<BV>(py)?.get().inner)?
+                }
                 "If" => GLOBAL_CONTEXT.if_(
                     &args[0].downcast_bound::<Bool>(py)?.get().inner,
                     &args[1].downcast_bound::<PyAstString>(py)?.get().inner,
                     &args[2].downcast_bound::<PyAstString>(py)?.get().inner,
                 )?,
                 _ => return Err(ClaripyError::InvalidOperation(op.to_string())),
-            }
+            },
         )
     }
 

--- a/crates/clarirs_py/src/error.rs
+++ b/crates/clarirs_py/src/error.rs
@@ -18,6 +18,8 @@ pub enum ClaripyError {
     CastingError(String),
     #[error("Invalid argument type: {0}")]
     InvalidArgumentType(String),
+    #[error("Invalid Operation: {0}")]
+    InvalidOp(String),
 }
 
 impl From<ClarirsError> for ClaripyError {


### PR DESCRIPTION
These are a hack for compatibility with current claripy, used by backends. These should be eliminated and these methods should be removed someday.