### PR TITLE
Fix O(n²) behavior in n-ary simplify for Concat/And/Or/Xor/Add/Mul

### DIFF
--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -92,6 +92,8 @@ impl<'c> Simplify<'c> for DynAst<'c> {
 enum SimplifyError<'c> {
     #[error("Missing child at index {0}")]
     MissingChild(usize),
+    #[error("Missing {} children", .0.len())]
+    MissingChildren(Vec<usize>),
     #[error("Re-run simplification")]
     #[allow(dead_code)]
     ReRun(DynAst<'c>),
@@ -131,6 +133,48 @@ impl<'c> SimplifyState<'c> {
             self.last_missed_child = Some(index);
             Err(SimplifyError::MissingChild(index))
         }
+    }
+
+    /// Return simplified versions of all children in one shot. If any are
+    /// missing, returns `MissingChildren` listing every missing index so the
+    /// main simplify loop can schedule them in one batch. This is crucial for
+    /// n-ary ops (like Concat) with many children: fetching them one at a
+    /// time causes quadratic re-runs of simplify_inner.
+    fn get_all_simplified(&self) -> Result<Vec<DynAst<'c>>, SimplifyError<'c>> {
+        let missing: Vec<usize> = self
+            .children
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| c.is_none().then_some(i))
+            .collect();
+        if !missing.is_empty() {
+            return Err(SimplifyError::MissingChildren(missing));
+        }
+        Ok(self.children.iter().map(|c| c.clone().unwrap()).collect())
+    }
+
+    fn get_all_bool_simplified(&self) -> Result<Vec<BoolAst<'c>>, SimplifyError<'c>> {
+        self.get_all_simplified()?
+            .into_iter()
+            .map(|c| {
+                c.into_bool()
+                    .ok_or(SimplifyError::Error(ClarirsError::TypeError(
+                        "Expected bool child".into(),
+                    )))
+            })
+            .collect()
+    }
+
+    fn get_all_bv_simplified(&self) -> Result<Vec<BitVecAst<'c>>, SimplifyError<'c>> {
+        self.get_all_simplified()?
+            .into_iter()
+            .map(|c| {
+                c.into_bitvec()
+                    .ok_or(SimplifyError::Error(ClarirsError::TypeError(
+                        "Expected bitvector child".into(),
+                    )))
+            })
+            .collect()
     }
 
     fn get_bool_simplified(&mut self, index: usize) -> Result<BoolAst<'c>, SimplifyError<'c>> {
@@ -282,6 +326,27 @@ fn simplify<'c>(
                     work_stack.push(state);
                     // Push the missing child onto the stack
                     work_stack.push(child_state);
+                }
+                Err(SimplifyError::MissingChildren(indices)) => {
+                    // Batch-simplify all missing children at once to avoid
+                    // O(n^2) behaviour for wide n-ary ops like Concat. We use
+                    // direct recursion here: the parent op is allowed to
+                    // defer all its children with a single request and we
+                    // simplify each child via the normal entry point. Stack
+                    // depth is bounded by the nesting depth of n-ary ops,
+                    // not by the number of children.
+                    for idx in indices {
+                        if state.children[idx].is_none() {
+                            let child_expr = state.expr.get_child(idx).unwrap();
+                            let simplified =
+                                simplify(&child_expr, respect_annotations, error_on_dbz)?;
+                            state.children[idx] = Some(simplified);
+                        }
+                    }
+                    // All requested children are now cached; re-push the
+                    // state so simplify_inner will run again with children
+                    // available.
+                    work_stack.push(state);
                 }
                 Err(SimplifyError::ReRun(new_ast)) => {
                     // Push a new state with the new_ast onto the stack

--- a/crates/clarirs_core/src/algorithms/simplify/bool.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/bool.rs
@@ -124,9 +124,9 @@ pub(crate) fn simplify_bool<'c>(
                 return state.rerun(ctx.and(absorbed_args)?);
             }
 
-            let simplified_args = (0..args.len())
-                .map(|i| state.get_bool_simplified(i))
-                .collect::<Result<Vec<_>, _>>()?;
+            // Simplify all children in one batch to avoid quadratic re-runs
+            // for wide And.
+            let simplified_args = state.get_all_bool_simplified()?;
             Ok(ctx.and(simplified_args)?)
         }
         BooleanOp::Or(args) => {
@@ -214,9 +214,9 @@ pub(crate) fn simplify_bool<'c>(
                 return state.rerun(ctx.or(absorbed_args)?);
             }
 
-            let simplified_args = (0..args.len())
-                .map(|i| state.get_bool_simplified(i))
-                .collect::<Result<Vec<_>, _>>()?;
+            // Simplify all children in one batch to avoid quadratic re-runs
+            // for wide Or.
+            let simplified_args = state.get_all_bool_simplified()?;
             Ok(ctx.or(simplified_args)?)
         }
         BooleanOp::Xor(..) => {

--- a/crates/clarirs_core/src/algorithms/simplify/bv.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/bv.rs
@@ -19,11 +19,9 @@ pub(crate) fn simplify_bv<'c>(
                 _ => Ok(ctx.not(arc)?),
             }
         }
-        BitVecOp::And(args) => {
-            // Simplify all children
-            let simplified: Vec<BitVecAst<'c>> = (0..args.len())
-                .map(|i| state.get_bv_simplified(i))
-                .collect::<Result<_, _>>()?;
+        BitVecOp::And(_) => {
+            // Simplify all children in one batch to avoid quadratic re-runs.
+            let simplified = state.get_all_bv_simplified()?;
 
             let size = simplified[0].size();
 
@@ -227,11 +225,9 @@ pub(crate) fn simplify_bv<'c>(
                 }
             }
         }
-        BitVecOp::Or(args) => {
-            // Simplify all children
-            let simplified: Vec<BitVecAst<'c>> = (0..args.len())
-                .map(|i| state.get_bv_simplified(i))
-                .collect::<Result<_, _>>()?;
+        BitVecOp::Or(_) => {
+            // Simplify all children in one batch to avoid quadratic re-runs.
+            let simplified = state.get_all_bv_simplified()?;
 
             let size = simplified[0].size();
             let all_ones =
@@ -347,11 +343,9 @@ pub(crate) fn simplify_bv<'c>(
                 }
             }
         }
-        BitVecOp::Xor(args) => {
-            // Simplify all children
-            let simplified: Vec<BitVecAst<'c>> = (0..args.len())
-                .map(|i| state.get_bv_simplified(i))
-                .collect::<Result<_, _>>()?;
+        BitVecOp::Xor(_) => {
+            // Simplify all children in one batch to avoid quadratic re-runs.
+            let simplified = state.get_all_bv_simplified()?;
 
             let size = simplified[0].size();
 
@@ -481,11 +475,9 @@ pub(crate) fn simplify_bv<'c>(
                 _ => Ok(ctx.neg(arc)?),
             }
         }
-        BitVecOp::Add(args) => {
-            // Simplify all children
-            let simplified: Vec<BitVecAst<'c>> = (0..args.len())
-                .map(|i| state.get_bv_simplified(i))
-                .collect::<Result<_, _>>()?;
+        BitVecOp::Add(_) => {
+            // Simplify all children in one batch to avoid quadratic re-runs.
+            let simplified = state.get_all_bv_simplified()?;
 
             let size = simplified[0].size();
 
@@ -631,11 +623,9 @@ pub(crate) fn simplify_bv<'c>(
                 _ => Ok(ctx.sub(arc, arc1)?),
             }
         }
-        BitVecOp::Mul(args) => {
-            // Simplify all children
-            let simplified: Vec<BitVecAst<'c>> = (0..args.len())
-                .map(|i| state.get_bv_simplified(i))
-                .collect::<Result<_, _>>()?;
+        BitVecOp::Mul(_) => {
+            // Simplify all children in one batch to avoid quadratic re-runs.
+            let simplified = state.get_all_bv_simplified()?;
 
             let size = simplified[0].size();
 
@@ -1234,11 +1224,11 @@ pub(crate) fn simplify_bv<'c>(
                 _ => Ok(ctx.extract(arc, *high, *low)?),
             }
         }
-        BitVecOp::Concat(args) => {
-            // Simplify all children first
-            let simplified_args: Vec<BitVecAst<'c>> = (0..args.len())
-                .map(|i| state.get_bv_simplified(i))
-                .collect::<Result<Vec<_>, _>>()?;
+        BitVecOp::Concat(_) => {
+            // Simplify all children in one batch. Fetching them one at a
+            // time would make simplify_inner re-run for every child and
+            // turn wide Concats into a quadratic cost.
+            let simplified_args = state.get_all_bv_simplified()?;
 
             // Flatten nested Concats and filter zero-size args
             let mut flattened: Vec<BitVecAst<'c>> = Vec::new();

--- a/crates/clarirs_core/src/ast/bitvec.rs
+++ b/crates/clarirs_core/src/ast/bitvec.rs
@@ -342,6 +342,24 @@ impl<'c> Op<'c> for BitVecOp<'c> {
         BitVecOp::child_iter(self)
     }
 
+    /// O(1) direct indexing for n-ary ops. Without this override the default
+    /// impl uses `child_iter().nth(index)`, which walks the iterator from the
+    /// start and is O(index). When simplification processes all N children
+    /// of an n-ary op, iterating get_child(0..N) then costs O(N^2).
+    /// Overriding for Concat/And/Or/Xor/Add/Mul restores linear-time child
+    /// traversal for wide expressions.
+    fn get_child(&self, index: usize) -> Option<DynAst<'c>> {
+        match self {
+            BitVecOp::And(args)
+            | BitVecOp::Or(args)
+            | BitVecOp::Xor(args)
+            | BitVecOp::Add(args)
+            | BitVecOp::Mul(args)
+            | BitVecOp::Concat(args) => args.get(index).cloned().map(Into::into),
+            _ => self.child_iter().nth(index),
+        }
+    }
+
     fn variables(&self) -> BTreeSet<InternedString> {
         if let BitVecOp::BVS(s, _) = self {
             let mut set = BTreeSet::new();

--- a/crates/clarirs_core/src/ast/bool.rs
+++ b/crates/clarirs_core/src/ast/bool.rs
@@ -338,6 +338,15 @@ impl<'c> Op<'c> for BooleanOp<'c> {
         BooleanOp::child_iter(self)
     }
 
+    /// O(1) direct indexing for n-ary And/Or. See the note on
+    /// BitVecOp::get_child for why.
+    fn get_child(&self, index: usize) -> Option<DynAst<'c>> {
+        match self {
+            BooleanOp::And(args) | BooleanOp::Or(args) => args.get(index).cloned().map(Into::into),
+            _ => self.child_iter().nth(index),
+        }
+    }
+
     fn is_true(&self) -> bool {
         matches!(self, BooleanOp::BoolV(true))
     }


### PR DESCRIPTION
## Summary

For wide n-ary ops the simplify harness was quadratic. Each call to `simplify_inner` iterated children from index 0, stopping at the first unsimplified child and returning `MissingChild(i)`. The main loop then simplified child `i` and re-ran `simplify_inner`, which started over from 0, found `0..=i` cached, and hit the next missing child at `i+1`. Total child lookups across all re-runs: `1 + 2 + ... + n = O(n^2)`.

### Repro

```python
import claripy, time
for n in [256, 512, 1024, 2048, 4096]:
    bvs = [claripy.BVS(f'x{i}', 8) for i in range(n)]
    t = time.time()
    claripy.Concat(*bvs)
    print(f'n={n}: {(time.time()-t)*1000:.1f}ms')
```

Before:
```
n=256:   0.9 ms
n=512:   3.0 ms
n=1024:  11.8 ms   (4x)
n=2048:  46.1 ms   (4x)
n=4096: 188.0 ms   (4x)   <- doubling n quadruples time
```

After (both commits):
```
n=1024:  0.4 ms
n=2048:  0.8 ms
n=4096:  1.7 ms    <- 110x faster, and clearly linear in n
n=8192:  3.2 ms
n=16384: 7.8 ms
```

## Changes

**Commit 1: batch child simplification**

- Added a `MissingChildren(Vec<usize>)` variant to `SimplifyError` so an op can request all its missing children in one shot.
- Added `SimplifyState::get_all_bv_simplified()` / `get_all_bool_simplified()` methods. Each either returns every simplified child in one Vec or reports every missing index via `MissingChildren` so the main loop can schedule them in a single batch. Callers no longer need separate "require + fetch" steps.
- The main `simplify` loop handles `MissingChildren` by recursively simplifying each missing child inline via the normal `simplify()` entry point. Stack depth is bounded by the nesting depth of n-ary ops, not the number of children.
- Updated the n-ary op cases in `simplify/bv.rs` (`Concat`, `And`, `Or`, `Xor`, `Add`, `Mul`) and `simplify/bool.rs` (`And`, `Or`) to call `state.get_all_bv_simplified()` / `state.get_all_bool_simplified()` and get every simplified child in one call.

**Commit 2: O(1) `get_child` override for n-ary ops**

- After commit 1, the next bottleneck was `Op::get_child`, whose default implementation walks `child_iter().nth(index)` and is O(index). Iterating `get_child(0..N)` over an n-ary op was therefore still O(N^2).
- Overrode `get_child` on `BitVecOp` (for `Concat`, `And`, `Or`, `Xor`, `Add`, `Mul`) and `BooleanOp` (for `And`, `Or`) to index directly into the children `Vec` in O(1). Combined with commit 1, wide `Concat`s are now truly linear.

## Real-world impact

Measured on angr's `test_identifier::test_comparison_identification`, which exercises symbolic memory operations that build large `Concat` expressions:

- Before: 208 seconds
- After: 15.7 seconds (13x speedup)

## Test plan

- [x] `cargo test -p clarirs_core` (127/127 passing)
- [x] Manual Concat scaling benchmark (see before/after above)
- [x] angr's `test_identifier::test_comparison_identification` went from 208s to 15.7s

Generated with [Claude Code](https://claude.com/claude-code)