### PR TITLE
fix: default Annotation.relocatable to False to match claripy

### DIFF
--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -23,7 +23,7 @@ impl PyAnnotation {
 
     #[classattr]
     fn relocatable() -> bool {
-        true
+        false
     }
 
     #[classattr]
@@ -82,7 +82,7 @@ impl PyAnnotation {
             let relocatable = slf
                 .getattr("relocatable")
                 .and_then(|v| v.extract::<bool>())
-                .unwrap_or(true);
+                .unwrap_or(false);
             let module_name = slf.getattr("__module__")?.extract::<String>()?;
             let class_name = slf
                 .getattr("__class__")?

--- a/crates/clarirs_py/tests/test_annotations.py
+++ b/crates/clarirs_py/tests/test_annotations.py
@@ -23,7 +23,7 @@ class CustomRelocatableAnnotation(claripy.Annotation):
 
 class TestAnnotationClasses(unittest.TestCase):
     def test_base_class_flags(self):
-        self.assertTrue(claripy.Annotation.relocatable)
+        self.assertFalse(claripy.Annotation.relocatable)
         self.assertTrue(claripy.Annotation.eliminatable)
 
     def test_builtin_subclasses_are_annotations(self):
@@ -124,7 +124,7 @@ class TestAnnotationRoundtrip(unittest.TestCase):
         self.assertIsInstance(anno, CustomAnnotation)
         self.assertEqual(anno.payload, "payload")
         # Defaults inherited from the base class.
-        self.assertTrue(anno.relocatable)
+        self.assertFalse(anno.relocatable)
         self.assertTrue(anno.eliminatable)
 
     def test_user_annotation_overridden_flags(self):


### PR DESCRIPTION
## Rescoped after #586

This PR originally reworked the embedded-Python annotation classes to match claripy. #586 ("Reimplement claripy.annotation as native PyO3 classes") since reimplemented that module and **already incorporated most of those semantics** — the strided-interval / region / empty / uninitialized flags are now correct, and the built-ins carry `__repr__`.

One claripy divergence remained (and was codified in #586's new tests): the **base `Annotation.relocatable` default**.

## Problem

claripy's base `Annotation` is `eliminatable=True` but `relocatable=False`. A relocatable annotation is re-collected onto the results of operations; a non-relocatable one stays on its node. The native classes defaulted `relocatable` to `True` for both the base class and the unknown/user-defined fallback, so a bare user annotation leaked from a single node onto every expression derived from it. Analyses that use annotations to mark specific nodes (variable recovery, VSA regions, def-use tracking) depend on the `False` default.

```python
# claripy
>>> claripy.Annotation().relocatable, claripy.Annotation().eliminatable
(False, True)
```

## Change

- Base `PyAnnotation.relocatable` classattr: `True` → `False`.
- Unknown/user-defined annotation fallback: default `relocatable` to `False`.
- Update `test_annotations.py` (`test_base_class_flags`, `test_user_annotation_roundtrip`) to assert claripy's actual defaults.

The subclass flags (`StridedInterval`/`Region`/`Empty` = `(False, False)`, `Uninitialized` = `(True, False)`) were already correct after #586 and are unchanged.

## Testing

`cargo fmt` clean. `crates/clarirs_py/tests` — all annotation tests pass; the only failures (`test_if_errors`, `test_fp_ops::test_div`, `test_vsa_simplify_solving`) are pre-existing and also fail on `main`. Confirmed a default-annotated value now drops its annotation across operations, matching claripy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
