### PR TITLE
Preserve Python identity of user-defined annotations

### DIFF
--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -13,13 +13,14 @@ use crate::prelude::*;
 static ORIGINAL_ANNOTATIONS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
 fn original_annotations(py: Python<'_>) -> Result<Bound<'_, PyAny>, ClaripyError> {
-    let cache = ORIGINAL_ANNOTATIONS.get_or_try_init(py, || -> Result<Py<PyAny>, ClaripyError> {
-        Ok(py
-            .import("weakref")?
-            .getattr("WeakValueDictionary")?
-            .call0()?
-            .unbind())
-    })?;
+    let cache =
+        ORIGINAL_ANNOTATIONS.get_or_try_init(py, || -> Result<Py<PyAny>, ClaripyError> {
+            Ok(py
+                .import("weakref")?
+                .getattr("WeakValueDictionary")?
+                .call0()?
+                .unbind())
+        })?;
     Ok(cache.bind(py).clone())
 }
 

--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -1,7 +1,27 @@
 use num_bigint::BigUint;
-use pyo3::types::{PyDict, PyTuple, PyType};
+use pyo3::sync::PyOnceLock;
+use pyo3::types::{PyBytes, PyDict, PyTuple, PyType};
 
 use crate::prelude::*;
+
+/// Process-global cache of the original Python objects for user-defined
+/// (Unknown) annotations, keyed by their pickled bytes. It lets retrieval
+/// return the very object that was attached — while it is still alive —
+/// instead of an unpickled copy, so `is` and `==` hold for callers that
+/// round-trip an annotation through an AST. It is a `WeakValueDictionary`, so
+/// entries evict once the original annotation is garbage-collected.
+static ORIGINAL_ANNOTATIONS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
+fn original_annotations(py: Python<'_>) -> Result<Bound<'_, PyAny>, ClaripyError> {
+    let cache = ORIGINAL_ANNOTATIONS.get_or_try_init(py, || -> Result<Py<PyAny>, ClaripyError> {
+        Ok(py
+            .import("weakref")?
+            .getattr("WeakValueDictionary")?
+            .call0()?
+            .unbind())
+    })?;
+    Ok(cache.bind(py).clone())
+}
 
 /// `claripy.annotation.Annotation`
 ///
@@ -88,11 +108,20 @@ impl PyAnnotation {
                 .getattr("__class__")?
                 .getattr("__name__")?
                 .extract::<String>()?;
-            let pickle_dumps = slf.py().import("pickle")?.getattr("dumps")?;
+            let py = slf.py();
+            let pickle_dumps = py.import("pickle")?.getattr("dumps")?;
+            let pickled = pickle_dumps.call1((slf,))?.extract::<Vec<u8>>()?;
+            // Remember the original object, keyed by its pickled bytes, so
+            // retrieval can return it verbatim while it is still alive,
+            // preserving Python identity. Best-effort: objects that are not
+            // weak-referenceable are simply not cached.
+            if let Ok(cache) = original_annotations(py) {
+                let _ = cache.set_item(PyBytes::new(py, &pickled), slf);
+            }
             Ok(Annotation::new(
                 AnnotationType::Unknown {
                     name: format!("{module_name}:{class_name}"),
-                    value: pickle_dumps.call1((slf,))?.extract::<Vec<u8>>()?,
+                    value: pickled,
                 },
                 eliminatable,
                 relocatable,
@@ -107,8 +136,20 @@ impl PyAnnotation {
     ) -> Result<Bound<'py, PyAnnotation>, ClaripyError> {
         match annotation.type_() {
             AnnotationType::Unknown { value, .. } => {
-                let pickle_loads = py.import("pickle")?.getattr("loads")?;
-                Ok(pickle_loads.call1((value,))?.cast_into::<PyAnnotation>()?)
+                // Return the original Python object if it is still cached and
+                // alive (preserving identity); otherwise reconstruct it by
+                // unpickling the stored bytes.
+                let cached = original_annotations(py)
+                    .ok()
+                    .and_then(|cache| cache.call_method1("get", (PyBytes::new(py, value),)).ok())
+                    .filter(|obj| !obj.is_none());
+                match cached {
+                    Some(obj) => Ok(obj.cast_into::<PyAnnotation>()?),
+                    None => {
+                        let pickle_loads = py.import("pickle")?.getattr("loads")?;
+                        Ok(pickle_loads.call1((value,))?.cast_into::<PyAnnotation>()?)
+                    }
+                }
             }
             AnnotationType::SimplificationAvoidance => upcast(Bound::new(
                 py,

--- a/crates/clarirs_py/tests/test_annotations.py
+++ b/crates/clarirs_py/tests/test_annotations.py
@@ -137,6 +137,25 @@ class TestAnnotationRoundtrip(unittest.TestCase):
         self.assertIsInstance(roundtripped, CustomRelocatableAnnotation)
         self.assertEqual(roundtripped.tag, "t")
 
+    def test_user_annotation_identity_preserved(self):
+        # While the original Python object is alive, retrieval returns it
+        # verbatim rather than an unpickled copy, so `is` holds.
+        anno = CustomRelocatableAnnotation("t")
+        bv = claripy.BVS("x", 32).annotate(anno)
+        self.assertIs(bv.annotations[0], anno)
+        self.assertIs(bv.annotations[0], bv.annotations[0])
+
+    def test_user_annotation_reconstructed_after_original_gc(self):
+        # Once the original is gone, retrieval falls back to unpickling a fresh
+        # equal copy (the cache holds only a weak reference).
+        import gc
+
+        bv = claripy.BVS("x", 32).annotate(CustomRelocatableAnnotation("t"))
+        gc.collect()
+        roundtripped = bv.annotations[0]
+        self.assertIsInstance(roundtripped, CustomRelocatableAnnotation)
+        self.assertEqual(roundtripped.tag, "t")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When a user-defined (Unknown) annotation is attached to an AST, it is pickled into the core annotation. Retrieval (`ast.annotations`, `get_annotation`, …) previously always unpickled it, producing a *fresh* Python object every time:

```python
a = MyAnnotation()
x = claripy.BVS("x", 32).annotate(a)
x.annotations[0] is a            # was False
x.annotations[0] is x.annotations[0]  # was False
```

For annotations without value `__eq__`, the reconstructed object wasn't even `==` to the original.

This keeps the original objects in a process-global `weakref.WeakValueDictionary`, keyed by their pickled bytes, and returns them on retrieval while they are still alive — so `is` (and `==`) hold. Once the original is garbage-collected the weak entry evicts and retrieval falls back to unpickling a fresh copy, as before. Built-in (typed) annotations go through their own conversion and are unaffected; objects that aren't weak-referenceable are simply not cached (best-effort).

Tests: identity is preserved while the original is alive, and an annotation is still reconstructed correctly after the original is GC'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
