### PR TITLE
Drop stale @expectedFailure on test_solving_with_constraints

### DIFF
--- a/crates/clarirs_py/tests/test_vsa_simplify_solving.py
+++ b/crates/clarirs_py/tests/test_vsa_simplify_solving.py
@@ -243,7 +243,6 @@ class TestVSASimplificationAndSolving(unittest.TestCase):
         self.assertTrue(self.solver.solution(expr, 10))
         self.assertFalse(self.solver.solution(expr, 5))
 
-    @unittest.expectedFailure
     def test_solving_with_constraints(self):
         """Test solving with added constraints."""
         # Note: VSA solver might not handle constraints in the same way as the Z3 solver


### PR DESCRIPTION
## Summary
- The VSA solver now passes `test_solving_with_constraints`, so the `@unittest.expectedFailure` decorator was producing an "unexpected success" pytest failure.
- This is one of three Python test failures surfaced while sweeping the suite during the recent perf review (see `PERF_REVIEW.md` items "stale @expectedFailure").

## Test plan
- [x] `pytest crates/clarirs_py/tests/test_vsa_simplify_solving.py` — 12 passed.
- [x] Full suite still passes the previously-passing tests (no regressions in this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)