### PR TITLE
fix: And()/Or() of no arguments return the identity element

### DIFF
--- a/crates/clarirs_py/src/ast/mod.rs
+++ b/crates/clarirs_py/src/ast/mod.rs
@@ -34,6 +34,11 @@ pub fn and<'py>(
     py: Python<'py>,
     args: Vec<Bound<'py, PyAny>>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
+    // No operands: the identity element, true.
+    if args.is_empty() {
+        return Bool::new(py, &GLOBAL_CONTEXT.true_()?)
+            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+    }
     // If all args are actually Bools (or Python bool literals) — not BVs
     // being coerced through the Bool path — use the Bool And. Otherwise fall
     // back to BV bitwise And.
@@ -73,6 +78,11 @@ pub fn or<'py>(
     py: Python<'py>,
     args: Vec<Bound<'py, PyAny>>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
+    // No operands: the identity element, false.
+    if args.is_empty() {
+        return Bool::new(py, &GLOBAL_CONTEXT.false_()?)
+            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+    }
     // Same policy as And: prefer the Bool path whenever every arg is a Bool.
     let all_bools = args
         .iter()


### PR DESCRIPTION
## Problem
`claripy.And()` of no arguments is `true` and `claripy.Or()` of no arguments is `false` — the identity elements. clarirs raised `Invalid arguments: n-ary operation requires at least one operand`.

## Fix
Return the identity element for empty `And`/`Or`. angr constructs `And(*constraints)` / `Or(*constraints)` from lists that can be empty (condition recovery, structuring), and relies on the claripy semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
