### PR TITLE
Coerce Bool/BV/int freely in arithmetic and solver operations

### DIFF
--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -5,6 +5,23 @@ use pyo3::types::{PyFloat, PyInt};
 
 use crate::prelude::*;
 
+/// Coerce a BV into a Bool: concrete BVVs resolve to true/false directly,
+/// symbolic BVs become `bv != 0`.
+fn bv_to_bool(bv: &BV) -> Result<BoolAst<'static>, ClaripyError> {
+    let inner = &bv.inner;
+    if let Ok(simplified) = inner.simplify()
+        && let BitVecOp::BVV(v) = simplified.op()
+    {
+        return Ok(if v.is_zero() {
+            GLOBAL_CONTEXT.false_()?
+        } else {
+            GLOBAL_CONTEXT.true_()?
+        });
+    }
+    let zero = GLOBAL_CONTEXT.bvv(BitVec::from_prim_with_size(0u8, bv.size() as u32)?)?;
+    Ok(GLOBAL_CONTEXT.neq(inner, &zero)?)
+}
+
 #[derive(Clone)]
 pub struct CoerceBool<'py>(pub Bound<'py, Bool>);
 
@@ -25,41 +42,8 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBool<'py> {
                 Bool::new(val.py(), &GLOBAL_CONTEXT.boolv(i != BigInt::ZERO).unwrap()).unwrap(),
             ))
         } else if let Ok(bv_val) = val.cast::<BV>() {
-            // Coerce BV to Bool: check if concrete, otherwise use If(BV == 0, false, true)
-            let py = val.py();
-            let inner = &bv_val.get().inner;
-            // Try to simplify and check concrete value
-            let bool_ast = if let Ok(simplified) = inner.simplify() {
-                if let BitVecOp::BVV(bv) = simplified.op() {
-                    if bv.is_zero() {
-                        GLOBAL_CONTEXT.false_().map_err(ClaripyError::from)?
-                    } else {
-                        GLOBAL_CONTEXT.true_().map_err(ClaripyError::from)?
-                    }
-                } else {
-                    // Symbolic: create BV != 0
-                    let zero = GLOBAL_CONTEXT
-                        .bvv(
-                            BitVec::from_prim_with_size(0u8, bv_val.get().size() as u32)
-                                .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?,
-                        )
-                        .map_err(ClaripyError::from)?;
-                    GLOBAL_CONTEXT
-                        .neq(inner, &zero)
-                        .map_err(ClaripyError::from)?
-                }
-            } else {
-                let zero = GLOBAL_CONTEXT
-                    .bvv(
-                        BitVec::from_prim_with_size(0u8, bv_val.get().size() as u32)
-                            .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?,
-                    )
-                    .map_err(ClaripyError::from)?;
-                GLOBAL_CONTEXT
-                    .neq(inner, &zero)
-                    .map_err(ClaripyError::from)?
-            };
-            Ok(CoerceBool(Bool::new(py, &bool_ast)?))
+            // Coerce BV to Bool: concrete fast-path, otherwise `bv != 0`.
+            Ok(CoerceBool(Bool::new(val.py(), &bv_to_bool(bv_val.get())?)?))
         } else {
             Err(ClaripyError::InvalidArgumentType("Expected Bool".to_string()).into())
         }
@@ -104,15 +88,9 @@ impl<'py> CoerceBV<'py> {
                 BV::new(py, &GLOBAL_CONTEXT.bvv(bv)?)
             }
             CoerceBV::Bool(bool_val) => {
-                // Convert Bool to BV of the requested size: If(bool, BVV(1, size), BVV(0, size))
-                let one = GLOBAL_CONTEXT.bvv(
-                    BitVec::from_prim_with_size(1u8, size)
-                        .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?,
-                )?;
-                let zero = GLOBAL_CONTEXT.bvv(
-                    BitVec::from_prim_with_size(0u8, size)
-                        .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?,
-                )?;
+                // Convert Bool to BV of the requested size: If(bool, 1, 0).
+                let one = GLOBAL_CONTEXT.bvv(BitVec::from_prim_with_size(1u8, size)?)?;
+                let zero = GLOBAL_CONTEXT.bvv(BitVec::from_prim_with_size(0u8, size)?)?;
                 let bv_ast = GLOBAL_CONTEXT.ite(&bool_val.get().inner, &one, &zero)?;
                 BV::new(py, &bv_ast)
             }

--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -380,25 +380,32 @@ impl<'a, 'py> FromPyObject<'a, 'py> for CoerceBase<'py> {
     type Error = PyErr;
 
     fn extract(val: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
-        if let Ok(bool) = CoerceBool::extract(val) {
-            Ok(CoerceBase(bool.0.cast()?.clone()))
-        } else if let Ok(bv) = CoerceBV::extract(val) {
-            match bv {
-                CoerceBV::BV(bv) => Ok(CoerceBase(bv.cast()?.clone())),
-                CoerceBV::Int(int) => {
-                    // Just default to 64 bits for now
-                    let bv = BitVec::from_bigint_trunc(&int, 64);
-                    let bv = BV::new(
-                        val.py(),
-                        &GLOBAL_CONTEXT.bvv(bv).map_err(ClaripyError::from)?,
-                    )?;
-                    Ok(CoerceBase(bv.cast()?.clone()))
-                }
-                CoerceBV::Bool(bool_val) => {
-                    // Bool is already handled above via CoerceBool, but just in case
-                    Ok(CoerceBase(bool_val.cast()?.clone()))
-                }
-            }
+        // Check concrete AST types first, preserving the actual type of the input.
+        // Do NOT use CoerceBool here since that now accepts BVs (via BV != 0), which
+        // would incorrectly turn a BV expression into a Bool expression in contexts
+        // like solver.solution(bv_expr, value) that need to preserve the original type.
+        if let Ok(bool_val) = val.cast::<Bool>() {
+            Ok(CoerceBase(bool_val.to_owned().cast()?.clone()))
+        } else if let Ok(bv_val) = val.cast::<BV>() {
+            Ok(CoerceBase(bv_val.to_owned().cast()?.clone()))
+        } else if let Ok(fp_val) = val.cast::<FP>() {
+            Ok(CoerceBase(fp_val.to_owned().cast()?.clone()))
+        } else if let Ok(string_val) = val.cast::<PyAstString>() {
+            Ok(CoerceBase(string_val.to_owned().cast()?.clone()))
+        } else if let Ok(py_bool) = val.extract::<bool>() {
+            // Handle Python bool literals by wrapping in BoolV
+            let bool_ast =
+                Bool::new(val.py(), &GLOBAL_CONTEXT.boolv(py_bool).map_err(ClaripyError::from)?)?;
+            Ok(CoerceBase(bool_ast.cast()?.clone()))
+        } else if let Ok(int_val) = val.cast::<PyInt>() {
+            // Handle Python int literals by wrapping in BVV (64-bit default)
+            let int: BigInt = int_val.extract()?;
+            let bv = BitVec::from_bigint_trunc(&int, 64);
+            let bv_ast = BV::new(
+                val.py(),
+                &GLOBAL_CONTEXT.bvv(bv).map_err(ClaripyError::from)?,
+            )?;
+            Ok(CoerceBase(bv_ast.cast()?.clone()))
         } else if let Ok(fp) = CoerceFP::extract(val) {
             match fp {
                 CoerceFP::FP(fp) => Ok(CoerceBase(fp.cast()?.clone())),

--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -39,8 +39,10 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBool<'py> {
                 } else {
                     // Symbolic: create BV != 0
                     let zero = GLOBAL_CONTEXT
-                        .bvv(BitVec::from_prim_with_size(0u8, bv_val.get().size() as u32)
-                            .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?)
+                        .bvv(
+                            BitVec::from_prim_with_size(0u8, bv_val.get().size() as u32)
+                                .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?,
+                        )
                         .map_err(ClaripyError::from)?;
                     GLOBAL_CONTEXT
                         .neq(inner, &zero)
@@ -48,8 +50,10 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBool<'py> {
                 }
             } else {
                 let zero = GLOBAL_CONTEXT
-                    .bvv(BitVec::from_prim_with_size(0u8, bv_val.get().size() as u32)
-                        .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?)
+                    .bvv(
+                        BitVec::from_prim_with_size(0u8, bv_val.get().size() as u32)
+                            .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?,
+                    )
                     .map_err(ClaripyError::from)?;
                 GLOBAL_CONTEXT
                     .neq(inner, &zero)
@@ -101,10 +105,14 @@ impl<'py> CoerceBV<'py> {
             }
             CoerceBV::Bool(bool_val) => {
                 // Convert Bool to BV of the requested size: If(bool, BVV(1, size), BVV(0, size))
-                let one = GLOBAL_CONTEXT
-                    .bvv(BitVec::from_prim_with_size(1u8, size).map_err(|e| ClaripyError::from(ClarirsError::from(e)))?)?;
-                let zero = GLOBAL_CONTEXT
-                    .bvv(BitVec::from_prim_with_size(0u8, size).map_err(|e| ClaripyError::from(ClarirsError::from(e)))?)?;
+                let one = GLOBAL_CONTEXT.bvv(
+                    BitVec::from_prim_with_size(1u8, size)
+                        .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?,
+                )?;
+                let zero = GLOBAL_CONTEXT.bvv(
+                    BitVec::from_prim_with_size(0u8, size)
+                        .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?,
+                )?;
                 let bv_ast = GLOBAL_CONTEXT.ite(&bool_val.get().inner, &one, &zero)?;
                 BV::new(py, &bv_ast)
             }
@@ -132,17 +140,11 @@ impl<'py> CoerceBV<'py> {
         let rhs_size = rhs.get_size();
 
         match (lhs_size, rhs_size) {
-            (Some(ls), Some(rs)) if ls != rs => {
-                Err(ClaripyError::TypeError(format!(
-                    "BV size mismatch: left operand has {ls} bits, right operand has {rs} bits"
-                )))
-            }
-            (Some(size), _) => {
-                Ok((lhs.unpack(py, size, false)?, rhs.unpack(py, size, false)?))
-            }
-            (_, Some(size)) => {
-                Ok((lhs.unpack(py, size, false)?, rhs.unpack(py, size, false)?))
-            }
+            (Some(ls), Some(rs)) if ls != rs => Err(ClaripyError::TypeError(format!(
+                "BV size mismatch: left operand has {ls} bits, right operand has {rs} bits"
+            ))),
+            (Some(size), _) => Ok((lhs.unpack(py, size, false)?, rhs.unpack(py, size, false)?)),
+            (_, Some(size)) => Ok((lhs.unpack(py, size, false)?, rhs.unpack(py, size, false)?)),
             (None, None) => {
                 // Both are Int or Bool - guess size
                 match (lhs, rhs) {
@@ -172,12 +174,12 @@ impl<'py> CoerceBV<'py> {
         }
 
         // First, determine the size to use
-        let size = vals
-            .iter()
-            .find_map(|val| val.get_size())
-            .ok_or(ClaripyError::InvalidArgumentType(
-                "Failed to extract size of BVs in list".to_string(),
-            ))?;
+        let size =
+            vals.iter()
+                .find_map(|val| val.get_size())
+                .ok_or(ClaripyError::InvalidArgumentType(
+                    "Failed to extract size of BVs in list".to_string(),
+                ))?;
 
         // Round up to the nearest power of 2
         let size = size.next_power_of_two();
@@ -197,12 +199,12 @@ impl<'py> CoerceBV<'py> {
             ));
         }
 
-        let default_size = vals
-            .iter()
-            .find_map(|val| val.get_size())
-            .ok_or(ClaripyError::InvalidArgumentType(
-                "Failed to extract size of BVs in list".to_string(),
-            ))?;
+        let default_size =
+            vals.iter()
+                .find_map(|val| val.get_size())
+                .ok_or(ClaripyError::InvalidArgumentType(
+                    "Failed to extract size of BVs in list".to_string(),
+                ))?;
 
         let mut results = Vec::with_capacity(vals.len());
 
@@ -394,8 +396,10 @@ impl<'a, 'py> FromPyObject<'a, 'py> for CoerceBase<'py> {
             Ok(CoerceBase(string_val.to_owned().cast()?.clone()))
         } else if let Ok(py_bool) = val.extract::<bool>() {
             // Handle Python bool literals by wrapping in BoolV
-            let bool_ast =
-                Bool::new(val.py(), &GLOBAL_CONTEXT.boolv(py_bool).map_err(ClaripyError::from)?)?;
+            let bool_ast = Bool::new(
+                val.py(),
+                &GLOBAL_CONTEXT.boolv(py_bool).map_err(ClaripyError::from)?,
+            )?;
             Ok(CoerceBase(bool_ast.cast()?.clone()))
         } else if let Ok(int_val) = val.cast::<PyInt>() {
             // Handle Python int literals by wrapping in BVV (64-bit default)

--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -18,6 +18,44 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBool<'py> {
             Ok(CoerceBool(
                 Bool::new(val.py(), &GLOBAL_CONTEXT.boolv(bool_val).unwrap()).unwrap(),
             ))
+        } else if let Ok(int_val) = val.cast::<PyInt>() {
+            // Coerce int (0 or non-zero) to Bool
+            let i: BigInt = int_val.extract()?;
+            Ok(CoerceBool(
+                Bool::new(val.py(), &GLOBAL_CONTEXT.boolv(i != BigInt::ZERO).unwrap()).unwrap(),
+            ))
+        } else if let Ok(bv_val) = val.cast::<BV>() {
+            // Coerce BV to Bool: check if concrete, otherwise use If(BV == 0, false, true)
+            let py = val.py();
+            let inner = &bv_val.get().inner;
+            // Try to simplify and check concrete value
+            let bool_ast = if let Ok(simplified) = inner.simplify() {
+                if let BitVecOp::BVV(bv) = simplified.op() {
+                    if bv.is_zero() {
+                        GLOBAL_CONTEXT.false_().map_err(ClaripyError::from)?
+                    } else {
+                        GLOBAL_CONTEXT.true_().map_err(ClaripyError::from)?
+                    }
+                } else {
+                    // Symbolic: create BV != 0
+                    let zero = GLOBAL_CONTEXT
+                        .bvv(BitVec::from_prim_with_size(0u8, bv_val.get().size() as u32)
+                            .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?)
+                        .map_err(ClaripyError::from)?;
+                    GLOBAL_CONTEXT
+                        .neq(inner, &zero)
+                        .map_err(ClaripyError::from)?
+                }
+            } else {
+                let zero = GLOBAL_CONTEXT
+                    .bvv(BitVec::from_prim_with_size(0u8, bv_val.get().size() as u32)
+                        .map_err(|e| ClaripyError::from(ClarirsError::from(e)))?)
+                    .map_err(ClaripyError::from)?;
+                GLOBAL_CONTEXT
+                    .neq(inner, &zero)
+                    .map_err(ClaripyError::from)?
+            };
+            Ok(CoerceBool(Bool::new(py, &bool_ast)?))
         } else {
             Err(ClaripyError::InvalidArgumentType("Expected Bool".to_string()).into())
         }
@@ -39,6 +77,7 @@ impl<'py> From<CoerceBool<'py>> for BoolAst<'static> {
 pub enum CoerceBV<'py> {
     BV(Bound<'py, BV>),
     Int(BigInt),
+    Bool(Bound<'py, Bool>),
 }
 
 impl<'py> CoerceBV<'py> {
@@ -60,6 +99,15 @@ impl<'py> CoerceBV<'py> {
                 let bv = BitVec::from_bigint_trunc(int, size);
                 BV::new(py, &GLOBAL_CONTEXT.bvv(bv)?)
             }
+            CoerceBV::Bool(bool_val) => {
+                // Convert Bool to BV of the requested size: If(bool, BVV(1, size), BVV(0, size))
+                let one = GLOBAL_CONTEXT
+                    .bvv(BitVec::from_prim_with_size(1u8, size).map_err(|e| ClaripyError::from(ClarirsError::from(e)))?)?;
+                let zero = GLOBAL_CONTEXT
+                    .bvv(BitVec::from_prim_with_size(0u8, size).map_err(|e| ClaripyError::from(ClarirsError::from(e)))?)?;
+                let bv_ast = GLOBAL_CONTEXT.ite(&bool_val.get().inner, &one, &zero)?;
+                BV::new(py, &bv_ast)
+            }
         }
     }
 
@@ -67,47 +115,52 @@ impl<'py> CoerceBV<'py> {
         self.unpack(py, like.size() as u32, false)
     }
 
+    fn get_size(&self) -> Option<u32> {
+        match self {
+            CoerceBV::BV(bv) => Some(bv.get().size() as u32),
+            CoerceBV::Int(_) | CoerceBV::Bool(_) => None,
+        }
+    }
+
     pub fn unpack_pair(
         py: Python<'py>,
         lhs: &CoerceBV<'py>,
         rhs: &CoerceBV<'py>,
     ) -> Result<(Bound<'py, BV>, Bound<'py, BV>), ClaripyError> {
-        Ok(match (lhs, rhs) {
-            (CoerceBV::BV(lhs), CoerceBV::BV(rhs)) => {
-                // Check for size mismatch when both are BVs
-                let lhs_size = lhs.get().size() as u32;
-                let rhs_size = rhs.get().size() as u32;
-                if lhs_size != rhs_size {
-                    return Err(ClaripyError::TypeError(format!(
-                        "BV size mismatch: left operand has {lhs_size} bits, right operand has {rhs_size} bits"
-                    )));
-                }
-                (lhs.clone(), rhs.clone())
-            }
-            (CoerceBV::Int(_), CoerceBV::BV(rhs)) => {
-                let lhs = lhs.unpack_like(py, rhs.get())?;
-                (lhs, rhs.clone())
-            }
-            (CoerceBV::BV(lhs), CoerceBV::Int(_)) => {
-                let rhs = rhs.unpack_like(py, lhs.get())?;
-                (lhs.clone(), rhs)
-            }
-            (CoerceBV::Int(lhs_int), CoerceBV::Int(rhs_int)) => {
-                // Both args are ints, so we kinda have to guess the size
-                // Take the max size of the two ints, then round up to the nearest power of 2
+        // Determine target size from whichever operand has a concrete size
+        let lhs_size = lhs.get_size();
+        let rhs_size = rhs.get_size();
 
-                let mut size = max(lhs_int.bits() as u32, rhs_int.bits() as u32);
-                if *lhs_int < BigInt::ZERO || *rhs_int < BigInt::ZERO {
-                    // If either int is negative, we need to add an extra bit for the sign
-                    size += 1;
-                }
-                let size = size.next_power_of_two();
-
-                let lhs = lhs.unpack(py, size, false)?;
-                let rhs = rhs.unpack(py, size, false)?;
-                (lhs, rhs)
+        match (lhs_size, rhs_size) {
+            (Some(ls), Some(rs)) if ls != rs => {
+                Err(ClaripyError::TypeError(format!(
+                    "BV size mismatch: left operand has {ls} bits, right operand has {rs} bits"
+                )))
             }
-        })
+            (Some(size), _) => {
+                Ok((lhs.unpack(py, size, false)?, rhs.unpack(py, size, false)?))
+            }
+            (_, Some(size)) => {
+                Ok((lhs.unpack(py, size, false)?, rhs.unpack(py, size, false)?))
+            }
+            (None, None) => {
+                // Both are Int or Bool - guess size
+                match (lhs, rhs) {
+                    (CoerceBV::Int(lhs_int), CoerceBV::Int(rhs_int)) => {
+                        let mut size = max(lhs_int.bits() as u32, rhs_int.bits() as u32);
+                        if *lhs_int < BigInt::ZERO || *rhs_int < BigInt::ZERO {
+                            size += 1;
+                        }
+                        let size = size.next_power_of_two();
+                        Ok((lhs.unpack(py, size, false)?, rhs.unpack(py, size, false)?))
+                    }
+                    _ => {
+                        // Bool/Bool or Bool/Int combinations - default to 1-bit
+                        Ok((lhs.unpack(py, 1, false)?, rhs.unpack(py, 1, false)?))
+                    }
+                }
+            }
+        }
     }
 
     pub fn unpack_vec(
@@ -121,11 +174,7 @@ impl<'py> CoerceBV<'py> {
         // First, determine the size to use
         let size = vals
             .iter()
-            .find(|val| matches!(val, CoerceBV::BV(_)))
-            .map(|val| match val {
-                CoerceBV::BV(bv) => bv.get().size() as u32,
-                CoerceBV::Int(_) => 0,
-            })
+            .find_map(|val| val.get_size())
             .ok_or(ClaripyError::InvalidArgumentType(
                 "Failed to extract size of BVs in list".to_string(),
             ))?;
@@ -150,11 +199,7 @@ impl<'py> CoerceBV<'py> {
 
         let default_size = vals
             .iter()
-            .find(|val| matches!(val, CoerceBV::BV(_)))
-            .map(|val| match val {
-                CoerceBV::BV(bv) => bv.get().size() as u32,
-                CoerceBV::Int(_) => 0,
-            })
+            .find_map(|val| val.get_size())
             .ok_or(ClaripyError::InvalidArgumentType(
                 "Failed to extract size of BVs in list".to_string(),
             ))?;
@@ -162,15 +207,7 @@ impl<'py> CoerceBV<'py> {
         let mut results = Vec::with_capacity(vals.len());
 
         for val in vals {
-            let unpacked = match val {
-                CoerceBV::BV(bv) => Ok(bv.clone()),
-                CoerceBV::Int(int) => {
-                    // Match the size of the first BV in the list, otherwise default to 64 bits
-                    let bv = BitVec::from_bigint_trunc(int, default_size);
-                    BV::new(py, &GLOBAL_CONTEXT.bvv(bv).map_err(ClaripyError::from)?)
-                }
-            };
-            results.push(unpacked?);
+            results.push(val.unpack(py, default_size, true)?);
         }
 
         Ok(results)
@@ -185,6 +222,8 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBV<'py> {
             Ok(CoerceBV::from(bv_val.to_owned()))
         } else if let Ok(int_val) = val.cast::<PyInt>() {
             Ok(CoerceBV::from(int_val.to_owned()))
+        } else if let Ok(bool_val) = val.cast::<Bool>() {
+            Ok(CoerceBV::Bool(bool_val.to_owned()))
         } else if let Ok(bytes_val) = val.extract::<Vec<u8>>() {
             Ok(CoerceBV::BV(BV::new(
                 val.py(),
@@ -354,6 +393,10 @@ impl<'a, 'py> FromPyObject<'a, 'py> for CoerceBase<'py> {
                         &GLOBAL_CONTEXT.bvv(bv).map_err(ClaripyError::from)?,
                     )?;
                     Ok(CoerceBase(bv.cast()?.clone()))
+                }
+                CoerceBV::Bool(bool_val) => {
+                    // Bool is already handled above via CoerceBool, but just in case
+                    Ok(CoerceBase(bool_val.cast()?.clone()))
                 }
             }
         } else if let Ok(fp) = CoerceFP::extract(val) {

--- a/crates/clarirs_py/src/ast/mod.rs
+++ b/crates/clarirs_py/src/ast/mod.rs
@@ -34,6 +34,24 @@ pub fn and<'py>(
     py: Python<'py>,
     args: Vec<Bound<'py, PyAny>>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
+    // If all args are actually Bools (or Python bool literals) — not BVs
+    // being coerced through the Bool path — use the Bool And. Otherwise fall
+    // back to BV bitwise And.
+    let all_bools = args
+        .iter()
+        .all(|arg| arg.cast::<Bool>().is_ok() || arg.extract::<bool>().is_ok());
+    if all_bools {
+        let bool_args = args
+            .into_iter()
+            .map(|arg| {
+                arg.extract::<CoerceBool>()
+                    .map(|b| b.0.get().inner.clone())
+                    .map_err(|_| ClaripyError::TypeError("And arguments must be Bool".to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        return Bool::new(py, &GLOBAL_CONTEXT.and(bool_args)?)
+            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+    }
     if args.len() == 2
         && let Some(lhs) = args[0].extract::<CoerceBV>().ok()
         && let Some(rhs) = args[1].extract::<CoerceBV>().ok()
@@ -44,18 +62,10 @@ pub fn and<'py>(
             &GLOBAL_CONTEXT.bv_and(&lhs.get().inner, &rhs.get().inner)?,
         )
         .map(|b| b.into_any().cast::<Base>().unwrap().clone());
-    } else {
-        let args = args
-            .into_iter()
-            .map(|arg| {
-                arg.extract::<CoerceBool>()
-                    .map(|b| b.0.get().inner.clone())
-                    .map_err(|_| ClaripyError::TypeError("And arguments must be Bool".to_string()))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        return Bool::new(py, &GLOBAL_CONTEXT.and(args)?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
     }
+    Err(ClaripyError::TypeError(
+        "And: expected Bools or exactly two BVs".to_string(),
+    ))
 }
 
 #[pyfunction(name = "Or", signature = (*args))]
@@ -63,6 +73,22 @@ pub fn or<'py>(
     py: Python<'py>,
     args: Vec<Bound<'py, PyAny>>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
+    // Same policy as And: prefer the Bool path whenever every arg is a Bool.
+    let all_bools = args
+        .iter()
+        .all(|arg| arg.cast::<Bool>().is_ok() || arg.extract::<bool>().is_ok());
+    if all_bools {
+        let bool_args = args
+            .into_iter()
+            .map(|arg| {
+                arg.extract::<CoerceBool>()
+                    .map(|b| b.0.get().inner.clone())
+                    .map_err(|_| ClaripyError::TypeError("Or arguments must be Bool".to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        return Bool::new(py, &GLOBAL_CONTEXT.or(bool_args)?)
+            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+    }
     if args.len() == 2
         && let Some(lhs) = args[0].extract::<CoerceBV>().ok()
         && let Some(rhs) = args[1].extract::<CoerceBV>().ok()
@@ -73,18 +99,10 @@ pub fn or<'py>(
             &GLOBAL_CONTEXT.bv_or(&lhs.get().inner, &rhs.get().inner)?,
         )
         .map(|b| b.into_any().cast::<Base>().unwrap().clone());
-    } else {
-        let args = args
-            .into_iter()
-            .map(|arg| {
-                arg.extract::<CoerceBool>()
-                    .map(|b| b.0.get().inner.clone())
-                    .map_err(|_| ClaripyError::TypeError("And arguments must be Bool".to_string()))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        return Bool::new(py, &GLOBAL_CONTEXT.or(args)?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
     }
+    Err(ClaripyError::TypeError(
+        "Or: expected Bools or exactly two BVs".to_string(),
+    ))
 }
 
 #[pyfunction]

--- a/crates/clarirs_py/src/lib.rs
+++ b/crates/clarirs_py/src/lib.rs
@@ -118,6 +118,7 @@ fn is_true(expr: Bound<'_, PyAny>) -> Result<bool, ClaripyError> {
         match bv_expr {
             CoerceBV::BV(bv_expr) => Ok(bv_expr.get().inner.simplify()?.is_true()),
             CoerceBV::Int(int_expr) => Ok(int_expr != BigInt::ZERO),
+            CoerceBV::Bool(bool_expr) => Ok(bool_expr.get().inner.simplify()?.is_true()),
         }
     } else if let Ok(fp_expr) = expr.clone().extract::<CoerceFP>() {
         match fp_expr {
@@ -139,6 +140,7 @@ fn is_false(expr: Bound<'_, PyAny>) -> Result<bool, ClaripyError> {
         match bv_expr {
             CoerceBV::BV(bv_expr) => Ok(bv_expr.get().inner.simplify()?.is_false()),
             CoerceBV::Int(int_expr) => Ok(int_expr == BigInt::ZERO),
+            CoerceBV::Bool(bool_expr) => Ok(bool_expr.get().inner.simplify()?.is_false()),
         }
     } else if let Ok(fp_expr) = expr.clone().extract::<CoerceFP>() {
         match fp_expr {

--- a/crates/clarirs_py/src/solver.rs
+++ b/crates/clarirs_py/src/solver.rs
@@ -268,8 +268,11 @@ impl PySolver {
         &mut self,
         exprs: Bound<'py, PyAny>,
     ) -> Result<Vec<Bound<'py, Bool>>, ClaripyError> {
-        // Try to handle as iterable first (supports tuple, list, and any iterable)
-        let bool_exprs = if let Ok(iter) = exprs.try_iter() {
+        // First try to handle as a single Bool or BV (before trying iteration,
+        // since BV supports __getitem__ which makes it iterable in Python)
+        let bool_exprs = if let Ok(coerced) = exprs.extract::<CoerceBool>() {
+            vec![coerced.0]
+        } else if let Ok(iter) = exprs.try_iter() {
             // Convert iterable of expressions to Vec<Bound<Bool>>
             iter.map(|expr_result| {
                 let expr = expr_result
@@ -280,15 +283,9 @@ impl PySolver {
             })
             .collect::<Result<Vec<_>, _>>()?
         } else {
-            // Handle single expression case
-            vec![
-                exprs
-                    .extract::<CoerceBool>()
-                    .map_err(|_| {
-                        ClaripyError::TypeError("add: expression must be a boolean".to_string())
-                    })?
-                    .0,
-            ]
+            return Err(ClaripyError::TypeError(
+                "add: expression must be a boolean or iterable of booleans".to_string(),
+            ));
         };
 
         // Add all expressions to the solver


### PR DESCRIPTION
## Summary

claripy allows Bool, BV, and int operands to be mixed freely in the places you'd expect — e.g. `bv + bool`, `solver.add(1_bit_bv)`, `solver.add(1)`. This PR makes clarirs accept the same mixes.

### CoerceBV: accept Bool

`bv + bool_expr` used to fail with `unsupported operand type(s) for +: 'claripy.ast.bv.BV' and 'claripy.ast.bool.Bool'`. Add a new `Bool` variant to `CoerceBV`; in `unpack`, convert it to a BV of the target size via `If(bool, BVV(1, size), BVV(0, size))`. This is how claripy handled the same case, and angr's VEX engine depends on it for arithmetic over VEX guard expressions.

### CoerceBool: accept BV and int

`solver.add(1_bit_bv)` used to fail, because `CoerceBool` only accepted `Bool` or Python `bool`. Now accept:
- **BV**: coerced via `bv != 0` with a concrete fast-path for BVV (avoids constructing a symbolic `Neq` node for concrete values).
- **Python int**: interpreted as non-zero → true, zero → false. Matches claripy semantics.

### Solver.add: prefer single-Bool extraction before iteration

`Solver.add` currently tries `try_iter()` first, then falls back to single-Bool extraction. But BV supports `__getitem__` in Python, which makes it iterable — iterating yields individual bits. So `solver.add(some_bv)` would start chopping the BV into single bits instead of adding it as a constraint.

Swap the order: try to extract as a single `CoerceBool` first, then fall back to iteration. Keeps list/tuple support working while making BV-as-constraint work correctly.

## Test plan
- [ ] `claripy.BVV(5, 32) + claripy.BoolV(True)` → concrete 6
- [ ] `claripy.Solver().add(claripy.BVV(1, 1))` succeeds; `satisfiable()` → True
- [ ] `claripy.Solver().add(claripy.BVV(0, 1))` succeeds; `satisfiable()` → False
- [ ] `claripy.Solver().add([x > 5, x < 10])` still works (iterable path)
- [ ] `solver.solution(expr, 0)` with int value still works on any expr type

🤖 Generated with [Claude Code](https://claude.com/claude-code)