### PR TITLE
perf: scoped Solver::satisfiable_with_extra on persistent solvers

### DIFF
--- a/crates/clarirs_core/src/solver/composite.rs
+++ b/crates/clarirs_core/src/solver/composite.rs
@@ -176,6 +176,74 @@ impl<'c, S: Solver<'c>> Solver<'c> for CompositeSolver<'c, S> {
         Ok(true)
     }
 
+    fn satisfiable_with_extra(&mut self, extra: &[AstRef<'c>]) -> Result<bool, ClarirsError> {
+        if extra.is_empty() {
+            return self.satisfiable();
+        }
+
+        let mut vars: BTreeSet<InternedString> = BTreeSet::new();
+        for constraint in extra {
+            if constraint.variables().is_empty() {
+                if constraint.is_false() {
+                    return Ok(false);
+                }
+                continue;
+            }
+            vars.extend(constraint.variables().iter().cloned());
+        }
+
+        let ids = self.child_ids_for_vars(&vars);
+        match ids.len() {
+            0 => {
+                // The extras are independent of all current constraints.
+                let mut solver = self.template.clone();
+                for constraint in extra {
+                    solver.add(constraint)?;
+                }
+                if !solver.satisfiable()? {
+                    return Ok(false);
+                }
+                self.satisfiable()
+            }
+            1 => {
+                // Hot path: the extras only touch one child; that child's
+                // scoped check is incremental, and the other children's plain
+                // checks hit their persistent solvers.
+                let id = ids[0];
+                for (child_id, child) in self.children.iter_mut() {
+                    if *child_id != id && !child.satisfiable()? {
+                        return Ok(false);
+                    }
+                }
+                self.children
+                    .get_mut(&id)
+                    .expect("child id from child_ids_for_vars")
+                    .satisfiable_with_extra(extra)
+            }
+            _ => {
+                // The extras span several children: merge them temporarily.
+                let mut merged = self.template.clone();
+                for &id in &ids {
+                    for constraint in self.children[&id].constraints()? {
+                        merged.add(&constraint)?;
+                    }
+                }
+                for constraint in extra {
+                    merged.add(constraint)?;
+                }
+                if !merged.satisfiable()? {
+                    return Ok(false);
+                }
+                for (child_id, child) in self.children.iter_mut() {
+                    if !ids.contains(child_id) && !child.satisfiable()? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+        }
+    }
+
     fn is_true(&mut self, expr: &AstRef<'c>) -> Result<bool, ClarirsError> {
         let vars = expr.variables().clone();
         self.with_solver_for(&vars, |s| s.is_true(expr))

--- a/crates/clarirs_core/src/solver/hybrid.rs
+++ b/crates/clarirs_core/src/solver/hybrid.rs
@@ -95,6 +95,13 @@ impl<'c, A: Solver<'c>, E: Solver<'c>> Solver<'c> for HybridSolver<'c, A, E> {
         self.exact.satisfiable()
     }
 
+    fn satisfiable_with_extra(&mut self, extra: &[AstRef<'c>]) -> Result<bool, ClarirsError> {
+        if let Ok(false) = self.approximate.satisfiable_with_extra(extra) {
+            return Ok(false);
+        }
+        self.exact.satisfiable_with_extra(extra)
+    }
+
     fn is_true(&mut self, expr: &AstRef<'c>) -> Result<bool, ClarirsError> {
         if !expr.symbolic() {
             return self.approximate.is_true(expr);

--- a/crates/clarirs_core/src/solver/mod.rs
+++ b/crates/clarirs_core/src/solver/mod.rs
@@ -34,6 +34,22 @@ pub trait Solver<'c>: Clone + HasContext<'c> {
     /// Check if the current set of constraints is satisfiable
     fn satisfiable(&mut self) -> Result<bool, ClarirsError>;
 
+    /// Check satisfiability with `extra` constraints temporarily added.
+    /// The default clones the solver and adds the constraints; backends
+    /// override this with cheaper scoped checks (e.g. Z3 assumptions on the
+    /// persistent incremental solver). This is the hot path of symbolic
+    /// execution: every branch feasibility check goes through it.
+    fn satisfiable_with_extra(&mut self, extra: &[AstRef<'c>]) -> Result<bool, ClarirsError> {
+        if extra.is_empty() {
+            return self.satisfiable();
+        }
+        let mut solver = self.clone();
+        for constraint in extra {
+            solver.add(constraint)?;
+        }
+        solver.satisfiable()
+    }
+
     /// Evaluate an expression in the current model. The result has the same
     /// sort as the input expression.
     ///

--- a/crates/clarirs_core/src/solver_mixins/concrete_early_resolution.rs
+++ b/crates/clarirs_core/src/solver_mixins/concrete_early_resolution.rs
@@ -57,6 +57,17 @@ impl<'c, S: Solver<'c>> Solver<'c> for ConcreteEarlyResolutionMixin<'c, S> {
         self.inner.satisfiable()
     }
 
+    fn satisfiable_with_extra(&mut self, extra: &[AstRef<'c>]) -> Result<bool, ClarirsError> {
+        // Concretely-false extras decide the result without the solver.
+        if extra
+            .iter()
+            .any(|c| c.concrete() && matches!(c.op(), AstOp::BoolV(false)))
+        {
+            return Ok(false);
+        }
+        self.inner.satisfiable_with_extra(extra)
+    }
+
     fn is_true(&mut self, expr: &AstRef<'c>) -> Result<bool, ClarirsError> {
         // If the expression is concrete, we can determine the result without the solver
         // Assumes the expression is already simplified

--- a/crates/clarirs_core/src/solver_mixins/replacement.rs
+++ b/crates/clarirs_core/src/solver_mixins/replacement.rs
@@ -141,6 +141,14 @@ impl<'c, S: Solver<'c>> Solver<'c> for ReplacementSolver<'c, S> {
         self.inner.satisfiable()
     }
 
+    fn satisfiable_with_extra(&mut self, extra: &[AstRef<'c>]) -> Result<bool, ClarirsError> {
+        let replaced = extra
+            .iter()
+            .map(|c| self.apply_replacements(c))
+            .collect::<Result<Vec<_>, _>>()?;
+        self.inner.satisfiable_with_extra(&replaced)
+    }
+
     fn is_true(&mut self, expr: &AstRef<'c>) -> Result<bool, ClarirsError> {
         let replaced = self.apply_replacements(expr)?;
         self.inner.is_true(&replaced)

--- a/crates/clarirs_core/src/solver_mixins/simplification.rs
+++ b/crates/clarirs_core/src/solver_mixins/simplification.rs
@@ -55,6 +55,14 @@ impl<'c, S: Solver<'c>> Solver<'c> for SimplificationMixin<'c, S> {
         self.inner.satisfiable()
     }
 
+    fn satisfiable_with_extra(&mut self, extra: &[AstRef<'c>]) -> Result<bool, ClarirsError> {
+        let simplified = extra
+            .iter()
+            .map(|c| c.simplify())
+            .collect::<Result<Vec<_>, _>>()?;
+        self.inner.satisfiable_with_extra(&simplified)
+    }
+
     fn is_true(&mut self, expr: &AstRef<'c>) -> Result<bool, ClarirsError> {
         self.inner.is_true(&expr.simplify()?)
     }

--- a/crates/clarirs_py/src/dynsolver.rs
+++ b/crates/clarirs_py/src/dynsolver.rs
@@ -126,6 +126,10 @@ impl Solver<'static> for DynSolver {
         dispatch!(self, satisfiable)
     }
 
+    fn satisfiable_with_extra(&mut self, extra: &[AstRef<'static>]) -> Result<bool, ClarirsError> {
+        dispatch!(self, satisfiable_with_extra, extra)
+    }
+
     fn is_true(&mut self, expr: &AstRef<'static>) -> Result<bool, ClarirsError> {
         dispatch!(self, is_true, expr)
     }

--- a/crates/clarirs_py/src/solver.rs
+++ b/crates/clarirs_py/src/solver.rs
@@ -307,6 +307,16 @@ impl PySolver {
         exact: Option<Bound<'py, PyAny>>,
     ) -> Result<bool, ClaripyError> {
         let exact = Self::extract_exact(exact);
+        // Fast path: scoped extra-constraint checks reuse the persistent
+        // incremental backend solvers instead of cloning cold copies.
+        if exact.is_none() || !matches!(&self.inner, DynSolver::Hybrid(_)) {
+            let asts: Vec<AstRef<'static>> = extra_constraints
+                .into_iter()
+                .flatten()
+                .map(|c| c.0.get().inner.clone())
+                .collect();
+            return Ok(self.inner.satisfiable_with_extra(&asts)?);
+        }
         self.with_extra_constraints(extra_constraints, exact, |solver| Ok(solver.satisfiable()?))
     }
 

--- a/crates/clarirs_z3/src/solver.rs
+++ b/crates/clarirs_z3/src/solver.rs
@@ -332,6 +332,19 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         self.with_cached_solver(|z3_solver| Ok(z3_solver.check()? == z3::Lbool::True))
     }
 
+    fn satisfiable_with_extra(&mut self, extra: &[AstRef<'c>]) -> Result<bool, ClarirsError> {
+        // Check with the extra constraints as assumptions on the persistent
+        // incremental solver: no clone, no from-scratch re-assertion. This is
+        // angr's hottest solver call (every branch feasibility check).
+        let mut assumptions = Vec::with_capacity(extra.len());
+        for c in extra {
+            assumptions.push(c.simplify_z3()?.to_z3()?);
+        }
+        self.with_cached_solver(|z3_solver| {
+            Ok(z3_solver.check_assumptions(&assumptions)? == z3::Lbool::True)
+        })
+    }
+
     fn eval(&mut self, expr: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
         self.eval_in_model(expr)
     }


### PR DESCRIPTION
## Problem

Checking satisfiability with extra (temporary) constraints had no dedicated path: callers cloned the solver and added the constraints. A cloned `Z3Solver` gets a fresh cache id, so its persistent incremental Z3 solver is rebuilt and every constraint re-asserted and re-solved from scratch. This is the hottest solver call in symbolic execution — every branch-feasibility check goes through it — so the clone-and-rebuild cost dominates on large constraint sets.

## Fix

Add `Solver::satisfiable_with_extra(extra)` with a clone-based **default** (so every existing implementor keeps working unchanged), and override it down the stack:

- **`Z3Solver`** checks the extras as **assumptions** (`check_assumptions`) on its persistent incremental solver — no clone, no re-assertion.
- **`CompositeSolver`** routes the extras to the single owning child when they touch one partition (the common case), checking the other partitions with their persistent solvers; falls back to a temporary merge when the extras span partitions.
- **`HybridSolver`** tries approximate then exact.
- The **simplification / concrete-early-resolution / replacement** mixins forward with their usual per-constraint transformations.

The Python `Solver.satisfiable(extra_constraints=...)` fast-path uses it for all non-hybrid solvers (and hybrid without an explicit `exact`/approx choice).

Existing `clarirs_core`, `clarirs_z3`, and `clarirs-vsa` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
