### PR TITLE
Make native annotation classes picklable and subclassable

### DIFF
--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -1,5 +1,5 @@
 use num_bigint::BigUint;
-use pyo3::types::{PyDict, PyTuple};
+use pyo3::types::{PyDict, PyTuple, PyType};
 
 use crate::prelude::*;
 
@@ -165,7 +165,11 @@ pub struct SimplificationAvoidanceAnnotation;
 #[pymethods]
 impl SimplificationAvoidanceAnnotation {
     #[new]
-    fn py_new() -> PyClassInitializer<Self> {
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn py_new(
+        _args: &Bound<'_, PyTuple>,
+        _kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
         PyClassInitializer::from(PyAnnotation).add_subclass(SimplificationAvoidanceAnnotation)
     }
 
@@ -220,6 +224,17 @@ impl StridedIntervalAnnotation {
         false
     }
 
+    fn __reduce__<'py>(slf: PyRef<'py, Self>) -> (Bound<'py, PyType>, (BigUint, BigUint, BigUint)) {
+        (
+            slf.py().get_type::<Self>(),
+            (
+                slf.stride.clone(),
+                slf.lower_bound.clone(),
+                slf.upper_bound.clone(),
+            ),
+        )
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "StridedIntervalAnnotation(stride={}, lower_bound={}, upper_bound={})",
@@ -235,7 +250,11 @@ pub struct EmptyStridedIntervalAnnotation;
 #[pymethods]
 impl EmptyStridedIntervalAnnotation {
     #[new]
-    fn py_new() -> PyClassInitializer<Self> {
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn py_new(
+        _args: &Bound<'_, PyTuple>,
+        _kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
         PyClassInitializer::from(PyAnnotation).add_subclass(EmptyStridedIntervalAnnotation)
     }
 
@@ -283,6 +302,13 @@ impl RegionAnnotation {
         false
     }
 
+    fn __reduce__<'py>(slf: PyRef<'py, Self>) -> (Bound<'py, PyType>, (String, BigUint)) {
+        (
+            slf.py().get_type::<Self>(),
+            (slf.region_id.clone(), slf.region_base_addr.clone()),
+        )
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "RegionAnnotation(region_id={}, region_base_addr={})",
@@ -298,7 +324,11 @@ pub struct UninitializedAnnotation;
 #[pymethods]
 impl UninitializedAnnotation {
     #[new]
-    fn py_new() -> PyClassInitializer<Self> {
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn py_new(
+        _args: &Bound<'_, PyTuple>,
+        _kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
         PyClassInitializer::from(PyAnnotation).add_subclass(UninitializedAnnotation)
     }
 


### PR DESCRIPTION
## Problem
The native PyO3 annotation classes differ from ordinary Python classes in two ways that break real usage (angr serializes/vaults states that carry annotations, and subclasses annotations):

1. **Not picklable** — pickling an object carrying e.g. a `RegionAnnotation` fails with `cannot pickle 'claripy.annotation.RegionAnnotation' object`.
2. **No-arg constructors reject subclass init args** — `SimplificationAvoidanceAnnotation`/`EmptyStridedIntervalAnnotation`/`UninitializedAnnotation` take no constructor arguments, so a Python subclass with its own `__init__(self, x)` fails at `__new__` with "takes 0 positional arguments but 1 was given".

## Fix
- Add `__reduce__` to the required-argument leaves (`RegionAnnotation`, `StridedIntervalAnnotation`) to reconstruct them via their constructor with their fields.
- Make the three no-arg classes' constructors accept and ignore `*args`/`**kwargs`, like the base `Annotation`.
- The base and no-arg classes deliberately get **no** `__reduce__`, so user subclasses pickle through the default protocol with their `__dict__` state preserved.

## Verification
Round-trips `RegionAnnotation`, `StridedIntervalAnnotation`, every no-arg built-in, and a user subclass carrying state (`Sub(42)` → preserved class and `.x`). `cargo build`/`fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
