### PR TITLE
Fix subtraction logic with wrapping and operator overloading for BitVec

### DIFF
--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -352,21 +352,11 @@ impl<'c> Simplify<'c> for BitVecAst<'c> {
                     }
                 }
                 BitVecOp::Sub(arc, arc1) => {
-                    simplify!(arc, arc1);
-                
+                    simplify!(arc, arc1);                
                     match (arc.op(), arc1.op()) {
                         (BitVecOp::BVV(value1), BitVecOp::BVV(value2)) => {
-                            // Both sides are concrete bitvector values.
-                            // let val1_64 = value1.to_usize().unwrap(); 
-                            // let val2_64 = value2.to_usize().unwrap();
-                
-                            // let result = val1_64.wrapping_sub(val2_64);
-                            // ctx.bvv(BitVec::from_prim(result as u64));
-
-                            ctx.bvv(value1.clone() - value2.clone())
-                
+                            ctx.bvv(value1.clone() - value2.clone())        
                         },
-                        // Fall back to a general ctx.sub operation.
                         _ => ctx.sub(&arc, &arc1),
                     }
                 }                

--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -288,9 +288,7 @@ impl<'c> Simplify<'c> for BitVecAst<'c> {
         ctx.simplification_cache.get_or_insert_with_bv(hash, || {
             match &self.op() {
                 BitVecOp::BVS(name, width) => ctx.bvs(name.clone(), *width),
-                BitVecOp::BVV(_) => {
-                    Ok(self.clone())
-                }
+                BitVecOp::BVV(_) => Ok(self.clone()),
                 BitVecOp::SI(..) => todo!(),
                 BitVecOp::Not(ast) => {
                     simplify!(ast);
@@ -352,14 +350,14 @@ impl<'c> Simplify<'c> for BitVecAst<'c> {
                     }
                 }
                 BitVecOp::Sub(arc, arc1) => {
-                    simplify!(arc, arc1);                
+                    simplify!(arc, arc1);
                     match (arc.op(), arc1.op()) {
                         (BitVecOp::BVV(value1), BitVecOp::BVV(value2)) => {
-                            ctx.bvv(value1.clone() - value2.clone())        
-                        },
+                            ctx.bvv(value1.clone() - value2.clone())
+                        }
                         _ => ctx.sub(&arc, &arc1),
                     }
-                }                
+                }
                 BitVecOp::Mul(arc, arc1) => {
                     simplify!(arc, arc1);
                     match (arc.op(), arc1.op()) {

--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -353,13 +353,23 @@ impl<'c> Simplify<'c> for BitVecAst<'c> {
                 }
                 BitVecOp::Sub(arc, arc1) => {
                     simplify!(arc, arc1);
+                
                     match (arc.op(), arc1.op()) {
                         (BitVecOp::BVV(value1), BitVecOp::BVV(value2)) => {
+                            // Both sides are concrete bitvector values.
+                            // let val1_64 = value1.to_usize().unwrap(); 
+                            // let val2_64 = value2.to_usize().unwrap();
+                
+                            // let result = val1_64.wrapping_sub(val2_64);
+                            // ctx.bvv(BitVec::from_prim(result as u64));
+
                             ctx.bvv(value1.clone() - value2.clone())
-                        }
+                
+                        },
+                        // Fall back to a general ctx.sub operation.
                         _ => ctx.sub(&arc, &arc1),
                     }
-                }
+                }                
                 BitVecOp::Mul(arc, arc1) => {
                     simplify!(arc, arc1);
                     match (arc.op(), arc1.op()) {

--- a/crates/clarirs_core/src/algorithms/tests/test_bv.rs
+++ b/crates/clarirs_core/src/algorithms/tests/test_bv.rs
@@ -48,7 +48,6 @@ fn test_sub() -> Result<()> {
         (3, 2, 1),
         (3, 3, 0),
         (123, 45, 78),       
-
         (u64::MAX, 1, u64::MAX - 1), 
         (u64::MAX, u64::MAX, 0),     
         (u64::MAX, 0, u64::MAX),   
@@ -56,7 +55,6 @@ fn test_sub() -> Result<()> {
         (1, u64::MAX, 2), 
         (u64::MAX - 1, u64::MAX, u64::MAX),
         (45, 123, u64::MAX - 77), 
-
     ];
 
     for (a, b, expected) in table {

--- a/crates/clarirs_core/src/algorithms/tests/test_bv.rs
+++ b/crates/clarirs_core/src/algorithms/tests/test_bv.rs
@@ -47,14 +47,14 @@ fn test_sub() -> Result<()> {
         (2, 3, u64::MAX),
         (3, 2, 1),
         (3, 3, 0),
-        (123, 45, 78),       
-        (u64::MAX, 1, u64::MAX - 1), 
-        (u64::MAX, u64::MAX, 0),     
-        (u64::MAX, 0, u64::MAX),   
+        (123, 45, 78),
+        (u64::MAX, 1, u64::MAX - 1),
+        (u64::MAX, u64::MAX, 0),
+        (u64::MAX, 0, u64::MAX),
         (0, u64::MAX, 1),
-        (1, u64::MAX, 2), 
+        (1, u64::MAX, 2),
         (u64::MAX - 1, u64::MAX, u64::MAX),
-        (45, 123, u64::MAX - 77), 
+        (45, 123, u64::MAX - 77),
     ];
 
     for (a, b, expected) in table {

--- a/crates/clarirs_core/src/algorithms/tests/test_bv.rs
+++ b/crates/clarirs_core/src/algorithms/tests/test_bv.rs
@@ -47,6 +47,16 @@ fn test_sub() -> Result<()> {
         (2, 3, u64::MAX),
         (3, 2, 1),
         (3, 3, 0),
+        (123, 45, 78),       
+
+        (u64::MAX, 1, u64::MAX - 1), 
+        (u64::MAX, u64::MAX, 0),     
+        (u64::MAX, 0, u64::MAX),   
+        (0, u64::MAX, 1),
+        (1, u64::MAX, 2), 
+        (u64::MAX - 1, u64::MAX, u64::MAX),
+        (45, 123, u64::MAX - 77), 
+
     ];
 
     for (a, b, expected) in table {

--- a/crates/clarirs_core/src/ast/astcache.rs
+++ b/crates/clarirs_core/src/ast/astcache.rs
@@ -175,9 +175,9 @@ impl<'c> AstCache<'c> {
         let mut inner = self.inner.write().unwrap();
 
         // Step 4: Check again if the value was inserted while we were computing
-        let entry = inner.entry(hash).or_insert_with(|| {
-            AstCacheValue::BitVec(Weak::new())
-        });
+        let entry = inner
+            .entry(hash)
+            .or_insert_with(|| AstCacheValue::BitVec(Weak::new()));
 
         match entry {
             AstCacheValue::BitVec(weak) => {

--- a/crates/clarirs_num/src/bitvec.rs
+++ b/crates/clarirs_num/src/bitvec.rs
@@ -247,9 +247,12 @@ impl Add for BitVec {
 impl Sub for BitVec {
     type Output = Self;
 
-    fn sub(self, rhs: Self) -> Self::Output {        
+    fn sub(self, rhs: Self) -> Self::Output {
         // Ensure both BitVecs have the same length
-        assert_eq!(self.length, rhs.length, "BitVec lengths must match for subtraction");
+        assert_eq!(
+            self.length, rhs.length,
+            "BitVec lengths must match for subtraction"
+        );
 
         // Perform word-wise subtraction with wrapping
         let mut new_words = self

--- a/crates/clarirs_num/src/bitvec.rs
+++ b/crates/clarirs_num/src/bitvec.rs
@@ -247,8 +247,7 @@ impl Add for BitVec {
 impl Sub for BitVec {
     type Output = Self;
 
-    fn sub(self, rhs: Self) -> Self::Output {
-        
+    fn sub(self, rhs: Self) -> Self::Output {        
         // Ensure both BitVecs have the same length
         assert_eq!(self.length, rhs.length, "BitVec lengths must match for subtraction");
 


### PR DESCRIPTION
- Updated the Sub trait implementation to enable subtraction using the - operator
- Added logic to handle subtraction with wrapping behavior for fixed-width bitvectors, ensuring correctness for all cases, including underflows.
- Added more test cases to validate logic for edge cases