### PR TITLE
simplify: re-simplify Not nodes produced by bool rewrite rules

### DIFF
--- a/crates/clarirs_core/src/algorithms/simplify/bool.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/bool.rs
@@ -225,14 +225,8 @@ pub(crate) fn simplify_bool<'c>(
 
             match (early_lhs.op(), early_rhs.op()) {
                 (BooleanOp::BoolV(lhs), BooleanOp::BoolV(rhs)) => Ok(ctx.boolv(*lhs ^ *rhs)?),
-                (BooleanOp::BoolV(true), _) => {
-                    let inner = state.get_bool_simplified(1)?;
-                    state.rerun(ctx.not(inner)?)
-                }
-                (_, BooleanOp::BoolV(true)) => {
-                    let inner = state.get_bool_simplified(0)?;
-                    state.rerun(ctx.not(inner)?)
-                }
+                (BooleanOp::BoolV(true), _) => state.rerun(ctx.not(&early_rhs)?),
+                (_, BooleanOp::BoolV(true)) => state.rerun(ctx.not(&early_lhs)?),
                 (BooleanOp::BoolV(false), _) => Ok(state.get_bool_simplified(1)?),
                 (_, BooleanOp::BoolV(false)) => Ok(state.get_bool_simplified(0)?),
                 (BooleanOp::Not(lhs), rhs) if lhs.op() == rhs => Ok(ctx.true_()?),
@@ -250,14 +244,8 @@ pub(crate) fn simplify_bool<'c>(
                 (BooleanOp::BoolV(arc), BooleanOp::BoolV(arc1)) => Ok(ctx.boolv(arc == arc1)?),
                 (BooleanOp::BoolV(true), _) => Ok(state.get_bool_simplified(1)?),
                 (_, BooleanOp::BoolV(true)) => Ok(state.get_bool_simplified(0)?),
-                (BooleanOp::BoolV(false), _) => {
-                    let inner = state.get_bool_simplified(1)?;
-                    state.rerun(ctx.not(inner)?)
-                }
-                (_, BooleanOp::BoolV(false)) => {
-                    let inner = state.get_bool_simplified(0)?;
-                    state.rerun(ctx.not(inner)?)
-                }
+                (BooleanOp::BoolV(false), _) => state.rerun(ctx.not(&early_rhs)?),
+                (_, BooleanOp::BoolV(false)) => state.rerun(ctx.not(&early_lhs)?),
                 // a == a -> true. Even when floats are involved, this is a boolean
                 // identity: both sides are the same expression and evaluate to the same
                 // value (NaN only affects fp== itself, not bool== of two equal booleans).
@@ -271,14 +259,8 @@ pub(crate) fn simplify_bool<'c>(
 
             match (early_lhs.op(), early_rhs.op()) {
                 (BooleanOp::BoolV(arc), BooleanOp::BoolV(arc1)) => Ok(ctx.boolv(arc != arc1)?),
-                (BooleanOp::BoolV(true), _) => {
-                    let inner = state.get_bool_simplified(1)?;
-                    state.rerun(ctx.not(inner)?)
-                }
-                (_, BooleanOp::BoolV(true)) => {
-                    let inner = state.get_bool_simplified(0)?;
-                    state.rerun(ctx.not(inner)?)
-                }
+                (BooleanOp::BoolV(true), _) => state.rerun(ctx.not(&early_rhs)?),
+                (_, BooleanOp::BoolV(true)) => state.rerun(ctx.not(&early_lhs)?),
                 (BooleanOp::BoolV(false), _) => Ok(state.get_bool_simplified(1)?),
                 (_, BooleanOp::BoolV(false)) => Ok(state.get_bool_simplified(0)?),
                 // a != a -> false. Even when floats are involved, this is a boolean

--- a/crates/clarirs_core/src/algorithms/simplify/bool.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/bool.rs
@@ -225,8 +225,14 @@ pub(crate) fn simplify_bool<'c>(
 
             match (early_lhs.op(), early_rhs.op()) {
                 (BooleanOp::BoolV(lhs), BooleanOp::BoolV(rhs)) => Ok(ctx.boolv(*lhs ^ *rhs)?),
-                (BooleanOp::BoolV(true), _) => Ok(ctx.not(state.get_bool_simplified(1)?)?),
-                (_, BooleanOp::BoolV(true)) => Ok(ctx.not(state.get_bool_simplified(0)?)?),
+                (BooleanOp::BoolV(true), _) => {
+                    let inner = state.get_bool_simplified(1)?;
+                    state.rerun(ctx.not(inner)?)
+                }
+                (_, BooleanOp::BoolV(true)) => {
+                    let inner = state.get_bool_simplified(0)?;
+                    state.rerun(ctx.not(inner)?)
+                }
                 (BooleanOp::BoolV(false), _) => Ok(state.get_bool_simplified(1)?),
                 (_, BooleanOp::BoolV(false)) => Ok(state.get_bool_simplified(0)?),
                 (BooleanOp::Not(lhs), rhs) if lhs.op() == rhs => Ok(ctx.true_()?),
@@ -244,8 +250,14 @@ pub(crate) fn simplify_bool<'c>(
                 (BooleanOp::BoolV(arc), BooleanOp::BoolV(arc1)) => Ok(ctx.boolv(arc == arc1)?),
                 (BooleanOp::BoolV(true), _) => Ok(state.get_bool_simplified(1)?),
                 (_, BooleanOp::BoolV(true)) => Ok(state.get_bool_simplified(0)?),
-                (BooleanOp::BoolV(false), _) => Ok(ctx.not(state.get_bool_simplified(1)?)?),
-                (_, BooleanOp::BoolV(false)) => Ok(ctx.not(state.get_bool_simplified(0)?)?),
+                (BooleanOp::BoolV(false), _) => {
+                    let inner = state.get_bool_simplified(1)?;
+                    state.rerun(ctx.not(inner)?)
+                }
+                (_, BooleanOp::BoolV(false)) => {
+                    let inner = state.get_bool_simplified(0)?;
+                    state.rerun(ctx.not(inner)?)
+                }
                 // a == a -> true. Even when floats are involved, this is a boolean
                 // identity: both sides are the same expression and evaluate to the same
                 // value (NaN only affects fp== itself, not bool== of two equal booleans).
@@ -259,8 +271,14 @@ pub(crate) fn simplify_bool<'c>(
 
             match (early_lhs.op(), early_rhs.op()) {
                 (BooleanOp::BoolV(arc), BooleanOp::BoolV(arc1)) => Ok(ctx.boolv(arc != arc1)?),
-                (BooleanOp::BoolV(true), _) => Ok(ctx.not(state.get_bool_simplified(1)?)?),
-                (_, BooleanOp::BoolV(true)) => Ok(ctx.not(state.get_bool_simplified(0)?)?),
+                (BooleanOp::BoolV(true), _) => {
+                    let inner = state.get_bool_simplified(1)?;
+                    state.rerun(ctx.not(inner)?)
+                }
+                (_, BooleanOp::BoolV(true)) => {
+                    let inner = state.get_bool_simplified(0)?;
+                    state.rerun(ctx.not(inner)?)
+                }
                 (BooleanOp::BoolV(false), _) => Ok(state.get_bool_simplified(1)?),
                 (_, BooleanOp::BoolV(false)) => Ok(state.get_bool_simplified(0)?),
                 // a != a -> false. Even when floats are involved, this is a boolean
@@ -1551,7 +1569,7 @@ pub(crate) fn simplify_bool<'c>(
 
                 // Known then/else cases
                 (_, BooleanOp::BoolV(true), BooleanOp::BoolV(false)) => Ok(cond.clone()),
-                (_, BooleanOp::BoolV(false), BooleanOp::BoolV(true)) => Ok(ctx.not(cond)?),
+                (_, BooleanOp::BoolV(false), BooleanOp::BoolV(true)) => state.rerun(ctx.not(cond)?),
 
                 // When condition equals one branch with concrete other branch
                 (cond_op, BooleanOp::BoolV(true), else_op) if else_op == cond_op => {


### PR DESCRIPTION
## Problem
Several bool simplification arms rewrite to a negation but return the freshly built `Not` without re-entering the simplifier:
- `ITE(c, false, true) -> Not(c)`
- `Xor(true, x)` / `BoolEq(false, x)` / `BoolNeq(true, x)` `-> Not(x)`

So the `Not(comparison) -> inverse comparison` rules (`Not(Eq)→Neq`, `Not(ULE)→UGT`, …) never apply to them, and the result diverges from claripy, which canonicalizes these eagerly.

Observable: `excavate_ite(ULE(If(c, 20, 10), 15))` yields `lhs != rhs` in claripy but a raw `Not(Eq(..))` in clarirs. angr's balancer rejects the 1-arg `Not` as an unhandleable "unop bool", breaking `constraint_to_si` for the false side of `If` guards (angr's `test_if_si_greater_than{,_or_equal}_15`).

## Fix
Use `state.rerun()` in these arms so the produced `Not` canonicalizes like a directly-constructed one. Termination: the `Not` arm rewrites comparisons/`Not`/`BoolV` and otherwise returns the node as-is — no rerun cycles.

All 127 clarirs_core tests pass; both angr balancer tests go red→green; broader angr regression slice (solver, memory, variable recovery, structurer) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)