### PR TITLE
perf: cache subtree reductions within a VSA reduce walk

### DIFF
--- a/crates/clarirs-vsa/src/reduce.rs
+++ b/crates/clarirs-vsa/src/reduce.rs
@@ -3,6 +3,7 @@ mod bv;
 
 use crate::strided_interval::{ComparisonResult, StridedInterval};
 use clarirs_core::algorithms::walk_post_order;
+use clarirs_core::cache::GenericCache;
 use clarirs_core::prelude::*;
 
 // Define an enum to represent the result of reduction
@@ -47,6 +48,7 @@ pub trait Reduce<'c>: Sized {
 
 impl<'c> Reduce<'c> for AstRef<'c> {
     fn reduce(&self) -> Result<ReduceResult, ClarirsError> {
+        let cache = GenericCache::default();
         walk_post_order(
             self.clone(),
             |node, children| match node.ast_type() {
@@ -56,7 +58,7 @@ impl<'c> Reduce<'c> for AstRef<'c> {
                     "Unsupported operation for reduction".to_string(),
                 )),
             },
-            &(),
+            &cache,
         )
     }
 }


### PR DESCRIPTION
## Problem

VSA `reduce()` passed `&()` (the no-op cache) to `walk_post_order`, so a shared subexpression in an expression DAG was reduced once per parent rather than once. On VSA-heavy analyses this dominated runtime and could turn a reduction into a multi-minute hang.

## Fix

Pass a per-walk `GenericCache<u64, ReduceResult>` instead of `&()`. Combined with `walk_post_order`'s cache short-circuit (#581), a shared subtree reduces in O(1) after its first visit.

Existing `clarirs-vsa` tests pass.

> Stacked on #581 (the `walk_post_order` cache short-circuit), which provides most of the benefit. This PR targets that branch; it will retarget to `main` automatically once #581 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
