### PR TITLE
perf: don't re-traverse cached subtrees in walk_post_order

### DIFF
--- a/crates/clarirs_core/src/algorithms/post_order.rs
+++ b/crates/clarirs_core/src/algorithms/post_order.rs
@@ -59,10 +59,10 @@ pub fn walk_post_order<'c, T>(
             state.children_processed += 1;
 
             // If the child's result is already cached (from an earlier walk or
-            // from a shared subtree visited earlier in THIS walk), use it
-            // without re-traversing the subtree. Merged-state ASTs are DAGs
-            // with massive sharing; re-walking shared subtrees from every
-            // parent makes traversal time exponential in the sharing depth.
+            // from a shared subtree visited earlier in this walk), reuse it
+            // instead of re-traversing the subtree. ASTs are DAGs, so a shared
+            // subtree is reachable from multiple parents; reusing the cached
+            // result avoids re-running the traversal once per parent.
             if let Some(cached) = cache.get(&child.hash()) {
                 state.child_results.push(cached);
                 stack.push(state);

--- a/crates/clarirs_core/src/algorithms/post_order.rs
+++ b/crates/clarirs_core/src/algorithms/post_order.rs
@@ -58,6 +58,17 @@ pub fn walk_post_order<'c, T>(
             let child = state.node.get_child(state.children_processed).unwrap();
             state.children_processed += 1;
 
+            // If the child's result is already cached (from an earlier walk or
+            // from a shared subtree visited earlier in THIS walk), use it
+            // without re-traversing the subtree. Merged-state ASTs are DAGs
+            // with massive sharing; re-walking shared subtrees from every
+            // parent makes traversal time exponential in the sharing depth.
+            if let Some(cached) = cache.get(&child.hash()) {
+                state.child_results.push(cached);
+                stack.push(state);
+                continue;
+            }
+
             // Push parent back on stack
             stack.push(state);
 

--- a/crates/clarirs_core/src/cache.rs
+++ b/crates/clarirs_core/src/cache.rs
@@ -13,12 +13,19 @@ use crate::prelude::*;
 pub trait Cache<K, V> {
     fn get_or_insert<E>(&self, key: K, value_cv: impl FnMut() -> Result<V, E>) -> Result<V, E>;
 
+    /// Probe the cache without computing a value on miss.
+    fn get(&self, key: &K) -> Option<V>;
+
     fn drop(&self, key: K);
 }
 
 impl<K, V> Cache<K, V> for () {
     fn get_or_insert<E>(&self, _: K, mut value_cv: impl FnMut() -> Result<V, E>) -> Result<V, E> {
         value_cv()
+    }
+
+    fn get(&self, _key: &K) -> Option<V> {
+        None
     }
 
     fn drop(&self, _key: K) {
@@ -54,6 +61,10 @@ impl<K: Hash + Eq, V: Clone> Cache<K, V> for GenericCache<K, V> {
         let value = value_cv()?;
         locked.insert(key, value.clone());
         Ok(value)
+    }
+
+    fn get(&self, key: &K) -> Option<V> {
+        self.0.read().unwrap().get(key).cloned()
     }
 
     fn drop(&self, key: K) {
@@ -122,6 +133,10 @@ impl<'c> Cache<u64, AstRef<'c>> for AstCache<'c> {
 
             Ok(arc)
         }
+    }
+
+    fn get(&self, key: &u64) -> Option<AstRef<'c>> {
+        self.0.read().unwrap().get(key).and_then(Weak::upgrade)
     }
 
     fn drop(&self, key: u64) {


### PR DESCRIPTION
## Problem

`walk_post_order` caches each node's transformed result, but it descends into a node's children *before* consulting the cache. Because the context interns and deduplicates nodes, ASTs share subexpressions and are DAGs rather than trees. A subtree reachable from many parents was therefore re-walked once per parent — traversal time exponential in the sharing depth, even though every node's result was already cached after the first visit.

This shows up badly on heavily-shared ASTs such as merged symbolic-execution states: a single traversal (to_z3 conversion, VSA reduction, excavate-ite, or the smtlib dump — all go through `walk_post_order`) could hang for minutes.

## Fix

Add `Cache::get` (probe without computing) and consult it for each child before descending. When a child's result is already cached — from an earlier walk or a shared subtree visited earlier in the same walk — reuse it directly instead of re-traversing. A previously visited subtree becomes O(1) instead of O(size).

No behavior change; only redundant traversal is removed. Existing `clarirs_core` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
