### PR TITLE
simplify: don't constant-fold away concrete blocking annotations

### DIFF
--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -294,7 +294,7 @@ fn simplify<'c>(
             .annotations()
             .iter()
             .any(|a| !a.eliminatable() && !a.relocatable())
-            || state.expr.has_concrete_blocking_annotation();
+            || state.expr.has_concrete_blocker();
         let should_simplify = !respect_annotations || !has_blocking_annotations;
         if should_simplify {
             let inner_result = simplify_inner(&mut state, error_on_dbz);

--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -283,11 +283,18 @@ fn simplify<'c>(
             state.last_missed_child = None;
         }
 
+        // Don't simplify a node that itself carries a blocking annotation, nor
+        // one whose subtree contains a *concrete* blocking-annotated node:
+        // folding the latter (e.g. `(sp_annotated + 0x10) - 0x8`) would discard
+        // the annotated node that consumers like variable-recovery stack
+        // tracking rely on. Symbolic blocking annotations (strided intervals)
+        // are excluded so VSA can still reduce them.
         let has_blocking_annotations = state
             .expr
             .annotations()
             .iter()
-            .any(|a| !a.eliminatable() && !a.relocatable());
+            .any(|a| !a.eliminatable() && !a.relocatable())
+            || state.expr.has_concrete_blocking_annotation();
         let should_simplify = !respect_annotations || !has_blocking_annotations;
         if should_simplify {
             let inner_result = simplify_inner(&mut state, error_on_dbz);

--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -283,19 +283,13 @@ fn simplify<'c>(
             state.last_missed_child = None;
         }
 
-        // Don't simplify a node that itself carries a blocking annotation, nor
-        // one whose subtree contains a *concrete* blocking-annotated node:
-        // folding the latter (e.g. `(sp_annotated + 0x10) - 0x8`) would discard
-        // the annotated node that consumers like variable-recovery stack
-        // tracking rely on. Symbolic blocking annotations (strided intervals)
-        // are excluded so VSA can still reduce them.
-        let has_blocking_annotations = state
+        let blocked = state
             .expr
             .annotations()
             .iter()
             .any(|a| !a.eliminatable() && !a.relocatable())
-            || state.expr.has_concrete_blocker();
-        let should_simplify = !respect_annotations || !has_blocking_annotations;
+            || !state.expr.simplifiable();
+        let should_simplify = !respect_annotations || !blocked;
         if should_simplify {
             let inner_result = simplify_inner(&mut state, error_on_dbz);
             match inner_result {

--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -31,6 +31,15 @@ pub struct AstNode<'c, O: Op<'c>> {
     pub(crate) size: u32,
     #[serde(skip)]
     symbolic: bool,
+    // True if this node, or any node in its subtree, is concrete and carries an
+    // annotation that is neither eliminatable nor relocatable (e.g. a stack- or
+    // region-location annotation on the concrete stack pointer). Such a subtree
+    // must not be constant-folded, or the annotation — and the structure needed
+    // to recover the offset — would be lost. Symbolic blocking annotations (e.g.
+    // strided-interval annotations on a BVS) are intentionally excluded: VSA
+    // needs to reduce those, and folding never eliminates a symbolic node.
+    #[serde(skip)]
+    has_concrete_blocking_annotation: bool,
 }
 
 impl<'c, O> Drop for AstNode<'c, O>
@@ -96,6 +105,14 @@ impl<'c, O: Op<'c> + Serialize + SupportsAnnotate<'c>> AstNode<'c, O> {
             || op.is_inherently_symbolic()
             || op.child_iter().any(|c| c.symbolic());
 
+        let has_concrete_blocking_annotation = (!symbolic
+            && annotations
+                .iter()
+                .any(|a| !a.eliminatable() && !a.relocatable()))
+            || op
+                .child_iter()
+                .any(|c| c.has_concrete_blocking_annotation());
+
         Self {
             op,
             ctx,
@@ -105,7 +122,12 @@ impl<'c, O: Op<'c> + Serialize + SupportsAnnotate<'c>> AstNode<'c, O> {
             size,
             annotations,
             symbolic,
+            has_concrete_blocking_annotation,
         }
+    }
+
+    pub fn has_concrete_blocking_annotation(&self) -> bool {
+        self.has_concrete_blocking_annotation
     }
 
     pub fn op(&self) -> &O {
@@ -265,6 +287,15 @@ impl DynAst<'_> {
             DynAst::BitVec(ast) => ast.symbolic(),
             DynAst::Float(ast) => ast.symbolic(),
             DynAst::String(ast) => ast.symbolic(),
+        }
+    }
+
+    pub fn has_concrete_blocking_annotation(&self) -> bool {
+        match self {
+            DynAst::Boolean(ast) => ast.has_concrete_blocking_annotation(),
+            DynAst::BitVec(ast) => ast.has_concrete_blocking_annotation(),
+            DynAst::Float(ast) => ast.has_concrete_blocking_annotation(),
+            DynAst::String(ast) => ast.has_concrete_blocking_annotation(),
         }
     }
 }

--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -31,15 +31,12 @@ pub struct AstNode<'c, O: Op<'c>> {
     pub(crate) size: u32,
     #[serde(skip)]
     symbolic: bool,
-    // True if this node, or any node in its subtree, is concrete and carries an
-    // annotation that is neither eliminatable nor relocatable (e.g. a stack- or
-    // region-location annotation on the concrete stack pointer). Such a subtree
-    // must not be constant-folded, or the annotation — and the structure needed
-    // to recover the offset — would be lost. Symbolic blocking annotations (e.g.
-    // strided-interval annotations on a BVS) are intentionally excluded: VSA
-    // needs to reduce those, and folding never eliminates a symbolic node.
+    // Set if this node or any descendant is concrete and carries a
+    // non-eliminatable, non-relocatable annotation that constant-folding would
+    // discard. Symbolic blocking annotations (e.g. strided intervals) are
+    // excluded so VSA can still reduce them.
     #[serde(skip)]
-    has_concrete_blocking_annotation: bool,
+    has_concrete_blocker: bool,
 }
 
 impl<'c, O> Drop for AstNode<'c, O>
@@ -105,13 +102,11 @@ impl<'c, O: Op<'c> + Serialize + SupportsAnnotate<'c>> AstNode<'c, O> {
             || op.is_inherently_symbolic()
             || op.child_iter().any(|c| c.symbolic());
 
-        let has_concrete_blocking_annotation = (!symbolic
+        let has_concrete_blocker = (!symbolic
             && annotations
                 .iter()
                 .any(|a| !a.eliminatable() && !a.relocatable()))
-            || op
-                .child_iter()
-                .any(|c| c.has_concrete_blocking_annotation());
+            || op.child_iter().any(|c| c.has_concrete_blocker());
 
         Self {
             op,
@@ -122,12 +117,12 @@ impl<'c, O: Op<'c> + Serialize + SupportsAnnotate<'c>> AstNode<'c, O> {
             size,
             annotations,
             symbolic,
-            has_concrete_blocking_annotation,
+            has_concrete_blocker,
         }
     }
 
-    pub fn has_concrete_blocking_annotation(&self) -> bool {
-        self.has_concrete_blocking_annotation
+    pub fn has_concrete_blocker(&self) -> bool {
+        self.has_concrete_blocker
     }
 
     pub fn op(&self) -> &O {
@@ -290,12 +285,12 @@ impl DynAst<'_> {
         }
     }
 
-    pub fn has_concrete_blocking_annotation(&self) -> bool {
+    pub fn has_concrete_blocker(&self) -> bool {
         match self {
-            DynAst::Boolean(ast) => ast.has_concrete_blocking_annotation(),
-            DynAst::BitVec(ast) => ast.has_concrete_blocking_annotation(),
-            DynAst::Float(ast) => ast.has_concrete_blocking_annotation(),
-            DynAst::String(ast) => ast.has_concrete_blocking_annotation(),
+            DynAst::Boolean(ast) => ast.has_concrete_blocker(),
+            DynAst::BitVec(ast) => ast.has_concrete_blocker(),
+            DynAst::Float(ast) => ast.has_concrete_blocker(),
+            DynAst::String(ast) => ast.has_concrete_blocker(),
         }
     }
 }

--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -31,12 +31,8 @@ pub struct AstNode<'c, O: Op<'c>> {
     pub(crate) size: u32,
     #[serde(skip)]
     symbolic: bool,
-    // Set if this node or any descendant is concrete and carries a
-    // non-eliminatable, non-relocatable annotation that constant-folding would
-    // discard. Symbolic blocking annotations (e.g. strided intervals) are
-    // excluded so VSA can still reduce them.
     #[serde(skip)]
-    has_concrete_blocker: bool,
+    simplifiable: bool,
 }
 
 impl<'c, O> Drop for AstNode<'c, O>
@@ -102,11 +98,11 @@ impl<'c, O: Op<'c> + Serialize + SupportsAnnotate<'c>> AstNode<'c, O> {
             || op.is_inherently_symbolic()
             || op.child_iter().any(|c| c.symbolic());
 
-        let has_concrete_blocker = (!symbolic
-            && annotations
+        let simplifiable = (symbolic
+            || !annotations
                 .iter()
                 .any(|a| !a.eliminatable() && !a.relocatable()))
-            || op.child_iter().any(|c| c.has_concrete_blocker());
+            && op.child_iter().all(|c| c.simplifiable());
 
         Self {
             op,
@@ -117,12 +113,12 @@ impl<'c, O: Op<'c> + Serialize + SupportsAnnotate<'c>> AstNode<'c, O> {
             size,
             annotations,
             symbolic,
-            has_concrete_blocker,
+            simplifiable,
         }
     }
 
-    pub fn has_concrete_blocker(&self) -> bool {
-        self.has_concrete_blocker
+    pub fn simplifiable(&self) -> bool {
+        self.simplifiable
     }
 
     pub fn op(&self) -> &O {
@@ -285,12 +281,12 @@ impl DynAst<'_> {
         }
     }
 
-    pub fn has_concrete_blocker(&self) -> bool {
+    pub fn simplifiable(&self) -> bool {
         match self {
-            DynAst::Boolean(ast) => ast.has_concrete_blocker(),
-            DynAst::BitVec(ast) => ast.has_concrete_blocker(),
-            DynAst::Float(ast) => ast.has_concrete_blocker(),
-            DynAst::String(ast) => ast.has_concrete_blocker(),
+            DynAst::Boolean(ast) => ast.simplifiable(),
+            DynAst::BitVec(ast) => ast.simplifiable(),
+            DynAst::Float(ast) => ast.simplifiable(),
+            DynAst::String(ast) => ast.simplifiable(),
         }
     }
 }


### PR DESCRIPTION
## Problem
The simplify gate (post-#497) only inspects the **node's own** annotations. When a non-eliminatable/non-relocatable annotation (e.g. a `StackLocationAnnotation`) sits on a **concrete descendant**, constant-folding of an expression like `(sp + 0x10) - 0x8` eliminates that node and discards the annotation that consumers like angr's full `VariableRecovery` rely on.

## Fix
Cache a `has_concrete_blocking_annotation` flag per `AstNode` (true when a *concrete* node in the subtree carries a non-eliminatable/non-relocatable annotation) and OR it into the simplify gate.

**Symbolic blocking annotations (strided intervals on a BVS) are intentionally excluded** so VSA still reduces them — folding never eliminates a symbolic node, so there's no preservation problem there, and over-blocking would regress VSA.

## Relation
- Refines the gate introduced in #497 (which this builds directly on).
- Implements the "preserve descendant annotations" goal described in #505 (closed, never implemented).
- Follow-up: Rust tests in the #497 style (a concrete annotated node survives folding; a symbolic SI still reduces) recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)