### PR TITLE
Assert matching BitVec length on bitwise ops and Ord::cmp

### DIFF
--- a/crates/clarirs_num/src/bitvec/bitwise.rs
+++ b/crates/clarirs_num/src/bitvec/bitwise.rs
@@ -22,6 +22,10 @@ impl BitAnd for BitVec {
     type Output = Result<Self, BitVecError>;
 
     fn bitand(self, rhs: Self) -> Self::Output {
+        assert_eq!(
+            self.length, rhs.length,
+            "BitVec lengths must match for bitwise AND"
+        );
         let new_bv = self
             .words
             .iter()
@@ -36,6 +40,10 @@ impl BitOr for BitVec {
     type Output = Result<Self, BitVecError>;
 
     fn bitor(self, rhs: Self) -> Self::Output {
+        assert_eq!(
+            self.length, rhs.length,
+            "BitVec lengths must match for bitwise OR"
+        );
         let new_bv = self
             .words
             .iter()
@@ -50,6 +58,10 @@ impl BitXor for BitVec {
     type Output = Result<Self, BitVecError>;
 
     fn bitxor(self, rhs: Self) -> Self::Output {
+        assert_eq!(
+            self.length, rhs.length,
+            "BitVec lengths must match for bitwise XOR"
+        );
         let new_bv = self
             .words
             .iter()
@@ -216,6 +228,30 @@ mod tests {
         assert_eq!(result.to_u64().unwrap(), 0b01010101);
 
         Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "BitVec lengths must match for bitwise AND")]
+    fn test_bitand_different_lengths_panics() {
+        let bv1 = BitVec::from_prim_with_size(0xffu8, 8).unwrap();
+        let bv2 = BitVec::from_prim_with_size(0xffffu16, 16).unwrap();
+        let _ = bv1 & bv2;
+    }
+
+    #[test]
+    #[should_panic(expected = "BitVec lengths must match for bitwise OR")]
+    fn test_bitor_different_lengths_panics() {
+        let bv1 = BitVec::from_prim_with_size(0xffu8, 8).unwrap();
+        let bv2 = BitVec::from_prim_with_size(0xffffu16, 16).unwrap();
+        let _ = bv1 | bv2;
+    }
+
+    #[test]
+    #[should_panic(expected = "BitVec lengths must match for bitwise XOR")]
+    fn test_bitxor_different_lengths_panics() {
+        let bv1 = BitVec::from_prim_with_size(0xffu8, 8).unwrap();
+        let bv2 = BitVec::from_prim_with_size(0xffffu16, 16).unwrap();
+        let _ = bv1 ^ bv2;
     }
 
     #[test]

--- a/crates/clarirs_num/src/bitvec/comparison.rs
+++ b/crates/clarirs_num/src/bitvec/comparison.rs
@@ -8,6 +8,10 @@ impl PartialOrd for BitVec {
 
 impl Ord for BitVec {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        assert_eq!(
+            self.length, other.length,
+            "BitVec lengths must match for comparison"
+        );
         self.words
             .iter()
             .zip(other.words.iter())
@@ -211,5 +215,15 @@ mod tests {
         let bv1 = BitVec::from_prim_with_size(0x05u8, 8).unwrap();
         let bv2 = BitVec::from_prim_with_size(0x0005u16, 16).unwrap();
         let _ = bv1.signed_lt(&bv2);
+    }
+
+    #[test]
+    #[should_panic(expected = "BitVec lengths must match for comparison")]
+    fn test_unsigned_cmp_different_lengths() {
+        // Previously this silently truncated to the shorter operand and could
+        // return Ordering::Equal for unequal BVs.
+        let bv1 = BitVec::from_prim_with_size(0x05u8, 8).unwrap();
+        let bv2 = BitVec::from_prim_with_size(0x0005u16, 16).unwrap();
+        let _ = bv1.cmp(&bv2);
     }
 }


### PR DESCRIPTION
## Summary
- `BitAnd`/`BitOr`/`BitXor` silently truncated to the shorter `BitVec` because the implementations `.zip()`ped two `words` slices without checking lengths — a wrong-by-construction result rather than a panic.
- `Ord::cmp` had the same issue: comparing BVs of different widths could return `Ordering::Equal` for unequal values.
- Add `assert_eq!` length checks matching the convention already in place for `signed_lt` (`comparison.rs:25`).

## Test plan
- [x] `cargo test --workspace` — all previously-passing tests still pass
- [x] Four new `#[should_panic]` tests cover the AND/OR/XOR/cmp paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)