### PR TITLE
fix: evaluate through a bound auxiliary variable; convert fp.to_ieee_bv

### DIFF
--- a/crates/clarirs_py/tests/test_fp_ops.py
+++ b/crates/clarirs_py/tests/test_fp_ops.py
@@ -733,6 +733,23 @@ class TestFPOperations(unittest.TestCase):
         result = claripy.fpAdd(rm, sym_x, concrete)
         self.assertTrue(result.symbolic)
 
+    def test_eval_symbolic_fp(self):
+        """Evaluate a symbolic FP through the solver.
+
+        Z3 leaves fp.to_ieee_bv uninterpreted in models, so eval binds the
+        value through an auxiliary variable and converts the resulting IEEE
+        bits back to a float; the bitvector width selects f32 vs f64.
+        """
+        s = claripy.SolverZ3()
+        x = claripy.FPS("x", FSORT_FLOAT)
+        s.add(x == claripy.FPV(1.5, FSORT_FLOAT))
+        self.assertEqual(list(s.eval(x, 2)), [1.5])
+
+        s64 = claripy.SolverZ3()
+        y = claripy.FPS("y", claripy.FSORT_DOUBLE)
+        s64.add(y == claripy.FPV(2.5, claripy.FSORT_DOUBLE))
+        self.assertEqual(list(s64.eval(y, 2)), [2.5])
+
     def test_conversions(self):
         """Test FP conversion operations"""
         rm = RM.default()

--- a/crates/clarirs_z3/src/astext.rs
+++ b/crates/clarirs_z3/src/astext.rs
@@ -925,6 +925,9 @@ impl<'c> AstExtZ3<'c> for AstRef<'c> {
                             let sig = AstRef::from_z3(ctx, arg(2)?)?;
                             ctx.fp_fp(sign, exp, sig)
                         }
+                        z3::DeclKind::FpaToIeeeBv => {
+                            ctx.fp_to_ieeebv(AstRef::from_z3(ctx, arg(0)?)?)
+                        }
                         // Zero/infinity special values present as zero-argument
                         // apps, not numerals (e.g. in models: (_ -zero 8 24)).
                         // (FpaNan is handled above.)

--- a/crates/clarirs_z3/src/solver.rs
+++ b/crates/clarirs_z3/src/solver.rs
@@ -476,8 +476,40 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
             return Ok(vec![expr; n as usize]);
         }
 
-        // Convert to Z3 once
-        let z3_expr = expr.to_z3()?;
+        let ctx = self.context();
+
+        // Evaluate through a fresh variable asserted equal to the expression.
+        // Z3 keeps some operators (notably fp.to_ieee_bv) uninterpreted in
+        // models even with model completion, so evaluating the expression
+        // directly can return a non-constant term; an asserted equality forces
+        // the model to assign the variable a constant. Floats are bound via
+        // their IEEE bit pattern (fp equality would make the query unsat for
+        // NaN) and converted back after evaluation.
+        let aux_name = format!("__eval_{:x}", expr.hash());
+        let (aux, link, fp_sort) = match expr.ast_type() {
+            AstType::Float(fsort) => {
+                let aux = ctx.bvs(&aux_name, fsort.size())?;
+                let link = ctx.eq_(&aux, &ctx.fp_to_ieeebv(&expr)?)?;
+                (aux, link, Some(fsort))
+            }
+            AstType::Bool => {
+                let aux = ctx.bools(&aux_name)?;
+                let link = ctx.eq_(&aux, &expr)?;
+                (aux, link, None)
+            }
+            AstType::BitVec(width) => {
+                let aux = ctx.bvs(&aux_name, width)?;
+                let link = ctx.eq_(&aux, &expr)?;
+                (aux, link, None)
+            }
+            AstType::String => {
+                let aux = ctx.strings(&aux_name)?;
+                let link = ctx.eq_(&aux, &expr)?;
+                (aux, link, None)
+            }
+        };
+
+        let z3_aux = aux.to_z3()?;
 
         // Create and fill the Z3 solver once
         let mut z3_solver = RcSolver::new()?;
@@ -486,6 +518,7 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
             let converted = assertion.to_z3()?;
             z3_solver.assert(&converted)?;
         }
+        z3_solver.assert(&link.to_z3()?)?;
 
         for _ in 0..n {
             if z3_solver.check()? != z3::Lbool::True {
@@ -493,15 +526,22 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
             }
 
             let model = z3_solver.model()?;
-            let eval_result = model.eval(&z3_expr)?;
+            let eval_result = model.eval(&z3_aux)?;
 
-            let solution = AstRef::from_z3(self.context(), eval_result)?;
-            results.push(solution.clone());
+            let solution = AstRef::from_z3(ctx, eval_result)?;
 
             // Add constraint to exclude this solution
-            let neq_constraint = self.context().neq(&expr, &solution)?;
+            let neq_constraint = ctx.neq(&aux, &solution)?;
             let z3_neq = neq_constraint.to_z3()?;
             z3_solver.assert(&z3_neq)?;
+
+            // Convert the IEEE bit pattern back to a float constant. The
+            // bitvector width (32 or 64) selects the format.
+            let solution = match (&fp_sort, solution.op()) {
+                (Some(_), AstOp::BVV(bv)) => ctx.fpv(Float::try_from_ieee_bits(bv)?)?,
+                _ => solution,
+            };
+            results.push(solution);
         }
 
         Ok(results)


### PR DESCRIPTION
## Problem
Z3 leaves some operators — notably `fp.to_ieee_bv` — uninterpreted in models even with model completion, so evaluating an FP-bearing expression directly could return a non-constant term and fail to convert.

## Fix
`eval_n` binds the expression to a fresh variable via an asserted equality and evaluates the *variable*; floating-point values are bound through their IEEE bit pattern (an fp equality would be unsat for NaN) and converted back afterwards. Also adds a `from_z3` conversion for the `fp.to_ieee_bv` operator itself, which Z3's simplifier can leave in simplified expressions.

> Stacked on #590 (FP special-value conversion). Targets that branch; will retarget to `main` once #590 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
