### PR TITLE
Fix python variables extraction

### DIFF
--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -64,10 +64,7 @@ where
 impl<'c, O: Op<'c> + Serialize> AstNode<'c, O> {
     pub(crate) fn new(ctx: &'c Context<'c>, op: O, hash: u64) -> Self {
         let symbolic = op.child_iter().any(|child| child.symbolic());
-        let variables = op
-            .child_iter()
-            .flat_map(|child| child.variables().clone().into_iter())
-            .collect::<HashSet<String>>();
+        let variables = op.variables();
         let depth = op.depth();
 
         Self {

--- a/crates/clarirs_py/src/ast/bool.rs
+++ b/crates/clarirs_py/src/ast/bool.rs
@@ -216,7 +216,7 @@ impl Bool {
                 .variables()
                 .iter()
                 .map(|v| v.into_py_any(py))
-                .collect::<Result<Vec<_>, _>>()
+                .collect::<Result<Vec<_>, _>>()?
                 .iter(),
         )?
         .unbind())

--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -198,7 +198,7 @@ impl BV {
                 .variables()
                 .iter()
                 .map(|v| v.into_py_any(py))
-                .collect::<Result<Vec<_>, _>>()
+                .collect::<Result<Vec<_>, _>>()?
                 .iter(),
         )?
         .unbind())

--- a/crates/clarirs_py/src/ast/fp.rs
+++ b/crates/clarirs_py/src/ast/fp.rs
@@ -166,7 +166,7 @@ impl FP {
                 .variables()
                 .iter()
                 .map(|v| v.into_py_any(py))
-                .collect::<Result<Vec<_>, _>>()
+                .collect::<Result<Vec<_>, _>>()?
                 .iter(),
         )?
         .unbind())

--- a/crates/clarirs_py/src/ast/string.rs
+++ b/crates/clarirs_py/src/ast/string.rs
@@ -109,7 +109,7 @@ impl PyAstString {
                 .variables()
                 .iter()
                 .map(|v| v.into_py_any(py))
-                .collect::<Result<Vec<_>, _>>()
+                .collect::<Result<Vec<_>, _>>()?
                 .iter(),
         )?
         .unbind())


### PR DESCRIPTION
From discord:

I dislike that Result has an .iter()

Look at this code:
```rust
    #[getter]
    pub fn variables(&self, py: Python) -> Result<Py<PyFrozenSet>, ClaripyError> {
        Ok(PyFrozenSet::new(
            py,
            self.inner
                .variables()
                .iter()
                .map(|v| v.into_py_any(py))
                .collect::<Result<Vec<_>, _>>()
                .iter(),
        )?
        .unbind())
    }
```

This function gets the variables from an inner data structure as a HashSet<String>, converts them into a PyAny (which will be a python str instance), puts them into a PyFrozenSet and returns it

But there is a bug

The line with the collect call should have a ? at the end, and because it doesn't the final iter() ends up operating over the Result type rather than the Vec inside the result. The PyFrozenSet constructor then errors because the Vec (which is mapped to list) isn't hashable

So in writing python bindings to rust code, I have managed to experience python-like type confusion because the wrong type just happened to implement the right traits and methods, and led to the type error occurring at runtime