### PR TITLE
py: make replace_annotations set the annotation set verbatim

### DIFF
--- a/crates/clarirs_core/src/ast/factory.rs
+++ b/crates/clarirs_core/src/ast/factory.rs
@@ -31,6 +31,41 @@ pub trait AstFactory<'c>: Sized {
         annotations: BTreeSet<Annotation>,
     ) -> Result<StringAst<'c>, ClarirsError>;
 
+    // Exact-annotation constructors: build a node carrying *exactly* the given
+    // annotations, without propagating relocatable annotations up from the
+    // children. This matches claripy's `replace_annotations`, which sets a
+    // node's annotation set verbatim. The default implementation falls back to
+    // the propagating constructor; `Context` overrides these to skip
+    // propagation.
+    fn make_bool_annotated_exact(
+        &'c self,
+        op: BooleanOp<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> Result<BoolAst<'c>, ClarirsError> {
+        self.make_bool_annotated(op, annotations)
+    }
+    fn make_bitvec_annotated_exact(
+        &'c self,
+        op: BitVecOp<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> Result<BitVecAst<'c>, ClarirsError> {
+        self.make_bitvec_annotated(op, annotations)
+    }
+    fn make_float_annotated_exact(
+        &'c self,
+        op: FloatOp<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> Result<FloatAst<'c>, ClarirsError> {
+        self.make_float_annotated(op, annotations)
+    }
+    fn make_string_annotated_exact(
+        &'c self,
+        op: StringOp<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> Result<StringAst<'c>, ClarirsError> {
+        self.make_string_annotated(op, annotations)
+    }
+
     // Provided methods
 
     fn make_bool(&'c self, op: BooleanOp<'c>) -> Result<BoolAst<'c>, ClarirsError> {

--- a/crates/clarirs_core/src/context.rs
+++ b/crates/clarirs_core/src/context.rs
@@ -151,7 +151,14 @@ impl<'c> AstFactory<'c> for Context<'c> {
                 .flat_map(|c| c.annotations())
                 .filter(|a| a.relocatable()),
         );
+        self.make_bool_annotated_exact(op, annotations)
+    }
 
+    fn make_bool_annotated_exact(
+        &'c self,
+        op: BooleanOp<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> Result<BoolAst<'c>, ClarirsError> {
         let mut hasher = AHasher::default();
         0u32.hash(&mut hasher); // Domain separation for bools
         op.hash(&mut hasher);
@@ -186,7 +193,14 @@ impl<'c> AstFactory<'c> for Context<'c> {
                 .flat_map(|c| c.annotations())
                 .filter(|a| a.relocatable()),
         );
+        self.make_bitvec_annotated_exact(op, annotations)
+    }
 
+    fn make_bitvec_annotated_exact(
+        &'c self,
+        op: BitVecOp<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> Result<BitVecAst<'c>, ClarirsError> {
         let mut hasher = AHasher::default();
         1u32.hash(&mut hasher); // Domain separation for bitvecs
         op.hash(&mut hasher);
@@ -224,7 +238,14 @@ impl<'c> AstFactory<'c> for Context<'c> {
                 .flat_map(|c| c.annotations())
                 .filter(|a| a.relocatable()),
         );
+        self.make_float_annotated_exact(op, annotations)
+    }
 
+    fn make_float_annotated_exact(
+        &'c self,
+        op: FloatOp<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> std::result::Result<FloatAst<'c>, ClarirsError> {
         let mut hasher = AHasher::default();
         2u32.hash(&mut hasher); // Domain separation for floats
         op.hash(&mut hasher);
@@ -259,7 +280,14 @@ impl<'c> AstFactory<'c> for Context<'c> {
                 .flat_map(|c| c.annotations())
                 .filter(|a| a.relocatable()),
         );
+        self.make_string_annotated_exact(op, annotations)
+    }
 
+    fn make_string_annotated_exact(
+        &'c self,
+        op: StringOp<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> Result<StringAst<'c>, ClarirsError> {
         let mut hasher = AHasher::default();
         3u32.hash(&mut hasher); // Domain separation for strings
         op.hash(&mut hasher);

--- a/crates/clarirs_py/src/ast/bool.rs
+++ b/crates/clarirs_py/src/ast/bool.rs
@@ -37,12 +37,28 @@ impl Bool {
         Self::new_with_name(py, inner, None)
     }
 
+    /// Wrap an AST without re-simplifying it. See `BV::new_unsimplified`.
+    pub fn new_unsimplified<'py>(
+        py: Python<'py>,
+        inner: &BoolAst<'static>,
+    ) -> Result<Bound<'py, Bool>, ClaripyError> {
+        Self::new_inner(py, inner, None)
+    }
+
     pub fn new_with_name<'py>(
         py: Python<'py>,
         inner: &BoolAst<'static>,
         name: Option<String>,
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         let inner = &inner.simplify()?;
+        Self::new_inner(py, inner, name)
+    }
+
+    fn new_inner<'py>(
+        py: Python<'py>,
+        inner: &BoolAst<'static>,
+        name: Option<String>,
+    ) -> Result<Bound<'py, Bool>, ClaripyError> {
         if let Some(cache_hit) = PY_BOOL_CACHE.get(&inner.hash()).and_then(|cache_hit| {
             cache_hit
                 .bind(py)
@@ -466,11 +482,11 @@ impl Bool {
         py: Python<'py>,
         annotations: Vec<PyAnnotation>,
     ) -> Result<Bound<'py, Self>, ClaripyError> {
-        let inner = self.inner.context().make_bool_annotated(
+        let inner = self.inner.context().make_bool_annotated_exact(
             self.inner.op().clone(),
             annotations.into_iter().map(|a| a.0).collect(),
         )?;
-        Self::new(py, &inner)
+        Self::new_unsimplified(py, &inner)
     }
 
     pub fn remove_annotation<'py>(

--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -36,12 +36,31 @@ impl BV {
         Self::new_with_name(py, inner, None)
     }
 
+    /// Wrap an AST without re-simplifying it. Used by annotation-only operations
+    /// (e.g. `replace_annotations`) where the underlying op is already simplified
+    /// and re-simplifying would re-propagate relocatable annotations from the
+    /// children, defeating an explicit annotation replacement.
+    pub fn new_unsimplified<'py>(
+        py: Python<'py>,
+        inner: &BitVecAst<'static>,
+    ) -> Result<Bound<'py, BV>, ClaripyError> {
+        Self::new_inner(py, inner, None)
+    }
+
     pub fn new_with_name<'py>(
         py: Python<'py>,
         inner: &BitVecAst<'static>,
         name: Option<String>,
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         let inner = &inner.simplify_ext(true, true)?;
+        Self::new_inner(py, inner, name)
+    }
+
+    fn new_inner<'py>(
+        py: Python<'py>,
+        inner: &BitVecAst<'static>,
+        name: Option<String>,
+    ) -> Result<Bound<'py, BV>, ClaripyError> {
         if let Some(cache_hit) = PY_BV_CACHE.get(&inner.hash()).and_then(|cache_hit| {
             cache_hit
                 .bind(py)
@@ -545,11 +564,11 @@ impl BV {
         py: Python<'py>,
         annotations: Vec<PyAnnotation>,
     ) -> Result<Bound<'py, Self>, ClaripyError> {
-        let inner = self.inner.context().make_bitvec_annotated(
+        let inner = self.inner.context().make_bitvec_annotated_exact(
             self.inner.op().clone(),
             annotations.into_iter().map(|a| a.0).collect(),
         )?;
-        Self::new(py, &inner)
+        Self::new_unsimplified(py, &inner)
     }
 
     pub fn remove_annotation<'py>(

--- a/crates/clarirs_py/src/ast/fp.rs
+++ b/crates/clarirs_py/src/ast/fp.rs
@@ -172,12 +172,28 @@ impl FP {
         Self::new_with_name(py, inner, None)
     }
 
+    /// Wrap an AST without re-simplifying it. See `BV::new_unsimplified`.
+    pub fn new_unsimplified<'py>(
+        py: Python<'py>,
+        inner: &FloatAst<'static>,
+    ) -> Result<Bound<'py, FP>, ClaripyError> {
+        Self::new_inner(py, inner, None)
+    }
+
     pub fn new_with_name<'py>(
         py: Python<'py>,
         inner: &FloatAst<'static>,
         name: Option<String>,
     ) -> Result<Bound<'py, FP>, ClaripyError> {
         let inner = &inner.simplify()?;
+        Self::new_inner(py, inner, name)
+    }
+
+    fn new_inner<'py>(
+        py: Python<'py>,
+        inner: &FloatAst<'static>,
+        name: Option<String>,
+    ) -> Result<Bound<'py, FP>, ClaripyError> {
         if let Some(cache_hit) = PY_FP_CACHE.get(&inner.hash()).and_then(|cache_hit| {
             cache_hit
                 .bind(py)
@@ -567,11 +583,11 @@ impl FP {
         py: Python<'py>,
         annotations: Vec<PyAnnotation>,
     ) -> Result<Bound<'py, Self>, ClaripyError> {
-        let inner = self.inner.context().make_float_annotated(
+        let inner = self.inner.context().make_float_annotated_exact(
             self.inner.op().clone(),
             annotations.into_iter().map(|a| a.0).collect(),
         )?;
-        Self::new(py, &inner)
+        Self::new_unsimplified(py, &inner)
     }
 
     pub fn remove_annotation<'py>(

--- a/crates/clarirs_py/src/ast/string.rs
+++ b/crates/clarirs_py/src/ast/string.rs
@@ -34,12 +34,28 @@ impl PyAstString {
         Self::new_with_name(py, inner, None)
     }
 
+    /// Wrap an AST without re-simplifying it. See `BV::new_unsimplified`.
+    pub fn new_unsimplified<'py>(
+        py: Python<'py>,
+        inner: &StringAst<'static>,
+    ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
+        Self::new_inner(py, inner, None)
+    }
+
     pub fn new_with_name<'py>(
         py: Python<'py>,
         inner: &StringAst<'static>,
         name: Option<String>,
     ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
         let inner = &inner.simplify()?;
+        Self::new_inner(py, inner, name)
+    }
+
+    fn new_inner<'py>(
+        py: Python<'py>,
+        inner: &StringAst<'static>,
+        name: Option<String>,
+    ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
         if let Some(cache_hit) = PY_STRING_CACHE.get(&inner.hash()).and_then(|cache_hit| {
             cache_hit
                 .bind(py)
@@ -349,11 +365,11 @@ impl PyAstString {
         py: Python<'py>,
         annotations: Vec<PyAnnotation>,
     ) -> Result<Bound<'py, Self>, ClaripyError> {
-        let inner = self.inner.context().make_string_annotated(
+        let inner = self.inner.context().make_string_annotated_exact(
             self.inner.op().clone(),
             annotations.into_iter().map(|a| a.0).collect(),
         )?;
-        Self::new(py, &inner)
+        Self::new_unsimplified(py, &inner)
     }
 
     pub fn remove_annotation<'py>(


### PR DESCRIPTION
## Problem
claripy's `replace_annotations` sets a node's annotation tuple **verbatim**. clarirs diverged in two ways, so an explicit replace could never *remove* an annotation that had propagated in:
1. `make_*_annotated` re-propagates relocatable annotations up from children on every construction.
2. The Python wrappers eagerly simplify on construction, rebuilding via the propagating constructor.

Net effect: `replace_annotations((rdx,))` on an expression derived from another annotated value (e.g. `rbp - 0x28`) keeps the inherited `rbp` annotation, breaking VariableRecoveryFast register-phi recovery in angr.

## Fix
- Add `make_*_annotated_exact` constructors that build a node with **exactly** the given annotations (no child re-propagation).
- Add `new_unsimplified` wrappers (BV/Bool/FP/String) that wrap an AST without re-simplifying.
- Route `replace_annotations` through both.

## Relation
- **Supersedes #492** (closed): scopes the no-simplify/verbatim behavior to `replace_annotations` only (not `annotate`/`VS`), covers all four AST types, and additionally fixes the child-propagation half #492 did not.
- Complements append semantics from #394 (`annotate` still appends).
- Enabled by #473 (unknown annotations now report real relocatable/eliminatable flags).
- Follow-up: a Python test asserting `x.replace_annotations((a,)).annotations == (a,)` recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)