### PR TITLE
Correct test_div expected ULP for 2.5/1.5

### DIFF
--- a/crates/clarirs_py/tests/test_fp_ops.py
+++ b/crates/clarirs_py/tests/test_fp_ops.py
@@ -142,7 +142,10 @@ class TestFPOperations(unittest.TestCase):
         self._check_equal(result, 0.6)
 
         result = self.fp2 / self.fp1
-        self._check_equal(result, 1.6666665077, check_bits=True)
+        # 2.5/1.5 = 5/3, correctly-rounded to float32 = 0x3fd55555 = 1.6666666269302368.
+        # The previous expected value (1.6666665077 ~= 0x3fd55554) was one ULP below
+        # the IEEE-754 round-to-nearest-even result.
+        self._check_equal(result, 1.6666666269302368, check_bits=True)
 
         result = self.fp3 / self.fp4
         self._check_equal(result, 2.0)


### PR DESCRIPTION
## Summary
- `test_div` asserted `2.5 / 1.5 == 1.6666665077` (0x3fd55554), but the correctly-rounded float32 result of 5/3 is 0x3fd55555 = 1.6666666269302368 — one ULP higher.
- clarirs already produces the correct result; verified against Python's own float32 division:
  ```
  >>> import struct; struct.unpack('f', struct.pack('f', 2.5/1.5))[0]
  1.6666666269302368
  ```
- Originally surfaced as a Python-suite failure during the perf review.

## Test plan
- [x] `pytest crates/clarirs_py/tests/test_fp_ops.py` — 17 passed, 1 skipped
- [x] `cargo test --workspace` — no regressions (no Rust change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)