### PR TITLE
Add .length property to clarirs_py BVs

### DIFF
--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -251,6 +251,11 @@ impl BV {
         self.size()
     }
 
+    #[getter]
+    pub fn length(&self) -> usize {
+        self.size()
+    }
+
     pub fn __getitem__(self_: Bound<BV>, range: Bound<PyAny>) -> Result<Py<BV>, ClaripyError> {
         if let Ok(slice) = range.downcast::<PySlice>() {
             if slice.step()?.is_some() {


### PR DESCRIPTION
Add a `.length` property to the `BV` class in `crates/clarirs_py/src/ast/bv.rs`.

* Add a `.length` property that returns the size of the bit vector.
* Annotate the `.length` property with `#[getter]` attribute.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/twizmwazin/clarirs/pull/57?shareId=b4650fb0-c6b0-4e44-b010-dfd2087af85f).