### PR TITLE
Allow negative bounds in StridedIntervalAnnotation

### DIFF
--- a/crates/clarirs-vsa/src/reduce/bv.rs
+++ b/crates/clarirs-vsa/src/reduce/bv.rs
@@ -1,6 +1,20 @@
 use super::ReduceResult;
 use crate::strided_interval::{ComparisonResult, StridedInterval};
 use clarirs_core::prelude::*;
+use num_bigint::{BigInt, BigUint};
+
+/// Wrap a possibly-negative signed bound into its unsigned representation
+/// modulo 2^bits (two's complement), matching claripy's strided intervals.
+fn wrap_signed_to_bits(value: &BigInt, bits: u32) -> BigUint {
+    if let Some(unsigned) = value.to_biguint() {
+        unsigned
+    } else {
+        let modulus = BigInt::from(1u8) << bits;
+        (((value % &modulus) + &modulus) % &modulus)
+            .to_biguint()
+            .unwrap_or_default()
+    }
+}
 
 fn child(children: &[ReduceResult], index: usize) -> Result<ComparisonResult, ClarirsError> {
     if let Some(ReduceResult::Bool(result)) = children.get(index) {
@@ -46,8 +60,8 @@ pub(crate) fn reduce_bv(
                         Some(StridedInterval::new(
                             *bits,
                             stride.clone(),
-                            lower_bound.clone(),
-                            upper_bound.clone(),
+                            wrap_signed_to_bits(lower_bound, *bits),
+                            wrap_signed_to_bits(upper_bound, *bits),
                         ))
                     } else if let AnnotationType::EmptyStridedInterval = ann.type_() {
                         Some(StridedInterval::empty(*bits))

--- a/crates/clarirs_core/src/ast/annotation.rs
+++ b/crates/clarirs_core/src/ast/annotation.rs
@@ -1,4 +1,4 @@
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
 use serde::Serialize;
 
 /// This struct is a sort of hack to allow us to access data in python
@@ -12,8 +12,11 @@ pub enum AnnotationType {
     SimplificationAvoidance,
     StridedInterval {
         stride: BigUint,
-        lower_bound: BigUint,
-        upper_bound: BigUint,
+        // Bounds are signed: claripy allows negative bounds (e.g. from
+        // constraints like `x > -5`); they wrap to the value's bit width when
+        // the strided interval is materialized.
+        lower_bound: BigInt,
+        upper_bound: BigInt,
     },
     EmptyStridedInterval,
     Region {

--- a/crates/clarirs_core/src/ast/factory.rs
+++ b/crates/clarirs_core/src/ast/factory.rs
@@ -809,8 +809,8 @@ pub trait AstFactory<'c>: Sized {
             BTreeSet::from([Annotation::new(
                 AnnotationType::StridedInterval {
                     stride,
-                    lower_bound,
-                    upper_bound,
+                    lower_bound: lower_bound.into(),
+                    upper_bound: upper_bound.into(),
                 },
                 false,
                 false,

--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -1,6 +1,6 @@
 use std::{ffi::CString, mem::discriminant, str::FromStr};
 
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
 use pyo3::types::PyType;
 
 use crate::prelude::*;
@@ -58,8 +58,8 @@ impl<'py> FromPyObject<'_, 'py> for PyAnnotationType {
             ("claripy.annotation", "StridedIntervalAnnotation") => {
                 AnnotationType::StridedInterval {
                     stride: BigUint::from(0u32),
-                    lower_bound: BigUint::from(0u32),
-                    upper_bound: BigUint::from(0u32),
+                    lower_bound: BigInt::from(0),
+                    upper_bound: BigInt::from(0),
                 }
             }
             ("claripy.annotation", "RegionAnnotation") => AnnotationType::Region {
@@ -115,8 +115,8 @@ impl<'py> FromPyObject<'_, 'py> for PyAnnotation {
                 }
                 ("claripy.annotation", "StridedIntervalAnnotation") => {
                     let stride = annotation.getattr("stride")?.extract::<BigUint>()?;
-                    let lower_bound = annotation.getattr("lower_bound")?.extract::<BigUint>()?;
-                    let upper_bound = annotation.getattr("upper_bound")?.extract::<BigUint>()?;
+                    let lower_bound = annotation.getattr("lower_bound")?.extract::<BigInt>()?;
+                    let upper_bound = annotation.getattr("upper_bound")?.extract::<BigInt>()?;
 
                     PyAnnotation::new(
                         AnnotationType::StridedInterval {


### PR DESCRIPTION
## Problem
claripy permits negative strided-interval bounds (e.g. from constraints like `x > -5`). The annotation-extraction path in `clarirs_py/src/annotation.rs` extracted `lower_bound`/`upper_bound` as `BigUint` and raised *"Cannot convert negative int"*, breaking angr's balancer (`constraint_to_si`).

## Fix
Store the bounds as signed `BigInt` through the annotation pipeline (`ast/annotation.rs`, `ast/factory.rs`, `clarirs_py/src/annotation.rs`) and wrap them two's-complement to the value's bit width when the strided interval is materialized in VSA reduction (`clarirs-vsa/src/reduce/bv.rs`). `BigUint -> BigInt` is lossless; positive-bound behavior is unchanged (`to_biguint()` returns the value directly).

## Relation
Complements #246, which wrapped negatives only in the `SI()` constructor. This fixes the **separate annotation-extraction entry point** #246 left unhandled (the one angr's balancer exercises). With this change the annotation can carry a negative `BigInt` end-to-end, and the wrap in `reduce/bv.rs` is the single source of truth at materialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)