### PR TITLE
Fix CompositeSolver to not raise Unsat from add()

### DIFF
--- a/crates/clarirs_core/src/solver/composite.rs
+++ b/crates/clarirs_core/src/solver/composite.rs
@@ -278,14 +278,18 @@ mod tests {
     }
 
     #[test]
-    fn test_composite_solver_unsat_concrete() {
+    fn test_composite_solver_unsat_concrete() -> Result<(), ClarirsError> {
         let ctx = Context::new();
         let template = ConcreteSolver::new(&ctx);
         let mut solver = CompositeSolver::new(&ctx, template);
 
-        // Adding false should return Unsat
-        let result = solver.add(&ctx.false_().unwrap());
-        assert!(result.is_err());
+        // Adding false should succeed but leave the solver unsatisfiable.
+        // (Other solvers behave the same way — only `satisfiable()` / `eval()`
+        // should surface UNSAT, never `add()`.)
+        solver.add(&ctx.false_()?)?;
+        // ConcreteSolver doesn't actually implement satisfiable() usefully,
+        // but we can at least verify the constraint was stored without error.
+        Ok(())
     }
 
     #[test]

--- a/crates/clarirs_core/src/solver/composite.rs
+++ b/crates/clarirs_core/src/solver/composite.rs
@@ -121,10 +121,15 @@ impl<'c, S: Solver<'c>> Solver<'c> for CompositeSolver<'c, S> {
         let vars: BTreeSet<InternedString> = constraint.variables().clone();
 
         if vars.is_empty() {
-            // Concrete constraint — reject immediately if false.
-            if constraint.is_false() {
-                return Err(ClarirsError::Unsat);
+            // Concrete constraint: skip if true, store in a dedicated child if false
+            // (so satisfiable() will later return false). Do NOT raise Unsat from add.
+            if constraint.is_true() {
+                return Ok(());
             }
+            // For concrete false constraints, we need to store them somewhere so that
+            // satisfiable() returns false. Add to a new child as a degenerate case.
+            let target_id = self.new_child();
+            self.children.get_mut(&target_id).unwrap().add(constraint)?;
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary
- When a concrete `false` constraint is added to `CompositeSolver`, it currently returns `Err(ClarirsError::Unsat)` immediately from `add()`. This diverges from every other solver backend (`Z3Solver`, `ConcreteSolver`, `VSASolver`) which all accept any constraint in `add()` and only report UNSAT from `satisfiable()` / `eval()`.
- The eager error breaks callers that expect `add()` to be infallible for well-formed boolean expressions — e.g. `state.add_constraints` in angr, where adding `false` is a valid way to mark a branch as unreachable.
- Store concrete `false` in a fresh child so `satisfiable()` later returns `false`, and drop `true` since it carries no information.

## Test plan
- [ ] `cargo test -p clarirs_core`
- [ ] Manual: `s = claripy.SolverComposite(); s.add(claripy.false()); assert s.satisfiable() is False` (previously raised `UnsatError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)