### PR TITLE
Add __eq__/__ne__/__hash__/__repr__ to PyFSort

### DIFF
--- a/crates/clarirs_py/src/ast/fp.rs
+++ b/crates/clarirs_py/src/ast/fp.rs
@@ -111,6 +111,26 @@ impl PyFSort {
         let from_size = class.getattr("from_size")?;
         Ok((from_size.into_any(), (self.0.size(),)))
     }
+
+    pub fn __eq__(&self, other: &PyFSort) -> bool {
+        self.0 == other.0
+    }
+
+    pub fn __ne__(&self, other: &PyFSort) -> bool {
+        self.0 != other.0
+    }
+
+    pub fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        self.0.size().hash(&mut h);
+        h.finish()
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("FSORT_{}", self.0.size())
+    }
 }
 
 impl From<PyFSort> for FSort {


### PR DESCRIPTION
## Summary
- claripy's \`FSort\` supports equality comparison — e.g. \`fp_expr.sort == claripy.FSORT_DOUBLE\`.
- Without \`__eq__\`, PyO3 falls back to identity comparison, so two distinct instances of the same sort compare unequal. This breaks angr's calling convention logic which dispatches FP-vs-BV register packing based on \`arg.sort == claripy.FSORT_FLOAT\`.
- Add value-based \`__eq__\`/\`__ne__\` (delegating to the underlying \`FSort\`, which already derives \`PartialEq\`), a matching \`__hash__\`, and a readable \`__repr__\` (e.g. \`FSORT_64\`).

## Test plan
- [ ] \`claripy.FPV(1.0, claripy.FSORT_DOUBLE).sort == claripy.FSORT_DOUBLE\` → \`True\`
- [ ] \`claripy.FSORT_FLOAT == claripy.FSORT_DOUBLE\` → \`False\`
- [ ] \`hash(claripy.FSORT_DOUBLE) == hash(claripy.FSORT_DOUBLE)\`
- [ ] \`repr(claripy.FSORT_DOUBLE) == 'FSORT_64'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)