### PR TITLE
Drop AstNode Drop hook; rely on lazy weakref cleanup

### DIFF
--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -33,14 +33,13 @@ pub struct AstNode<'c, O: Op<'c>> {
     symbolic: bool,
 }
 
-impl<'c, O> Drop for AstNode<'c, O>
-where
-    O: Op<'c>,
-{
-    fn drop(&mut self) {
-        self.ctx.drop_cache(self.hash);
-    }
-}
+// The cache stores `Weak` references and `get_or_insert` already falls
+// through to recompute when an upgrade fails, so dropping an `AstNode`
+// does not need to eagerly evict its cache entry. The previous `Drop`
+// took three write locks (ast_cache / simplification_cache /
+// excavate_ite_cache) on every Arc destruction — devastating in tight
+// loops that build and discard short-lived expressions. Stale `Weak`
+// entries are pruned lazily as their hashes are reinserted.
 
 impl<'c, O> Debug for AstNode<'c, O>
 where

--- a/crates/clarirs_core/src/cache.rs
+++ b/crates/clarirs_core/src/cache.rs
@@ -335,6 +335,24 @@ mod tests {
     }
 
     #[test]
+    fn test_ephemeral_asts_do_not_corrupt_cache() -> Result<(), ClarirsError> {
+        // Build then immediately drop many ephemeral ASTs. With lazy
+        // weakref cleanup, stale Weaks accumulate in the cache; verify
+        // that subsequent inserts at the same hash overwrite cleanly and
+        // produce the right Arc.
+        let ctx = crate::context::Context::new();
+        for _ in 0..1000 {
+            let _ = ctx.bvv_prim_with_size(42u64, 64)?;
+        }
+        // The interned BVV(42, 64) should still resolve identically — the
+        // cache must not have returned a stale Weak.
+        let a = ctx.bvv_prim_with_size(42u64, 64)?;
+        let b = ctx.bvv_prim_with_size(42u64, 64)?;
+        assert_eq!(a, b);
+        Ok(())
+    }
+
+    #[test]
     fn test_generic_cache_basic() {
         let cache = GenericCache::<u64, String>::default();
 

--- a/crates/clarirs_core/src/context.rs
+++ b/crates/clarirs_core/src/context.rs
@@ -129,11 +129,6 @@ impl Context<'_> {
         InternedString(arc)
     }
 
-    pub fn drop_cache(&self, hash: u64) {
-        self.ast_cache.drop(hash);
-        self.simplification_cache.drop(hash);
-        self.excavate_ite_cache.drop(hash);
-    }
 }
 
 impl<'c> AstFactory<'c> for Context<'c> {


### PR DESCRIPTION
## Summary
- `AstNode::Drop` called `ctx.drop_cache(self.hash)`, which acquired **three** `RwLock` write locks (`ast_cache`, `simplification_cache`, `excavate_ite_cache`) on every `Arc<AstNode>` destruction. Hot loops that build and discard short-lived expressions paid that cost on every step.
- The cache already holds `Weak` references and `AstCache::get_or_insert` already falls through to recompute when an upgrade fails — so eviction isn't required for correctness, only for memory hygiene.
- Removed the `Drop` hook and the now-unused `Context::drop_cache` (no external callers). Stale `Weak` entries are pruned lazily as the same hash is re-inserted.

## Test plan
- [x] `cargo test --workspace` — all 336 tests still pass, including `test_ast_cache_weak_reference_cleanup` which exercises the lazy-cleanup path
- [x] `cargo test --workspace --features panic-on-hash-collision` — 130 tests pass
- [x] New `test_ephemeral_asts_do_not_corrupt_cache` stress-builds-then-drops 1000 ASTs and confirms subsequent lookups return correct results, proving stale Weaks don't poison the cache

## Trade-off
Stale `Weak` entries can accumulate in pathological workloads that create many unique-hash ephemeral ASTs without recycling. If that ever surfaces, periodic pruning is a straightforward follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)