### PR TITLE
Add CI workflow to build and save wheel artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Rust toolchain
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       
       - name: Install Maturin
         run: pip install maturin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,35 @@ jobs:
 
       - name: Build and install Python bindings
         run: pip install .
+
+  build-wheels:
+    name: Building wheel files on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup Rust toolchain
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      
+      - name: Install Maturin
+        run: pip install maturin
+
+      - name: Build Wheel
+        run: maturin build --release -o dist
+
+      - name: Upload Wheel Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: dist/*.whl
+  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: maturin build --release -o dist
 
       - name: Upload Wheel Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
           path: dist/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,28 +55,6 @@ jobs:
       - name: Run tests
         run: cargo test --all-features --no-fail-fast
 
-  python-bindings:
-    name: Python Bindings on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Build and install Python bindings
-        run: pip install .
-
   build-wheels:
     name: Building wheel files on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- Added a new job 'build-wheels' in order to build wheel files
- Uploaded the wheel files as artifacts to GitHub Actions storage
- Fixes **Issue #93** - "Produce wheel artifacts in CI."