### PR TITLE
fix: is_true/is_false return False for objects they cannot prove

### DIFF
--- a/crates/clarirs_py/src/lib.rs
+++ b/crates/clarirs_py/src/lib.rs
@@ -124,7 +124,11 @@ fn is_true(expr: Bound<'_, PyAny>) -> Result<bool, ClaripyError> {
     } else if let Ok(string_expr) = expr.clone().extract::<CoerceString>() {
         Ok(string_expr.0.get().inner.simplify()?.is_true())
     } else {
-        Ok(expr.is_truthy()?)
+        // Anything we cannot prove true is not true. This matches claripy
+        // (whose concrete backend raises BackendError for non-AST inputs,
+        // which is_true treats as False); falling back to Python truthiness
+        // would instead report every foreign object as true.
+        Ok(false)
     }
 }
 
@@ -146,7 +150,8 @@ fn is_false(expr: Bound<'_, PyAny>) -> Result<bool, ClaripyError> {
     } else if let Ok(string_expr) = expr.clone().extract::<CoerceString>() {
         Ok(string_expr.0.get().inner.simplify()?.is_false())
     } else {
-        Ok(!expr.is_truthy()?)
+        // See is_true: claripy returns False for anything it cannot prove.
+        Ok(false)
     }
 }
 


### PR DESCRIPTION
## Problem

`claripy.is_true` / `is_false` return `False` for anything they cannot prove — the concrete backend raises `BackendError` for non-AST inputs and the helpers swallow it. clarirs instead fell back to **Python truthiness** (`expr.is_truthy()`) for any input that wasn't a clarirs AST, so:

- a foreign (non-claripy) object was reported as *provably true* by `is_true`, and
- a falsy foreign object was reported as *provably false* by `is_false`.

This breaks callers that legitimately pass mixed claripy / non-claripy values. angr's decompiler passes **AIL expressions** to `claripy.is_true`, and its `EmptyNodeRemover` removes a condition node when its condition "is true" — so the truthiness fallback silently dropped real guards and the code under them.

## Fix

Return `False` from the fallback arm of both `is_true` and `is_false` (the Bool/BV/FP/String arms above it are unchanged). This matches claripy's "False unless provable" contract.

## Verification

Checked against claripy across input types — clarirs now agrees on every case:

| input | `is_true` | `is_false` |
|-------|-----------|------------|
| `True` / `False` | True / False | False / True |
| `1` / `0` | True / False | False / True |
| `'a'` (str) | False | False |
| arbitrary object | False | False |
| `claripy.true()` / `false()` | True / False | False / True |

The bool and int cases are already handled by the existing Bool/BV coercion arms; only the foreign-object fallback changes. `cargo build`/`fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
