### PR TITLE
fix: return only the actually-added constraints from Solver.add

### DIFF
--- a/crates/clarirs_py/src/solver.rs
+++ b/crates/clarirs_py/src/solver.rs
@@ -287,12 +287,21 @@ impl PySolver {
             ));
         };
 
-        // Add all expressions to the solver
+        // Return only the constraints actually added: trivially-true ones and
+        // duplicates of already-present constraints are filtered out.
+        let mut seen: std::collections::HashSet<u64> =
+            self.inner.constraints()?.iter().map(|c| c.hash()).collect();
+        let mut added = Vec::with_capacity(bool_exprs.len());
         for expr in &bool_exprs {
-            self.inner.add(&expr.get().inner)?;
+            let ast = expr.get().inner.clone();
+            self.inner.add(&ast)?;
+            if ast.simplify()?.is_true() || !seen.insert(ast.hash()) {
+                continue;
+            }
+            added.push(expr.clone());
         }
 
-        Ok(bool_exprs)
+        Ok(added)
     }
 
     fn simplify(&mut self) -> Result<(), ClaripyError> {


### PR DESCRIPTION
## Problem
claripy's `Solver.add` returns only the constraints it *actually* added — trivially-true constraints and duplicates of already-present constraints are filtered out of the return value. clarirs echoed every input back.

## Fix
Filter the return value to the newly-added, non-trivial constraints. Callers that act per returned constraint (e.g. angr records a constraint action for each) otherwise see spurious entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
