### PR TITLE
Add macro features to clarirs_num/Cargo.toml

### DIFF
--- a/crates/clarirs_num/Cargo.toml
+++ b/crates/clarirs_num/Cargo.toml
@@ -11,10 +11,10 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-num-bigint = "0.4.6"
+num-bigint = { version = "0.4.6", features = ["serde"] }
 num-traits = "0.2"
-serde = "1.0.209"
-smallvec = "1.13.2"
+serde = { version = "1.0.209", features = ["derive"] }
+smallvec = { version = "1.13.2", features = ["serde"] }
 thiserror = { workspace = true }
 
 [lints]


### PR DESCRIPTION
This crate wasn't building on its own because it depended on these features. The features were enabled in the crates the depend on this crate though, so they always were available. Didn't realize this could happen.