### PR TITLE
Add is_true()/is_false() methods on BV and FP

### DIFF
--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -311,6 +311,26 @@ impl BV {
         self.inner.depth() == 1
     }
 
+    pub fn is_true(&self) -> bool {
+        // A BV is "true" if it's a concrete non-zero value
+        if let Ok(simplified) = self.inner.simplify() {
+            if let BitVecOp::BVV(bv) = simplified.op() {
+                return !bv.is_zero();
+            }
+        }
+        false
+    }
+
+    pub fn is_false(&self) -> bool {
+        // A BV is "false" if it's a concrete zero value
+        if let Ok(simplified) = self.inner.simplify() {
+            if let BitVecOp::BVV(bv) = simplified.op() {
+                return bv.is_zero();
+            }
+        }
+        false
+    }
+
     #[pyo3(signature = (respect_annotations=true))]
     pub fn simplify<'py>(
         &self,

--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -313,20 +313,20 @@ impl BV {
 
     pub fn is_true(&self) -> bool {
         // A BV is "true" if it's a concrete non-zero value
-        if let Ok(simplified) = self.inner.simplify() {
-            if let BitVecOp::BVV(bv) = simplified.op() {
-                return !bv.is_zero();
-            }
+        if let Ok(simplified) = self.inner.simplify()
+            && let BitVecOp::BVV(bv) = simplified.op()
+        {
+            return !bv.is_zero();
         }
         false
     }
 
     pub fn is_false(&self) -> bool {
         // A BV is "false" if it's a concrete zero value
-        if let Ok(simplified) = self.inner.simplify() {
-            if let BitVecOp::BVV(bv) = simplified.op() {
-                return bv.is_zero();
-            }
+        if let Ok(simplified) = self.inner.simplify()
+            && let BitVecOp::BVV(bv) = simplified.op()
+        {
+            return bv.is_zero();
         }
         false
     }

--- a/crates/clarirs_py/src/ast/fp.rs
+++ b/crates/clarirs_py/src/ast/fp.rs
@@ -386,6 +386,26 @@ impl FP {
         self.inner.depth() == 1
     }
 
+    pub fn is_true(&self) -> bool {
+        // A FP is "true" if it's a concrete non-zero value
+        if let Ok(simplified) = self.inner.simplify() {
+            if let FloatOp::FPV(fp) = simplified.op() {
+                return !fp.is_zero();
+            }
+        }
+        false
+    }
+
+    pub fn is_false(&self) -> bool {
+        // A FP is "false" if it's a concrete zero value
+        if let Ok(simplified) = self.inner.simplify() {
+            if let FloatOp::FPV(fp) = simplified.op() {
+                return fp.is_zero();
+            }
+        }
+        false
+    }
+
     #[pyo3(signature = (respect_annotations=true))]
     pub fn simplify<'py>(
         &self,

--- a/crates/clarirs_py/src/ast/fp.rs
+++ b/crates/clarirs_py/src/ast/fp.rs
@@ -388,20 +388,20 @@ impl FP {
 
     pub fn is_true(&self) -> bool {
         // A FP is "true" if it's a concrete non-zero value
-        if let Ok(simplified) = self.inner.simplify() {
-            if let FloatOp::FPV(fp) = simplified.op() {
-                return !fp.is_zero();
-            }
+        if let Ok(simplified) = self.inner.simplify()
+            && let FloatOp::FPV(fp) = simplified.op()
+        {
+            return !fp.is_zero();
         }
         false
     }
 
     pub fn is_false(&self) -> bool {
         // A FP is "false" if it's a concrete zero value
-        if let Ok(simplified) = self.inner.simplify() {
-            if let FloatOp::FPV(fp) = simplified.op() {
-                return fp.is_zero();
-            }
+        if let Ok(simplified) = self.inner.simplify()
+            && let FloatOp::FPV(fp) = simplified.op()
+        {
+            return fp.is_zero();
         }
         false
     }


### PR DESCRIPTION
## Summary
- The `Base` class previously only exposed `is_true`/`is_false` as free functions at the module level (`claripy.is_true(expr)`). In the original claripy, these methods were also available on every AST type, so code like `guard.is_true()` where `guard` is a BV or FP is idiomatic.
- Add direct `is_true()` / `is_false()` methods to BV and FP. For BV, return `true` iff the expression simplifies to a concrete non-zero (resp. zero) bitvector. For FP, return `true` iff the expression simplifies to a concrete non-zero (resp. zero) float — matching Python's truthiness rules for int/float.
- Consumed by angr's VEX engine, which does `guard.is_false()` on the exit guard of conditional branches to decide whether a branch is impossible. Before this change, those `is_false` calls were raising `AttributeError` on BV guards.

## Test plan
- [ ] `claripy.BVV(1, 1).is_true()` → `True`; `.is_false()` → `False`
- [ ] `claripy.BVV(0, 1).is_true()` → `False`; `.is_false()` → `True`
- [ ] `claripy.BVV(42, 32).is_true()` → `True`
- [ ] `claripy.FPV(1.0, claripy.FSORT_DOUBLE).is_true()` → `True`
- [ ] `claripy.FPV(0.0, claripy.FSORT_DOUBLE).is_false()` → `True`
- [ ] Symbolic expressions return `False` for both (as expected — we can't prove truthiness without a solver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)