### PR TITLE
Impement Hash manually for ops to include discriminant

### DIFF
--- a/crates/clarirs_core/src/ast/bitvec.rs
+++ b/crates/clarirs_core/src/ast/bitvec.rs
@@ -7,7 +7,7 @@ use crate::prelude::*;
 
 use super::float::FloatExt;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum BitVecOp<'c> {
     BVS(String, u32),
     BVV(BitVec),
@@ -45,6 +45,177 @@ pub enum BitVecOp<'c> {
 }
 
 pub type BitVecAst<'c> = AstRef<'c, BitVecOp<'c>>;
+
+impl std::hash::Hash for BitVecOp<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        "bv".hash(state);
+        match self {
+            BitVecOp::BVS(s, size) => {
+                0.hash(state);
+                s.hash(state);
+                size.hash(state);
+            }
+            BitVecOp::BVV(bv) => {
+                1.hash(state);
+                bv.hash(state);
+            }
+            BitVecOp::Not(a) => {
+                2.hash(state);
+                a.hash(state);
+            }
+            BitVecOp::And(a, b) => {
+                3.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::Or(a, b) => {
+                4.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::Xor(a, b) => {
+                5.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::Abs(a) => {
+                6.hash(state);
+                a.hash(state);
+            }
+            BitVecOp::Add(a, b) => {
+                7.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::Sub(a, b) => {
+                8.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::Mul(a, b) => {
+                9.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::UDiv(a, b) => {
+                10.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::SDiv(a, b) => {
+                11.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::URem(a, b) => {
+                12.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::SRem(a, b) => {
+                13.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::Pow(a, b) => {
+                14.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::ShL(a, b) => {
+                15.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::LShR(a, b) => {
+                16.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::AShR(a, b) => {
+                17.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::RotateLeft(a, b) => {
+                18.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::RotateRight(a, b) => {
+                19.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::ZeroExt(a, size) => {
+                20.hash(state);
+                a.hash(state);
+                size.hash(state);
+            }
+            BitVecOp::SignExt(a, size) => {
+                21.hash(state);
+                a.hash(state);
+                size.hash(state);
+            }
+            BitVecOp::Extract(a, low, high) => {
+                22.hash(state);
+                a.hash(state);
+                low.hash(state);
+                high.hash(state);
+            }
+            BitVecOp::Concat(a, b) => {
+                23.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BitVecOp::Reverse(a) => {
+                24.hash(state);
+                a.hash(state);
+            }
+            BitVecOp::FpToIEEEBV(a) => {
+                25.hash(state);
+                a.hash(state);
+            }
+            BitVecOp::FpToUBV(a, size, rm) => {
+                26.hash(state);
+                a.hash(state);
+                size.hash(state);
+                rm.hash(state);
+            }
+            BitVecOp::FpToSBV(a, size, rm) => {
+                27.hash(state);
+                a.hash(state);
+                size.hash(state);
+                rm.hash(state);
+            }
+            BitVecOp::StrLen(a) => {
+                28.hash(state);
+                a.hash(state);
+            }
+            BitVecOp::StrIndexOf(a, b, c) => {
+                29.hash(state);
+                a.hash(state);
+                b.hash(state);
+                c.hash(state);
+            }
+            BitVecOp::StrToBV(a) => {
+                30.hash(state);
+                a.hash(state);
+            }
+            BitVecOp::If(a, b, c) => {
+                31.hash(state);
+                a.hash(state);
+                b.hash(state);
+                c.hash(state);
+            }
+            BitVecOp::Annotated(a, anno) => {
+                32.hash(state);
+                a.hash(state);
+                anno.hash(state);
+            }
+        }
+    }
+}
 
 impl<'c> Op<'c> for BitVecOp<'c> {
     fn child_iter(&self) -> IntoIter<VarAst<'c>> {

--- a/crates/clarirs_core/src/ast/bool.rs
+++ b/crates/clarirs_core/src/ast/bool.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::prelude::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum BooleanOp<'c> {
     BoolS(String),
     BoolV(bool),
@@ -44,6 +44,179 @@ pub enum BooleanOp<'c> {
 }
 
 pub type BoolAst<'c> = AstRef<'c, BooleanOp<'c>>;
+
+impl std::hash::Hash for BooleanOp<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        "bool".hash(state);
+        match self {
+            BooleanOp::BoolS(s) => {
+                0.hash(state);
+                s.hash(state);
+            }
+            BooleanOp::BoolV(b) => {
+                1.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::Not(a) => {
+                2.hash(state);
+                a.hash(state);
+            }
+            BooleanOp::And(a, b) => {
+                3.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::Or(a, b) => {
+                4.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::Xor(a, b) => {
+                5.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::BoolEq(a, b) => {
+                6.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::BoolNeq(a, b) => {
+                7.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::Eq(a, b) => {
+                8.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::Neq(a, b) => {
+                9.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::ULT(a, b) => {
+                10.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::ULE(a, b) => {
+                11.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::UGT(a, b) => {
+                12.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::UGE(a, b) => {
+                13.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::SLT(a, b) => {
+                14.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::SLE(a, b) => {
+                15.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::SGT(a, b) => {
+                16.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::SGE(a, b) => {
+                17.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::FpEq(a, b) => {
+                18.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::FpNeq(a, b) => {
+                19.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::FpLt(a, b) => {
+                20.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::FpLeq(a, b) => {
+                21.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::FpGt(a, b) => {
+                22.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::FpGeq(a, b) => {
+                23.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::FpIsNan(a) => {
+                24.hash(state);
+                a.hash(state);
+            }
+            BooleanOp::FpIsInf(a) => {
+                25.hash(state);
+                a.hash(state);
+            }
+            BooleanOp::StrContains(a, b) => {
+                26.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::StrPrefixOf(a, b) => {
+                27.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::StrSuffixOf(a, b) => {
+                28.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::StrIsDigit(a) => {
+                29.hash(state);
+                a.hash(state);
+            }
+            BooleanOp::StrEq(a, b) => {
+                30.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::StrNeq(a, b) => {
+                31.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            BooleanOp::If(a, b, c) => {
+                32.hash(state);
+                a.hash(state);
+                b.hash(state);
+                c.hash(state);
+            }
+            BooleanOp::Annotated(a, b) => {
+                33.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+        }
+    }
+}
 
 impl<'c> Op<'c> for BooleanOp<'c> {
     fn child_iter(&self) -> IntoIter<VarAst<'c>> {

--- a/crates/clarirs_core/src/ast/float.rs
+++ b/crates/clarirs_core/src/ast/float.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::prelude::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum FloatOp<'c> {
     FPS(String, FSort),
     FPV(Float),
@@ -23,6 +23,85 @@ pub enum FloatOp<'c> {
 }
 
 pub type FloatAst<'c> = AstRef<'c, FloatOp<'c>>;
+
+impl std::hash::Hash for FloatOp<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        "float".hash(state);
+        match self {
+            FloatOp::FPS(s, sort) => {
+                0.hash(state);
+                s.hash(state);
+                sort.hash(state);
+            }
+            FloatOp::FPV(f) => {
+                1.hash(state);
+                f.hash(state);
+            }
+            FloatOp::FpNeg(a, rm) => {
+                2.hash(state);
+                a.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::FpAbs(a, rm) => {
+                3.hash(state);
+                a.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::FpAdd(a, b, rm) => {
+                4.hash(state);
+                a.hash(state);
+                b.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::FpSub(a, b, rm) => {
+                5.hash(state);
+                a.hash(state);
+                b.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::FpMul(a, b, rm) => {
+                6.hash(state);
+                a.hash(state);
+                b.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::FpDiv(a, b, rm) => {
+                7.hash(state);
+                a.hash(state);
+                b.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::FpSqrt(a, rm) => {
+                8.hash(state);
+                a.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::FpToFp(a, sort, rm) => {
+                9.hash(state);
+                a.hash(state);
+                sort.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::BvToFpUnsigned(a, sort, rm) => {
+                10.hash(state);
+                a.hash(state);
+                sort.hash(state);
+                rm.hash(state);
+            }
+            FloatOp::If(a, b, c) => {
+                11.hash(state);
+                a.hash(state);
+                b.hash(state);
+                c.hash(state);
+            }
+            FloatOp::Annotated(a, anno) => {
+                12.hash(state);
+                a.hash(state);
+                anno.hash(state);
+            }
+        }
+    }
+}
 
 impl<'c> Op<'c> for FloatOp<'c> {
     fn child_iter(&self) -> IntoIter<VarAst<'c>> {

--- a/crates/clarirs_core/src/ast/string.rs
+++ b/crates/clarirs_core/src/ast/string.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::prelude::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum StringOp<'c> {
     StringS(String),
     StringV(String),
@@ -18,6 +18,53 @@ pub enum StringOp<'c> {
 }
 
 pub type StringAst<'c> = AstRef<'c, StringOp<'c>>;
+
+impl std::hash::Hash for StringOp<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        "string".hash(state);
+        match self {
+            StringOp::StringS(s) => {
+                0.hash(state);
+                s.hash(state);
+            }
+            StringOp::StringV(s) => {
+                1.hash(state);
+                s.hash(state);
+            }
+            StringOp::StrConcat(a, b) => {
+                2.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            StringOp::StrSubstr(a, b, c) => {
+                3.hash(state);
+                a.hash(state);
+                b.hash(state);
+                c.hash(state);
+            }
+            StringOp::StrReplace(a, b, c) => {
+                4.hash(state);
+                a.hash(state);
+                b.hash(state);
+                c.hash(state);
+            }
+            StringOp::BVToStr(a) => {
+                5.hash(state);
+                a.hash(state);
+            }
+            StringOp::If(a, b, c) => {
+                6.hash(state);
+                a.hash(state);
+                b.hash(state);
+                c.hash(state);
+            }
+            StringOp::Annotated(a, _) => {
+                7.hash(state);
+                a.hash(state);
+            }
+        }
+    }
+}
 
 impl<'c> Op<'c> for StringOp<'c> {
     fn child_iter(&self) -> IntoIter<VarAst<'c>> {


### PR DESCRIPTION
During testing I observed that we can get hash collisions very easily because the op types don't include anything unique about themselves, only their contents. Since our asts are stored in a single cache (maybe that's our problem...?) this caused collisions and bugs. This makes that case... more rare. We should fix it such that we can tolerate hash collisions.