### PR TITLE
Add claripy.vsa.simplify() as an alias for reduce()

### DIFF
--- a/crates/clarirs_py/src/vsa.rs
+++ b/crates/clarirs_py/src/vsa.rs
@@ -170,10 +170,24 @@ pub fn identical(a: Bound<'_, Base>, b: Bound<'_, Base>) -> Result<bool, Claripy
     ))
 }
 
+/// Simplify an expression using VSA reduction.
+///
+/// This is a compatibility shim for `claripy.backends.vsa.simplify()`.
+/// It simplifies the expression and then reduces it using VSA abstract
+/// interpretation, returning the result as an AST node.
+#[pyfunction]
+pub fn simplify<'py>(
+    py: Python<'py>,
+    expr: Bound<'py, Base>,
+) -> Result<Bound<'py, Base>, ClaripyError> {
+    reduce(py, expr)
+}
+
 pub(crate) fn import(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     add_pyfunctions!(
         m,
         reduce,
+        simplify,
         is_true,
         is_false,
         has_true,


### PR DESCRIPTION
## Summary
- Old claripy exposed a backend-based VSA API via `claripy.backends.vsa.simplify(expr)`, which returned an AST reduced via VSA abstract interpretation.
- clarirs exposes the equivalent via `claripy.vsa.reduce()` but many callers (e.g. angr's `Balancer` / jumptable resolver) still expect `simplify`.
- Add a thin `simplify()` alias in the `vsa` submodule that delegates to `reduce()`. This makes `claripy.vsa.simplify` a drop-in replacement for code that previously used `claripy.backends.vsa.simplify`.

## Test plan
- [ ] `python -c "import claripy; print(claripy.vsa.simplify(claripy.SI(bits=32, stride=1, lower_bound=0, upper_bound=10)))"` — should return an SI-annotated BV

🤖 Generated with [Claude Code](https://claude.com/claude-code)