### PR TITLE
Refactor BitVec conversions to use tuple-based From implementations

### DIFF
--- a/crates/clarirs-vsa/src/solver.rs
+++ b/crates/clarirs-vsa/src/solver.rs
@@ -67,7 +67,7 @@ impl<'c> Solver<'c> for VSASolver<'c> {
                 }
                 si.eval(n)
                     .into_iter()
-                    .map(|bv| self.context().bvv_from_biguint_with_size(&bv, expr.size()))
+                    .map(|bv| self.context().bvv(BitVec::from((bv, expr.size()))))
                     .collect()
             }),
             AstType::Float(_) | AstType::String => Err(ClarirsError::UnsupportedOperation(
@@ -108,7 +108,7 @@ impl<'c> Solver<'c> for VSASolver<'c> {
         expr.simplify()?.reduce()?.into_bv().and_then(|si| {
             let (min_bound, _) = si.get_unsigned_bounds();
             expr.context()
-                .bvv_from_biguint_with_size(&min_bound, expr.size())
+                .bvv(BitVec::from((min_bound, expr.size())))
         })
     }
 
@@ -116,7 +116,7 @@ impl<'c> Solver<'c> for VSASolver<'c> {
         expr.simplify()?.reduce()?.into_bv().and_then(|si| {
             let (_, max_bound) = si.get_unsigned_bounds();
             expr.context()
-                .bvv_from_biguint_with_size(&max_bound, expr.size())
+                .bvv(BitVec::from((max_bound, expr.size())))
         })
     }
 
@@ -132,7 +132,7 @@ impl<'c> Solver<'c> for VSASolver<'c> {
                 min_bound.to_biguint().unwrap()
             };
             expr.context()
-                .bvv_from_biguint_with_size(&unsigned_min, expr.size())
+                .bvv(BitVec::from((unsigned_min, expr.size())))
         })
     }
 
@@ -148,7 +148,7 @@ impl<'c> Solver<'c> for VSASolver<'c> {
                 max_bound.to_biguint().unwrap()
             };
             expr.context()
-                .bvv_from_biguint_with_size(&unsigned_max, expr.size())
+                .bvv(BitVec::from((unsigned_max, expr.size())))
         })
     }
 }

--- a/crates/clarirs_core/src/algorithms/canonicalize.rs
+++ b/crates/clarirs_core/src/algorithms/canonicalize.rs
@@ -200,8 +200,8 @@ mod tests {
 
         // Create AST with no variables
         let ast = ctx.add(
-            &ctx.bvv_prim_with_size(5u64, 32)?,
-            &ctx.bvv_prim_with_size(10u64, 32)?,
+            &ctx.bvv(BitVec::from((5u64, 32)))?,
+            &ctx.bvv(BitVec::from((10u64, 32)))?,
         )?;
         let dyn_ast = ast.clone();
 
@@ -219,14 +219,14 @@ mod tests {
     fn test_canonicalize_single_var() -> Result<(), ClarirsError> {
         let ctx = Context::new();
 
-        let ast = ctx.add(&ctx.bvs("x", 64)?, &ctx.bvv_prim_with_size(5u64, 64)?)?;
+        let ast = ctx.add(&ctx.bvs("x", 64)?, &ctx.bvv(BitVec::from((5u64, 64)))?)?;
         let dyn_ast = ast.clone();
 
         let (map, counter, canonical) = canonicalize(&dyn_ast)?;
 
         // Check that the variable was renamed to v0
         let canonical_expected =
-            ctx.add(&ctx.bvs("v0", 64)?, &ctx.bvv_prim_with_size(5u64, 64)?)?;
+            ctx.add(&ctx.bvs("v0", 64)?, &ctx.bvv(BitVec::from((5u64, 64)))?)?;
         let dyn_canonical_expected = canonical_expected.clone();
 
         assert_eq!(canonical, dyn_canonical_expected);
@@ -380,9 +380,9 @@ mod tests {
         let ctx = Context::new();
 
         // ASTs with constants and variables
-        let ast1 = ctx.add(&ctx.bvs("x", 64)?, &ctx.bvv_prim_with_size(5u64, 64)?)?;
-        let ast2 = ctx.add(&ctx.bvs("y", 64)?, &ctx.bvv_prim_with_size(5u64, 64)?)?;
-        let ast3 = ctx.add(&ctx.bvs("z", 64)?, &ctx.bvv_prim_with_size(10u64, 64)?)?;
+        let ast1 = ctx.add(&ctx.bvs("x", 64)?, &ctx.bvv(BitVec::from((5u64, 64)))?)?;
+        let ast2 = ctx.add(&ctx.bvs("y", 64)?, &ctx.bvv(BitVec::from((5u64, 64)))?)?;
+        let ast3 = ctx.add(&ctx.bvs("z", 64)?, &ctx.bvv(BitVec::from((10u64, 64)))?)?;
 
         let dyn_ast1 = ast1.clone();
         let dyn_ast2 = ast2.clone();
@@ -404,11 +404,11 @@ mod tests {
         // e.g. (x + y) == 5 where x,y are BVS and the result is Bool
         let ast1 = ctx.eq_(
             &ctx.add(&ctx.bvs("x", 32)?, &ctx.bvs("y", 32)?)?,
-            &ctx.bvv_prim_with_size(5u64, 32)?,
+            &ctx.bvv(BitVec::from((5u64, 32)))?,
         )?;
         let ast2 = ctx.eq_(
             &ctx.add(&ctx.bvs("a", 32)?, &ctx.bvs("b", 32)?)?,
-            &ctx.bvv_prim_with_size(5u64, 32)?,
+            &ctx.bvv(BitVec::from((5u64, 32)))?,
         )?;
 
         let dyn_ast1 = ast1.clone();

--- a/crates/clarirs_core/src/algorithms/canonicalize.rs
+++ b/crates/clarirs_core/src/algorithms/canonicalize.rs
@@ -200,8 +200,8 @@ mod tests {
 
         // Create AST with no variables
         let ast = ctx.add(
-            &ctx.bvv(BitVec::from((5u64, 32)))?,
-            &ctx.bvv(BitVec::from((10u64, 32)))?,
+            &ctx.bvv(BitVec::from((5, 32)))?,
+            &ctx.bvv(BitVec::from((10, 32)))?,
         )?;
         let dyn_ast = ast.clone();
 
@@ -219,14 +219,14 @@ mod tests {
     fn test_canonicalize_single_var() -> Result<(), ClarirsError> {
         let ctx = Context::new();
 
-        let ast = ctx.add(&ctx.bvs("x", 64)?, &ctx.bvv(BitVec::from((5u64, 64)))?)?;
+        let ast = ctx.add(&ctx.bvs("x", 64)?, &ctx.bvv(BitVec::from((5, 64)))?)?;
         let dyn_ast = ast.clone();
 
         let (map, counter, canonical) = canonicalize(&dyn_ast)?;
 
         // Check that the variable was renamed to v0
         let canonical_expected =
-            ctx.add(&ctx.bvs("v0", 64)?, &ctx.bvv(BitVec::from((5u64, 64)))?)?;
+            ctx.add(&ctx.bvs("v0", 64)?, &ctx.bvv(BitVec::from((5, 64)))?)?;
         let dyn_canonical_expected = canonical_expected.clone();
 
         assert_eq!(canonical, dyn_canonical_expected);
@@ -380,9 +380,9 @@ mod tests {
         let ctx = Context::new();
 
         // ASTs with constants and variables
-        let ast1 = ctx.add(&ctx.bvs("x", 64)?, &ctx.bvv(BitVec::from((5u64, 64)))?)?;
-        let ast2 = ctx.add(&ctx.bvs("y", 64)?, &ctx.bvv(BitVec::from((5u64, 64)))?)?;
-        let ast3 = ctx.add(&ctx.bvs("z", 64)?, &ctx.bvv(BitVec::from((10u64, 64)))?)?;
+        let ast1 = ctx.add(&ctx.bvs("x", 64)?, &ctx.bvv(BitVec::from((5, 64)))?)?;
+        let ast2 = ctx.add(&ctx.bvs("y", 64)?, &ctx.bvv(BitVec::from((5, 64)))?)?;
+        let ast3 = ctx.add(&ctx.bvs("z", 64)?, &ctx.bvv(BitVec::from((10, 64)))?)?;
 
         let dyn_ast1 = ast1.clone();
         let dyn_ast2 = ast2.clone();
@@ -404,11 +404,11 @@ mod tests {
         // e.g. (x + y) == 5 where x,y are BVS and the result is Bool
         let ast1 = ctx.eq_(
             &ctx.add(&ctx.bvs("x", 32)?, &ctx.bvs("y", 32)?)?,
-            &ctx.bvv(BitVec::from((5u64, 32)))?,
+            &ctx.bvv(BitVec::from((5, 32)))?,
         )?;
         let ast2 = ctx.eq_(
             &ctx.add(&ctx.bvs("a", 32)?, &ctx.bvs("b", 32)?)?,
-            &ctx.bvv(BitVec::from((5u64, 32)))?,
+            &ctx.bvv(BitVec::from((5, 32)))?,
         )?;
 
         let dyn_ast1 = ast1.clone();

--- a/crates/clarirs_core/src/algorithms/pre_order.rs
+++ b/crates/clarirs_core/src/algorithms/pre_order.rs
@@ -122,7 +122,7 @@ mod tests {
         let y = ctx.bvs("y", 64)?;
         let add = ctx.add(&x, &y)?;
 
-        let replacement = ctx.bvv_prim(99u64)?.clone();
+        let replacement = ctx.bvv(BitVec::from((99u64, 64)))?.clone();
 
         // Short-circuit the entire tree
         let result = walk_pre_order(

--- a/crates/clarirs_core/src/algorithms/pre_order.rs
+++ b/crates/clarirs_core/src/algorithms/pre_order.rs
@@ -122,7 +122,7 @@ mod tests {
         let y = ctx.bvs("y", 64)?;
         let add = ctx.add(&x, &y)?;
 
-        let replacement = ctx.bvv(BitVec::from((99u64, 64)))?.clone();
+        let replacement = ctx.bvv(BitVec::from((99, 64)))?.clone();
 
         // Short-circuit the entire tree
         let result = walk_pre_order(

--- a/crates/clarirs_core/src/algorithms/simplify/bv.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/bv.rs
@@ -98,10 +98,7 @@ pub(crate) fn simplify_bv<'c>(
                     .any(|(a, b)| a.hash() != b.hash());
 
             match sym_args.len() {
-                0 => Ok(ctx.bvv(BitVec::from_biguint(
-                    &((BigUint::one() << size) - BigUint::one()),
-                    size,
-                ))?),
+                0 => Ok(ctx.bvv(BitVec::from(((BigUint::one() << size) - BigUint::one(), size)))?),
                 1 => Ok(sym_args.into_iter().next().unwrap()),
                 2 => {
                     let (a, b) = (&sym_args[0], &sym_args[1]);
@@ -169,10 +166,7 @@ pub(crate) fn simplify_bv<'c>(
                                                     & &full_mask;
 
                                                 let unrotated_bvv =
-                                                    ctx.bvv(BitVec::from_biguint(
-                                                        &unrotated,
-                                                        bitwidth as u32,
-                                                    ))?;
+                                                    ctx.bvv(BitVec::from((unrotated, bitwidth as u32)))?;
                                                 let masked_a =
                                                     ctx.and2(shl_inner.clone(), unrotated_bvv)?;
                                                 let new_shl =
@@ -230,7 +224,7 @@ pub(crate) fn simplify_bv<'c>(
             let simplified = state.get_all_simplified()?;
 
             let size = simplified[0].size();
-            let all_ones = BitVec::from_biguint(&((BigUint::one() << size) - BigUint::one()), size);
+            let all_ones = BitVec::from(((BigUint::one() << size) - BigUint::one(), size));
 
             // Flatten nested Ors, fold constants, remove identities, detect absorber
             let mut bvv_acc: Option<BitVec> = None;
@@ -679,7 +673,7 @@ pub(crate) fn simplify_bv<'c>(
                     .any(|(a, b)| a.hash() != b.hash());
 
             match sym_args.len() {
-                0 => Ok(ctx.bvv(BitVec::from_prim_with_size(1u64, size)?)?),
+                0 => Ok(ctx.bvv(BitVec::from((1u64, size)))?),
                 1 => Ok(sym_args.into_iter().next().unwrap()),
                 _ => {
                     if changed {
@@ -781,10 +775,7 @@ pub(crate) fn simplify_bv<'c>(
                         } else {
                             ctx.shl(
                                 inner,
-                                &ctx.bvv(BitVec::from_prim_with_size(
-                                    inner_shift as u64,
-                                    inner.size(),
-                                )?)?,
+                                &ctx.bvv(BitVec::from((inner_shift as u64, inner.size())))?,
                             )?
                         };
                         // Zeros go at the bottom (LSB), shifted_inner goes at the top (MSB)
@@ -927,10 +918,7 @@ pub(crate) fn simplify_bv<'c>(
                     // If shifting >= bit_length, return all-ones (if negative) or all-zeros (if positive)
                     if shift_amount_u32 >= bit_length {
                         return if sign_bit_set {
-                            Ok(ctx.bvv(BitVec::from_biguint(
-                                &((BigUint::one() << bit_length) - BigUint::one()),
-                                bit_length,
-                            ))?)
+                            Ok(ctx.bvv(BitVec::from(((BigUint::one() << bit_length) - BigUint::one(), bit_length)))?)
                         } else {
                             Ok(ctx.bvv(BitVec::zeros(bit_length))?)
                         };
@@ -949,7 +937,7 @@ pub(crate) fn simplify_bv<'c>(
                         unsigned_shifted
                     };
 
-                    Ok(ctx.bvv(BitVec::from_biguint(&result, bit_length))?)
+                    Ok(ctx.bvv(BitVec::from((result, bit_length)))?)
                 }
                 // Fallback case
                 _ => Ok(ctx.ashr(arc, arc1)?),
@@ -982,7 +970,7 @@ pub(crate) fn simplify_bv<'c>(
                         let size = arc.size();
                         let combined_amt = (inner_amt_val.to_bigint() + outer_amt.to_bigint())
                             % BigInt::from(size);
-                        let combined_amt_bv = BitVec::from_bigint(&combined_amt, arc1.size());
+                        let combined_amt_bv = BitVec::from((combined_amt, arc1.size()));
                         state.rerun(ctx.rotate_left(inner.clone(), ctx.bvv(combined_amt_bv)?)?)
                     } else {
                         // Inner rotation amount is not concrete, fall through
@@ -1023,7 +1011,7 @@ pub(crate) fn simplify_bv<'c>(
                         let size = arc.size();
                         let combined_amt = (inner_amt_val.to_bigint() + outer_amt.to_bigint())
                             % BigInt::from(size);
-                        let combined_amt_bv = BitVec::from_bigint(&combined_amt, arc1.size());
+                        let combined_amt_bv = BitVec::from((combined_amt, arc1.size()));
                         state.rerun(ctx.rotate_right(inner.clone(), ctx.bvv(combined_amt_bv)?)?)
                     } else {
                         // Inner rotation amount is not concrete, fall through
@@ -1407,7 +1395,7 @@ pub(crate) fn simplify_bv<'c>(
                     let bit_length = float.fsort().size();
 
                     // Create a BitVec with the IEEE 754 representation
-                    Ok(ctx.bvv(BitVec::from_biguint(&ieee_bits, bit_length))?)
+                    Ok(ctx.bvv(BitVec::from((ieee_bits, bit_length)))?)
                 }
                 _ => Ok(ctx.fp_to_ieeebv(arc)?), // Fallback for non-concrete values
             }
@@ -1420,7 +1408,7 @@ pub(crate) fn simplify_bv<'c>(
                     let unsigned_value = float.to_unsigned_biguint().unwrap_or(BigUint::zero());
 
                     // Truncate or extend the result to fit within the specified bit size
-                    let result_bitvec = BitVec::from_biguint(&unsigned_value, *bit_size);
+                    let result_bitvec = BitVec::from((unsigned_value, *bit_size));
 
                     Ok(ctx.bvv(result_bitvec)?)
                 }
@@ -1438,7 +1426,7 @@ pub(crate) fn simplify_bv<'c>(
                     let unsigned_value = signed_value.to_biguint().unwrap_or(BigUint::zero());
 
                     // Create a BitVec with the result, truncating or extending to fit within the specified bit size
-                    let result_bitvec = BitVec::from_biguint(&unsigned_value, *bit_size);
+                    let result_bitvec = BitVec::from((unsigned_value, *bit_size));
 
                     Ok(ctx.bvv(result_bitvec)?)
                 }
@@ -1451,7 +1439,7 @@ pub(crate) fn simplify_bv<'c>(
                 AstOp::StringV(value) => {
                     // chars().count() returns the number of Unicode scalar values
                     let length = value.chars().count() as u64;
-                    Ok(ctx.bvv(BitVec::from_prim_with_size(length, 64)?)?)
+                    Ok(ctx.bvv(BitVec::from((length, 64)))?)
                 }
                 _ => Ok(ctx.str_len(arc)?), // Fallback to symbolic
             }
@@ -1490,13 +1478,13 @@ pub(crate) fn simplify_bv<'c>(
                                 // Convert byte position back to character position
                                 let byte_pos = byte_index + pos;
                                 let char_pos = s[..byte_pos].chars().count();
-                                Ok(ctx.bvv(BitVec::from_prim_with_size(char_pos as u64, 64)?)?)
+                                Ok(ctx.bvv(BitVec::from((char_pos as u64, 64)))?)
                             }
-                            None => Ok(ctx.bvv(BitVec::from_prim_with_size(-1i64 as u64, 64)?)?), // -1 if not found
+                            None => Ok(ctx.bvv(BitVec::from((-1i64 as u64, 64)))?), // -1 if not found
                         }
                     } else {
                         // If start index is out of bounds, return -1
-                        Ok(ctx.bvv(BitVec::from_prim_with_size(-1i64 as u64, 64)?)?)
+                        Ok(ctx.bvv(BitVec::from((-1i64 as u64, 64)))?)
                     }
                 }
                 _ => Ok(ctx.str_index_of(arc, arc1, arc2)?), // Fallback to symbolic
@@ -1508,7 +1496,7 @@ pub(crate) fn simplify_bv<'c>(
                 AstOp::StringV(string) => {
                     if string.is_empty() {
                         let max_int = BigUint::from_str_radix("ffffffffffffffff", 16).unwrap();
-                        return Ok(ctx.bvv(BitVec::from_biguint(&max_int, 64))?);
+                        return Ok(ctx.bvv(BitVec::from((max_int, 64)))?);
                     }
 
                     // Attempt to parse the string as a decimal integer
@@ -1524,7 +1512,7 @@ pub(crate) fn simplify_bv<'c>(
                         return Ok(ctx.bvv(BitVec::zeros(64))?);
                     }
 
-                    Ok(ctx.bvv(BitVec::from_biguint(&value, 64))?)
+                    Ok(ctx.bvv(BitVec::from((value, 64)))?)
                 }
                 _ => Ok(ctx.str_to_bv(arc)?),
             }

--- a/crates/clarirs_core/src/algorithms/simplify/bv.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/bv.rs
@@ -673,7 +673,7 @@ pub(crate) fn simplify_bv<'c>(
                     .any(|(a, b)| a.hash() != b.hash());
 
             match sym_args.len() {
-                0 => Ok(ctx.bvv(BitVec::from((1u64, size)))?),
+                0 => Ok(ctx.bvv(BitVec::from((1, size)))?),
                 1 => Ok(sym_args.into_iter().next().unwrap()),
                 _ => {
                     if changed {

--- a/crates/clarirs_core/src/algorithms/simplify/test_bool.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/test_bool.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use clarirs_num::BitVec;
 
 use crate::{
     ast::{
@@ -274,9 +275,9 @@ fn test_ult() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(2u8)?, ctx.true_()?),
-        (ctx.bvv_prim(2u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.false_()?),
     ];
 
@@ -296,9 +297,9 @@ fn test_ule() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(2u8)?, ctx.true_()?),
-        (ctx.bvv_prim(2u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.true_()?),
     ];
 
@@ -318,9 +319,9 @@ fn test_ugt() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(2u8)?, ctx.false_()?),
-        (ctx.bvv_prim(2u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.false_()?),
     ];
 
@@ -340,9 +341,9 @@ fn test_uge() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(2u8)?, ctx.false_()?),
-        (ctx.bvv_prim(2u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.true_()?),
     ];
 
@@ -362,11 +363,11 @@ fn test_slt() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(2u8)?, ctx.true_()?),
-        (ctx.bvv_prim(2u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
-        (ctx.bvv_prim(255u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(255u8)?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((255u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((255u64, 8)))?, ctx.false_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.false_()?),
     ];
 
@@ -386,11 +387,11 @@ fn test_sle() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(2u8)?, ctx.true_()?),
-        (ctx.bvv_prim(2u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
-        (ctx.bvv_prim(255u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(255u8)?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((255u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((255u64, 8)))?, ctx.false_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.true_()?),
     ];
 
@@ -410,11 +411,11 @@ fn test_sgt() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(2u8)?, ctx.false_()?),
-        (ctx.bvv_prim(2u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
-        (ctx.bvv_prim(255u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(255u8)?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((255u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((255u64, 8)))?, ctx.true_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.false_()?),
     ];
 
@@ -434,11 +435,11 @@ fn test_sge() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(2u8)?, ctx.false_()?),
-        (ctx.bvv_prim(2u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(1u8)?, ctx.true_()?),
-        (ctx.bvv_prim(255u8)?, ctx.bvv_prim(1u8)?, ctx.false_()?),
-        (ctx.bvv_prim(1u8)?, ctx.bvv_prim(255u8)?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((255u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((255u64, 8)))?, ctx.true_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.true_()?),
     ];
 

--- a/crates/clarirs_core/src/algorithms/simplify/test_bool.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/test_bool.rs
@@ -275,9 +275,9 @@ fn test_ult() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((2, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((2, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.false_()?),
     ];
 
@@ -297,9 +297,9 @@ fn test_ule() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((2, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((2, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.true_()?),
     ];
 
@@ -319,9 +319,9 @@ fn test_ugt() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((2, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((2, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.false_()?),
     ];
 
@@ -341,9 +341,9 @@ fn test_uge() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((2, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((2, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.true_()?),
     ];
 
@@ -363,11 +363,11 @@ fn test_slt() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((255u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((255u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((2, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((2, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((255, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((255, 8)))?, ctx.false_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.false_()?),
     ];
 
@@ -387,11 +387,11 @@ fn test_sle() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((255u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((255u64, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((2, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((2, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((255, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((255, 8)))?, ctx.false_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.true_()?),
     ];
 
@@ -411,11 +411,11 @@ fn test_sgt() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((255u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((255u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((2, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((2, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((255, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((255, 8)))?, ctx.true_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.false_()?),
     ];
 
@@ -435,11 +435,11 @@ fn test_sge() -> Result<()> {
     let ctx = Context::new();
 
     let table = vec![
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((2u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((2u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.true_()?),
-        (ctx.bvv(BitVec::from((255u64, 8)))?, ctx.bvv(BitVec::from((1u64, 8)))?, ctx.false_()?),
-        (ctx.bvv(BitVec::from((1u64, 8)))?, ctx.bvv(BitVec::from((255u64, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((2, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((2, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.true_()?),
+        (ctx.bvv(BitVec::from((255, 8)))?, ctx.bvv(BitVec::from((1, 8)))?, ctx.false_()?),
+        (ctx.bvv(BitVec::from((1, 8)))?, ctx.bvv(BitVec::from((255, 8)))?, ctx.true_()?),
         (ctx.bvs("a", 8)?, ctx.bvs("a", 8)?, ctx.true_()?),
     ];
 

--- a/crates/clarirs_core/src/algorithms/simplify/test_bv.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/test_bv.rs
@@ -23,8 +23,8 @@ fn test_neg() -> Result<()> {
     ];
 
     for (a, expected) in table.clone() {
-        let a = ctx.bvv_prim(a).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.neg(&a)?.simplify()?;
         assert_eq!(result, expected);
@@ -48,8 +48,8 @@ fn test_double_negation() -> Result<()> {
     ];
 
     for (a, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let neg_a = ctx.neg(&a)?;
         let double_neg = ctx.neg(&neg_a)?.simplify()?;
@@ -88,9 +88,9 @@ fn test_add() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.add(&a, &b)?;
         let simplified = result.simplify()?;
@@ -127,9 +127,9 @@ fn test_sub() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.sub(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -165,9 +165,9 @@ fn test_mul() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.mul(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -199,9 +199,9 @@ fn test_udiv() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((u64::from(a), 8))).unwrap();
+        let b = ctx.bvv(BitVec::from((u64::from(b), 8))).unwrap();
+        let expected = ctx.bvv(BitVec::from((u64::from(expected), 8))).unwrap();
 
         let result = ctx.udiv(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -257,9 +257,9 @@ fn test_sdiv() -> Result<()> {
         let b_bits = b_i64 as u64;
         let expected_bits = expected_i64 as u64;
 
-        let a = ctx.bvv_prim(a_bits)?;
-        let b = ctx.bvv_prim(b_bits)?;
-        let expected = ctx.bvv_prim(expected_bits)?;
+        let a = ctx.bvv(BitVec::from((a_bits, 64)))?;
+        let b = ctx.bvv(BitVec::from((b_bits, 64)))?;
+        let expected = ctx.bvv(BitVec::from((expected_bits, 64)))?;
 
         let result = ctx.sdiv(&a, &b)?.simplify()?;
         assert_eq!(result, expected, "Failed for a={a_i64}, b={b_i64}");
@@ -300,9 +300,9 @@ fn test_urem() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.urem(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -352,9 +352,9 @@ fn test_srem() -> Result<()> {
         let b_bits = b_i64 as u64;
         let expected_bits = expected_i64 as u64;
 
-        let a = ctx.bvv_prim(a_bits)?;
-        let b = ctx.bvv_prim(b_bits)?;
-        let expected = ctx.bvv_prim(expected_bits)?;
+        let a = ctx.bvv(BitVec::from((a_bits, 64)))?;
+        let b = ctx.bvv(BitVec::from((b_bits, 64)))?;
+        let expected = ctx.bvv(BitVec::from((expected_bits, 64)))?;
 
         let result = ctx.srem(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -385,9 +385,9 @@ fn test_and() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.and2(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -418,9 +418,9 @@ fn test_or() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.or2(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -451,9 +451,9 @@ fn test_xor() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.xor2(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -483,8 +483,8 @@ fn test_not() -> Result<()> {
     ];
 
     for (a, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.not(&a)?.simplify()?;
         assert_eq!(result, expected);
@@ -517,9 +517,9 @@ fn test_shl() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.shl(&a, &b)?.simplify()?;
         assert_eq!(result, expected, "shl({a:?}, {b:?})");
@@ -527,7 +527,7 @@ fn test_shl() -> Result<()> {
 
     // Test zero-shift with symbolic value
     let x = ctx.bvs("x", 64)?;
-    let zero = ctx.bvv_prim(0u64)?;
+    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
     let result = ctx.shl(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -568,9 +568,9 @@ fn test_lshr() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.lshr(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -578,7 +578,7 @@ fn test_lshr() -> Result<()> {
 
     // Test zero-shift with symbolic value
     let x = ctx.bvs("x", 64)?;
-    let zero = ctx.bvv_prim(0u64)?;
+    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
     let result = ctx.lshr(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -619,9 +619,9 @@ fn test_ashr() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = ctx.bvv_prim(a).unwrap();
-        let b = ctx.bvv_prim(b).unwrap();
-        let expected = ctx.bvv_prim(expected).unwrap();
+        let a = ctx.bvv(BitVec::from((a, 64))).unwrap();
+        let b = ctx.bvv(BitVec::from((b, 64))).unwrap();
+        let expected = ctx.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = ctx.ashr(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -629,7 +629,7 @@ fn test_ashr() -> Result<()> {
 
     // Test zero-shift with symbolic value
     let x = ctx.bvs("x", 64)?;
-    let zero = ctx.bvv_prim(0u64)?;
+    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
     let result = ctx.ashr(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -642,24 +642,24 @@ fn test_zext() -> Result<()> {
 
     let table = vec![
         (
-            ctx.bvv_prim_with_size(0u8, 4)?,
+            ctx.bvv(BitVec::from((0u64, 4)))?,
             0,
-            ctx.bvv_prim_with_size(0u8, 4)?,
+            ctx.bvv(BitVec::from((0u64, 4)))?,
         ),
         (
-            ctx.bvv_prim_with_size(0u8, 4)?,
+            ctx.bvv(BitVec::from((0u64, 4)))?,
             1,
-            ctx.bvv_prim_with_size(0u8, 5)?,
+            ctx.bvv(BitVec::from((0u64, 5)))?,
         ),
         (
-            ctx.bvv_prim_with_size(1u8, 4)?,
+            ctx.bvv(BitVec::from((1u64, 4)))?,
             0,
-            ctx.bvv_prim_with_size(1u8, 4)?,
+            ctx.bvv(BitVec::from((1u64, 4)))?,
         ),
         (
-            ctx.bvv_prim_with_size(1u8, 4)?,
+            ctx.bvv(BitVec::from((1u64, 4)))?,
             1,
-            ctx.bvv_prim_with_size(1u8, 5)?,
+            ctx.bvv(BitVec::from((1u64, 5)))?,
         ),
     ];
 
@@ -676,54 +676,54 @@ fn test_sext() -> Result<()> {
 
     let table = vec![
         (
-            ctx.bvv_prim_with_size(0u8, 4)?,
+            ctx.bvv(BitVec::from((0u64, 4)))?,
             0,
-            ctx.bvv_prim_with_size(0u8, 4)?,
+            ctx.bvv(BitVec::from((0u64, 4)))?,
         ),
         (
-            ctx.bvv_prim_with_size(0u8, 4)?,
+            ctx.bvv(BitVec::from((0u64, 4)))?,
             1,
-            ctx.bvv_prim_with_size(0u8, 5)?,
+            ctx.bvv(BitVec::from((0u64, 5)))?,
         ),
         (
-            ctx.bvv_prim_with_size(1u8, 4)?,
+            ctx.bvv(BitVec::from((1u64, 4)))?,
             0,
-            ctx.bvv_prim_with_size(1u8, 4)?,
+            ctx.bvv(BitVec::from((1u64, 4)))?,
         ),
         (
-            ctx.bvv_prim_with_size(1u8, 4)?,
+            ctx.bvv(BitVec::from((1u64, 4)))?,
             1,
-            ctx.bvv_prim_with_size(1u8, 5)?,
+            ctx.bvv(BitVec::from((1u64, 5)))?,
         ),
         (
-            ctx.bvv_prim_with_size(15u8, 4)?,
+            ctx.bvv(BitVec::from((15u64, 4)))?,
             0,
-            ctx.bvv_prim_with_size(15u8, 4)?,
+            ctx.bvv(BitVec::from((15u64, 4)))?,
         ),
         (
-            ctx.bvv_prim_with_size(15u8, 4)?,
+            ctx.bvv(BitVec::from((15u64, 4)))?,
             1,
-            ctx.bvv_prim_with_size(31u8, 5)?,
+            ctx.bvv(BitVec::from((31u64, 5)))?,
         ),
         (
-            ctx.bvv_prim_with_size(0u8, 1)?,
+            ctx.bvv(BitVec::from((0u64, 1)))?,
             1,
-            ctx.bvv_prim_with_size(0u8, 2)?,
+            ctx.bvv(BitVec::from((0u64, 2)))?,
         ),
         (
-            ctx.bvv_prim_with_size(1u8, 1)?,
+            ctx.bvv(BitVec::from((1u64, 1)))?,
             1,
-            ctx.bvv_prim_with_size(3u8, 2)?,
+            ctx.bvv(BitVec::from((3u64, 2)))?,
         ),
         (
-            ctx.bvv_prim_with_size(8u8, 4)?,
+            ctx.bvv(BitVec::from((8u64, 4)))?,
             4,
-            ctx.bvv_prim_with_size(248u8, 8)?,
+            ctx.bvv(BitVec::from((248u64, 8)))?,
         ),
         (
-            ctx.bvv_prim_with_size(5u8, 4)?,
+            ctx.bvv(BitVec::from((5u64, 4)))?,
             4,
-            ctx.bvv_prim_with_size(5u8, 8)?,
+            ctx.bvv(BitVec::from((5u64, 8)))?,
         ),
     ];
 
@@ -751,8 +751,8 @@ fn test_byte_reverse() -> Result<()> {
     ];
 
     for (a, expected) in table {
-        let a = context.bvv_prim(a).unwrap();
-        let expected = context.bvv_prim(expected).unwrap();
+        let a = context.bvv(BitVec::from((a, 64))).unwrap();
+        let expected = context.bvv(BitVec::from((expected, 64))).unwrap();
 
         let result = context.byte_reverse(&a)?.simplify()?;
         assert_eq!(result, expected);
@@ -819,9 +819,9 @@ fn test_rotate_left() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = context.bvv_prim_with_size(a, 4).unwrap();
-        let b = context.bvv_prim_with_size(b, 4).unwrap();
-        let expected = context.bvv_prim_with_size(expected, 4).unwrap();
+        let a = context.bvv(BitVec::from((a, 4))).unwrap();
+        let b = context.bvv(BitVec::from((b, 4))).unwrap();
+        let expected = context.bvv(BitVec::from((expected, 4))).unwrap();
 
         let result = context.rotate_left(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -829,7 +829,7 @@ fn test_rotate_left() -> Result<()> {
 
     // Test zero-rotation with symbolic value
     let x = context.bvs("x", 4)?;
-    let zero = context.bvv_prim_with_size(0u64, 4)?;
+    let zero = context.bvv(BitVec::from((0u64, 4)))?;
     let result = context.rotate_left(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -866,9 +866,9 @@ fn test_rotate_right() -> Result<()> {
     ];
 
     for (a, b, expected) in table {
-        let a = context.bvv_prim_with_size(a, 4).unwrap();
-        let b = context.bvv_prim_with_size(b, 4).unwrap();
-        let expected = context.bvv_prim_with_size(expected, 4).unwrap();
+        let a = context.bvv(BitVec::from((a, 4))).unwrap();
+        let b = context.bvv(BitVec::from((b, 4))).unwrap();
+        let expected = context.bvv(BitVec::from((expected, 4))).unwrap();
 
         let result = context.rotate_right(&a, &b)?.simplify()?;
         assert_eq!(result, expected);
@@ -876,7 +876,7 @@ fn test_rotate_right() -> Result<()> {
 
     // Test zero-rotation with symbolic value
     let x = context.bvs("x", 4)?;
-    let zero = context.bvv_prim_with_size(0u64, 4)?;
+    let zero = context.bvv(BitVec::from((0u64, 4)))?;
     let result = context.rotate_right(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -888,7 +888,7 @@ fn test_extract() -> Result<()> {
     let ctx = Context::new();
 
     // Whole bitvector, concrete
-    let bv = ctx.bvv_prim(0x1234_5678_9ABC_DEF0_u64).unwrap();
+    let bv = ctx.bvv(BitVec::from((0x1234_5678_9ABC_DEF0_u64, 64))).unwrap();
     let extract = ctx.extract(&bv, 63, 0)?.simplify()?;
     assert_eq!(extract, bv);
 
@@ -899,7 +899,7 @@ fn test_extract() -> Result<()> {
 
     // Partial extraction, concrete
     let extract = ctx.extract(&bv, 63, 32)?.simplify()?;
-    let expected = ctx.bvv_prim(0x1234_5678_u32).unwrap();
+    let expected = ctx.bvv(BitVec::from((0x1234_5678_u64, 32))).unwrap();
     assert_eq!(extract, expected);
 
     Ok(())
@@ -937,9 +937,9 @@ fn test_identity_simplifications() -> anyhow::Result<()> {
 
     let x = ctx.bvs("x", 64)?;
 
-    let zero = ctx.bvv_prim(0u64)?;
-    let one = ctx.bvv_prim(1u64)?;
-    let all_ones = ctx.bvv_prim(u64::MAX)?;
+    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
+    let one = ctx.bvv(BitVec::from((1u64, 64)))?;
+    let all_ones = ctx.bvv(BitVec::from((u64::MAX, 64)))?;
 
     // AND identities
     let simplified = ctx.and2(&x, &zero)?.simplify()?;
@@ -1025,8 +1025,8 @@ fn test_bitvec_not_identities() -> Result<()> {
 
     let x = ctx.bvs("x", 64)?;
     let not_x = ctx.not(&x)?;
-    let zero = ctx.bvv_prim(0u64)?;
-    let all_ones = ctx.bvv_prim(u64::MAX)?;
+    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
+    let all_ones = ctx.bvv(BitVec::from((u64::MAX, 64)))?;
 
     // x & ¬x = 0
     let simplified = ctx.and2(&x, &not_x)?.simplify()?;
@@ -1058,7 +1058,7 @@ fn test_extract_full_width() -> Result<()> {
     assert_eq!(simplified, bvs);
 
     // Test extracting full width of a BVV
-    let bvv = ctx.bvv_prim(42u32)?;
+    let bvv = ctx.bvv(BitVec::from((42u64, 32)))?;
     let extract_full_bvv = ctx.extract(&bvv, 31, 0)?;
     let simplified_bvv = extract_full_bvv.simplify()?;
 

--- a/crates/clarirs_core/src/algorithms/simplify/test_bv.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/test_bv.rs
@@ -527,7 +527,7 @@ fn test_shl() -> Result<()> {
 
     // Test zero-shift with symbolic value
     let x = ctx.bvs("x", 64)?;
-    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
+    let zero = ctx.bvv(BitVec::from((0, 64)))?;
     let result = ctx.shl(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -578,7 +578,7 @@ fn test_lshr() -> Result<()> {
 
     // Test zero-shift with symbolic value
     let x = ctx.bvs("x", 64)?;
-    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
+    let zero = ctx.bvv(BitVec::from((0, 64)))?;
     let result = ctx.lshr(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -629,7 +629,7 @@ fn test_ashr() -> Result<()> {
 
     // Test zero-shift with symbolic value
     let x = ctx.bvs("x", 64)?;
-    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
+    let zero = ctx.bvv(BitVec::from((0, 64)))?;
     let result = ctx.ashr(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -642,24 +642,24 @@ fn test_zext() -> Result<()> {
 
     let table = vec![
         (
-            ctx.bvv(BitVec::from((0u64, 4)))?,
+            ctx.bvv(BitVec::from((0, 4)))?,
             0,
-            ctx.bvv(BitVec::from((0u64, 4)))?,
+            ctx.bvv(BitVec::from((0, 4)))?,
         ),
         (
-            ctx.bvv(BitVec::from((0u64, 4)))?,
+            ctx.bvv(BitVec::from((0, 4)))?,
             1,
-            ctx.bvv(BitVec::from((0u64, 5)))?,
+            ctx.bvv(BitVec::from((0, 5)))?,
         ),
         (
-            ctx.bvv(BitVec::from((1u64, 4)))?,
+            ctx.bvv(BitVec::from((1, 4)))?,
             0,
-            ctx.bvv(BitVec::from((1u64, 4)))?,
+            ctx.bvv(BitVec::from((1, 4)))?,
         ),
         (
-            ctx.bvv(BitVec::from((1u64, 4)))?,
+            ctx.bvv(BitVec::from((1, 4)))?,
             1,
-            ctx.bvv(BitVec::from((1u64, 5)))?,
+            ctx.bvv(BitVec::from((1, 5)))?,
         ),
     ];
 
@@ -676,54 +676,54 @@ fn test_sext() -> Result<()> {
 
     let table = vec![
         (
-            ctx.bvv(BitVec::from((0u64, 4)))?,
+            ctx.bvv(BitVec::from((0, 4)))?,
             0,
-            ctx.bvv(BitVec::from((0u64, 4)))?,
+            ctx.bvv(BitVec::from((0, 4)))?,
         ),
         (
-            ctx.bvv(BitVec::from((0u64, 4)))?,
+            ctx.bvv(BitVec::from((0, 4)))?,
             1,
-            ctx.bvv(BitVec::from((0u64, 5)))?,
+            ctx.bvv(BitVec::from((0, 5)))?,
         ),
         (
-            ctx.bvv(BitVec::from((1u64, 4)))?,
+            ctx.bvv(BitVec::from((1, 4)))?,
             0,
-            ctx.bvv(BitVec::from((1u64, 4)))?,
+            ctx.bvv(BitVec::from((1, 4)))?,
         ),
         (
-            ctx.bvv(BitVec::from((1u64, 4)))?,
+            ctx.bvv(BitVec::from((1, 4)))?,
             1,
-            ctx.bvv(BitVec::from((1u64, 5)))?,
+            ctx.bvv(BitVec::from((1, 5)))?,
         ),
         (
-            ctx.bvv(BitVec::from((15u64, 4)))?,
+            ctx.bvv(BitVec::from((15, 4)))?,
             0,
-            ctx.bvv(BitVec::from((15u64, 4)))?,
+            ctx.bvv(BitVec::from((15, 4)))?,
         ),
         (
-            ctx.bvv(BitVec::from((15u64, 4)))?,
+            ctx.bvv(BitVec::from((15, 4)))?,
             1,
-            ctx.bvv(BitVec::from((31u64, 5)))?,
+            ctx.bvv(BitVec::from((31, 5)))?,
         ),
         (
-            ctx.bvv(BitVec::from((0u64, 1)))?,
+            ctx.bvv(BitVec::from((0, 1)))?,
             1,
-            ctx.bvv(BitVec::from((0u64, 2)))?,
+            ctx.bvv(BitVec::from((0, 2)))?,
         ),
         (
-            ctx.bvv(BitVec::from((1u64, 1)))?,
+            ctx.bvv(BitVec::from((1, 1)))?,
             1,
-            ctx.bvv(BitVec::from((3u64, 2)))?,
+            ctx.bvv(BitVec::from((3, 2)))?,
         ),
         (
-            ctx.bvv(BitVec::from((8u64, 4)))?,
+            ctx.bvv(BitVec::from((8, 4)))?,
             4,
-            ctx.bvv(BitVec::from((248u64, 8)))?,
+            ctx.bvv(BitVec::from((248, 8)))?,
         ),
         (
-            ctx.bvv(BitVec::from((5u64, 4)))?,
+            ctx.bvv(BitVec::from((5, 4)))?,
             4,
-            ctx.bvv(BitVec::from((5u64, 8)))?,
+            ctx.bvv(BitVec::from((5, 8)))?,
         ),
     ];
 
@@ -829,7 +829,7 @@ fn test_rotate_left() -> Result<()> {
 
     // Test zero-rotation with symbolic value
     let x = context.bvs("x", 4)?;
-    let zero = context.bvv(BitVec::from((0u64, 4)))?;
+    let zero = context.bvv(BitVec::from((0, 4)))?;
     let result = context.rotate_left(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -876,7 +876,7 @@ fn test_rotate_right() -> Result<()> {
 
     // Test zero-rotation with symbolic value
     let x = context.bvs("x", 4)?;
-    let zero = context.bvv(BitVec::from((0u64, 4)))?;
+    let zero = context.bvv(BitVec::from((0, 4)))?;
     let result = context.rotate_right(&x, &zero)?.simplify()?;
     assert_eq!(result, x);
 
@@ -888,7 +888,7 @@ fn test_extract() -> Result<()> {
     let ctx = Context::new();
 
     // Whole bitvector, concrete
-    let bv = ctx.bvv(BitVec::from((0x1234_5678_9ABC_DEF0_u64, 64))).unwrap();
+    let bv = ctx.bvv(BitVec::from((0x1234_5678_9ABC_DEF0_, 64))).unwrap();
     let extract = ctx.extract(&bv, 63, 0)?.simplify()?;
     assert_eq!(extract, bv);
 
@@ -899,7 +899,7 @@ fn test_extract() -> Result<()> {
 
     // Partial extraction, concrete
     let extract = ctx.extract(&bv, 63, 32)?.simplify()?;
-    let expected = ctx.bvv(BitVec::from((0x1234_5678_u64, 32))).unwrap();
+    let expected = ctx.bvv(BitVec::from((0x1234_5678_, 32))).unwrap();
     assert_eq!(extract, expected);
 
     Ok(())
@@ -937,8 +937,8 @@ fn test_identity_simplifications() -> anyhow::Result<()> {
 
     let x = ctx.bvs("x", 64)?;
 
-    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
-    let one = ctx.bvv(BitVec::from((1u64, 64)))?;
+    let zero = ctx.bvv(BitVec::from((0, 64)))?;
+    let one = ctx.bvv(BitVec::from((1, 64)))?;
     let all_ones = ctx.bvv(BitVec::from((u64::MAX, 64)))?;
 
     // AND identities
@@ -1025,7 +1025,7 @@ fn test_bitvec_not_identities() -> Result<()> {
 
     let x = ctx.bvs("x", 64)?;
     let not_x = ctx.not(&x)?;
-    let zero = ctx.bvv(BitVec::from((0u64, 64)))?;
+    let zero = ctx.bvv(BitVec::from((0, 64)))?;
     let all_ones = ctx.bvv(BitVec::from((u64::MAX, 64)))?;
 
     // x & ¬x = 0
@@ -1058,7 +1058,7 @@ fn test_extract_full_width() -> Result<()> {
     assert_eq!(simplified, bvs);
 
     // Test extracting full width of a BVV
-    let bvv = ctx.bvv(BitVec::from((42u64, 32)))?;
+    let bvv = ctx.bvv(BitVec::from((42, 32)))?;
     let extract_full_bvv = ctx.extract(&bvv, 31, 0)?;
     let simplified_bvv = extract_full_bvv.simplify()?;
 

--- a/crates/clarirs_core/src/ast/factory.rs
+++ b/crates/clarirs_core/src/ast/factory.rs
@@ -747,7 +747,8 @@ pub trait AstFactory<'c>: Sized {
     }
 
     fn bvv_prim<T: Into<u64>>(&'c self, value: T) -> Result<AstRef<'c>, ClarirsError> {
-        self.bvv(BitVec::from_prim(value)?)
+        let length = (std::mem::size_of::<T>() * 8) as u32;
+        self.bvv(BitVec::from((value.into(), length)))
     }
 
     fn bvv_prim_with_size<T: Into<u64>>(
@@ -755,7 +756,7 @@ pub trait AstFactory<'c>: Sized {
         value: T,
         length: u32,
     ) -> Result<AstRef<'c>, ClarirsError> {
-        self.bvv(BitVec::from_prim_with_size(value, length)?)
+        self.bvv(BitVec::from((value.into(), length)))
     }
 
     fn bvv_from_biguint_with_size(
@@ -763,7 +764,7 @@ pub trait AstFactory<'c>: Sized {
         value: &BigUint,
         length: u32,
     ) -> Result<AstRef<'c>, ClarirsError> {
-        self.bvv(BitVec::from_biguint(value, length))
+        self.bvv(BitVec::from((value.clone(), length)))
     }
 
     fn fpv_from_f64(&'c self, value: f64) -> Result<AstRef<'c>, ClarirsError> {

--- a/crates/clarirs_core/src/ast/factory.rs
+++ b/crates/clarirs_core/src/ast/factory.rs
@@ -746,27 +746,6 @@ pub trait AstFactory<'c>: Sized {
         self.boolv(false)
     }
 
-    fn bvv_prim<T: Into<u64>>(&'c self, value: T) -> Result<AstRef<'c>, ClarirsError> {
-        let length = (std::mem::size_of::<T>() * 8) as u32;
-        self.bvv(BitVec::from((value.into(), length)))
-    }
-
-    fn bvv_prim_with_size<T: Into<u64>>(
-        &'c self,
-        value: T,
-        length: u32,
-    ) -> Result<AstRef<'c>, ClarirsError> {
-        self.bvv(BitVec::from((value.into(), length)))
-    }
-
-    fn bvv_from_biguint_with_size(
-        &'c self,
-        value: &BigUint,
-        length: u32,
-    ) -> Result<AstRef<'c>, ClarirsError> {
-        self.bvv(BitVec::from((value.clone(), length)))
-    }
-
     fn fpv_from_f64(&'c self, value: f64) -> Result<AstRef<'c>, ClarirsError> {
         self.fpv(Float::from(value))
     }

--- a/crates/clarirs_core/src/cache.rs
+++ b/crates/clarirs_core/src/cache.rs
@@ -156,7 +156,7 @@ mod tests {
         let cache = AstCache::default();
 
         // Create a simple AST
-        let ast1 = ctx.bvv_prim_with_size(42u64, 64)?;
+        let ast1 = ctx.bvv(BitVec::from((42u64, 64)))?;
         let hash1 = 12345u64; // Arbitrary hash for testing
 
         // Insert into cache
@@ -177,14 +177,14 @@ mod tests {
         let cache = AstCache::default();
 
         // Create a simple AST
-        let ast1 = ctx.bvv_prim_with_size(42u64, 64)?;
+        let ast1 = ctx.bvv(BitVec::from((42u64, 64)))?;
         let hash1 = 12345u64; // Arbitrary hash for testing
 
         // Insert into cache
         let result1 = cache.get_or_insert::<ClarirsError>(hash1, || Ok(ast1.clone()))?;
 
         // In collision mode, it will always recompute, so provide a valid computation
-        let ast2 = ctx.bvv_prim_with_size(42u64, 64)?;
+        let ast2 = ctx.bvv(BitVec::from((42u64, 64)))?;
         let result2 = cache.get_or_insert::<ClarirsError>(hash1, || Ok(ast2.clone()))?;
         assert_eq!(result1, result2);
         Ok(())
@@ -195,8 +195,8 @@ mod tests {
         let ctx = crate::context::Context::new();
         let cache = AstCache::default();
 
-        let ast1 = ctx.bvv_prim_with_size(42u64, 64)?;
-        let ast2 = ctx.bvv_prim_with_size(99u64, 64)?;
+        let ast1 = ctx.bvv(BitVec::from((42u64, 64)))?;
+        let ast2 = ctx.bvv(BitVec::from((99u64, 64)))?;
 
         let result1 = cache.get_or_insert::<ClarirsError>(1, || Ok(ast1.clone()))?;
         let result2 = cache.get_or_insert::<ClarirsError>(2, || Ok(ast2.clone()))?;
@@ -215,14 +215,14 @@ mod tests {
 
         {
             // Create and cache an AST
-            let ast = ctx.bvv_prim_with_size(42u64, 64)?;
+            let ast = ctx.bvv(BitVec::from((42u64, 64)))?;
             let _result = cache.get_or_insert::<ClarirsError>(hash, || Ok(ast.clone()))?;
             // ast and _result go out of scope here
         }
 
         // The weak reference should be expired now, so this should compute a new value
         let mut computed = false;
-        let ast2 = ctx.bvv_prim_with_size(42u64, 64)?;
+        let ast2 = ctx.bvv(BitVec::from((42u64, 64)))?;
         let _result = cache.get_or_insert::<ClarirsError>(hash, || {
             computed = true;
             Ok(ast2.clone())
@@ -245,13 +245,13 @@ mod tests {
         let hash = 777u64;
 
         // Insert first value
-        let ast1 = ctx.bvv_prim_with_size(42u64, 64).unwrap();
+        let ast1 = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
         let _ = cache
             .get_or_insert::<ClarirsError>(hash, || Ok(ast1.clone()))
             .unwrap();
 
         // Try to insert different value with same hash - should panic
-        let ast2 = ctx.bvv_prim_with_size(99u64, 64).unwrap();
+        let ast2 = ctx.bvv(BitVec::from((99u64, 64))).unwrap();
         let _ = cache
             .get_or_insert::<ClarirsError>(hash, || Ok(ast2.clone()))
             .unwrap();
@@ -265,11 +265,11 @@ mod tests {
         let hash = 888u64;
 
         // Insert first value
-        let ast1 = ctx.bvv_prim_with_size(42u64, 64)?;
+        let ast1 = ctx.bvv(BitVec::from((42u64, 64)))?;
         let result1 = cache.get_or_insert::<ClarirsError>(hash, || Ok(ast1.clone()))?;
 
         // Insert same value with same hash - should be fine
-        let ast2 = ctx.bvv_prim_with_size(42u64, 64)?;
+        let ast2 = ctx.bvv(BitVec::from((42u64, 64)))?;
         let result2 = cache.get_or_insert::<ClarirsError>(hash, || Ok(ast2.clone()))?;
 
         assert_eq!(result1, result2);
@@ -284,14 +284,14 @@ mod tests {
         let hash = 999u64;
 
         // Insert first value
-        let ast1 = ctx.bvv_prim_with_size(42u64, 64).unwrap();
+        let ast1 = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
         let _ = cache
             .get_or_insert::<ClarirsError>(hash, || Ok(ast1.clone()))
             .unwrap();
 
         // This should always compute, even though the value is in cache
         let mut computed = false;
-        let ast2 = ctx.bvv_prim_with_size(42u64, 64).unwrap();
+        let ast2 = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
         let _ = cache
             .get_or_insert::<ClarirsError>(hash, || {
                 computed = true;

--- a/crates/clarirs_core/src/cache.rs
+++ b/crates/clarirs_core/src/cache.rs
@@ -156,7 +156,7 @@ mod tests {
         let cache = AstCache::default();
 
         // Create a simple AST
-        let ast1 = ctx.bvv(BitVec::from((42u64, 64)))?;
+        let ast1 = ctx.bvv(BitVec::from((42, 64)))?;
         let hash1 = 12345u64; // Arbitrary hash for testing
 
         // Insert into cache
@@ -177,14 +177,14 @@ mod tests {
         let cache = AstCache::default();
 
         // Create a simple AST
-        let ast1 = ctx.bvv(BitVec::from((42u64, 64)))?;
+        let ast1 = ctx.bvv(BitVec::from((42, 64)))?;
         let hash1 = 12345u64; // Arbitrary hash for testing
 
         // Insert into cache
         let result1 = cache.get_or_insert::<ClarirsError>(hash1, || Ok(ast1.clone()))?;
 
         // In collision mode, it will always recompute, so provide a valid computation
-        let ast2 = ctx.bvv(BitVec::from((42u64, 64)))?;
+        let ast2 = ctx.bvv(BitVec::from((42, 64)))?;
         let result2 = cache.get_or_insert::<ClarirsError>(hash1, || Ok(ast2.clone()))?;
         assert_eq!(result1, result2);
         Ok(())
@@ -195,8 +195,8 @@ mod tests {
         let ctx = crate::context::Context::new();
         let cache = AstCache::default();
 
-        let ast1 = ctx.bvv(BitVec::from((42u64, 64)))?;
-        let ast2 = ctx.bvv(BitVec::from((99u64, 64)))?;
+        let ast1 = ctx.bvv(BitVec::from((42, 64)))?;
+        let ast2 = ctx.bvv(BitVec::from((99, 64)))?;
 
         let result1 = cache.get_or_insert::<ClarirsError>(1, || Ok(ast1.clone()))?;
         let result2 = cache.get_or_insert::<ClarirsError>(2, || Ok(ast2.clone()))?;
@@ -215,14 +215,14 @@ mod tests {
 
         {
             // Create and cache an AST
-            let ast = ctx.bvv(BitVec::from((42u64, 64)))?;
+            let ast = ctx.bvv(BitVec::from((42, 64)))?;
             let _result = cache.get_or_insert::<ClarirsError>(hash, || Ok(ast.clone()))?;
             // ast and _result go out of scope here
         }
 
         // The weak reference should be expired now, so this should compute a new value
         let mut computed = false;
-        let ast2 = ctx.bvv(BitVec::from((42u64, 64)))?;
+        let ast2 = ctx.bvv(BitVec::from((42, 64)))?;
         let _result = cache.get_or_insert::<ClarirsError>(hash, || {
             computed = true;
             Ok(ast2.clone())
@@ -245,13 +245,13 @@ mod tests {
         let hash = 777u64;
 
         // Insert first value
-        let ast1 = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
+        let ast1 = ctx.bvv(BitVec::from((42, 64))).unwrap();
         let _ = cache
             .get_or_insert::<ClarirsError>(hash, || Ok(ast1.clone()))
             .unwrap();
 
         // Try to insert different value with same hash - should panic
-        let ast2 = ctx.bvv(BitVec::from((99u64, 64))).unwrap();
+        let ast2 = ctx.bvv(BitVec::from((99, 64))).unwrap();
         let _ = cache
             .get_or_insert::<ClarirsError>(hash, || Ok(ast2.clone()))
             .unwrap();
@@ -265,11 +265,11 @@ mod tests {
         let hash = 888u64;
 
         // Insert first value
-        let ast1 = ctx.bvv(BitVec::from((42u64, 64)))?;
+        let ast1 = ctx.bvv(BitVec::from((42, 64)))?;
         let result1 = cache.get_or_insert::<ClarirsError>(hash, || Ok(ast1.clone()))?;
 
         // Insert same value with same hash - should be fine
-        let ast2 = ctx.bvv(BitVec::from((42u64, 64)))?;
+        let ast2 = ctx.bvv(BitVec::from((42, 64)))?;
         let result2 = cache.get_or_insert::<ClarirsError>(hash, || Ok(ast2.clone()))?;
 
         assert_eq!(result1, result2);
@@ -284,14 +284,14 @@ mod tests {
         let hash = 999u64;
 
         // Insert first value
-        let ast1 = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
+        let ast1 = ctx.bvv(BitVec::from((42, 64))).unwrap();
         let _ = cache
             .get_or_insert::<ClarirsError>(hash, || Ok(ast1.clone()))
             .unwrap();
 
         // This should always compute, even though the value is in cache
         let mut computed = false;
-        let ast2 = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
+        let ast2 = ctx.bvv(BitVec::from((42, 64))).unwrap();
         let _ = cache
             .get_or_insert::<ClarirsError>(hash, || {
                 computed = true;

--- a/crates/clarirs_core/src/smtlib.rs
+++ b/crates/clarirs_core/src/smtlib.rs
@@ -300,7 +300,7 @@ mod tests {
         let x = ctx.bvs("x", 32).unwrap();
         assert_eq!(x.to_smtlib(), "x");
 
-        let v = ctx.bvv_prim(42u64).unwrap();
+        let v = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
         assert_eq!(v.to_smtlib(), "(_ bv42 64)");
     }
 

--- a/crates/clarirs_core/src/smtlib.rs
+++ b/crates/clarirs_core/src/smtlib.rs
@@ -300,7 +300,7 @@ mod tests {
         let x = ctx.bvs("x", 32).unwrap();
         assert_eq!(x.to_smtlib(), "x");
 
-        let v = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
+        let v = ctx.bvv(BitVec::from((42, 64))).unwrap();
         assert_eq!(v.to_smtlib(), "(_ bv42 64)");
     }
 

--- a/crates/clarirs_core/src/solver/concrete.rs
+++ b/crates/clarirs_core/src/solver/concrete.rs
@@ -104,8 +104,8 @@ mod tests {
 
         // BV tests
         assert!(
-            solver.eval(&context.add(&context.bvv(BitVec::from((1u64, 8)))?, &context.bvv(BitVec::from((1u64, 8)))?)?)?
-                == context.bvv(BitVec::from((2u64, 8)))?
+            solver.eval(&context.add(&context.bvv(BitVec::from((1, 8)))?, &context.bvv(BitVec::from((1, 8)))?)?)?
+                == context.bvv(BitVec::from((2, 8)))?
         );
         assert!(solver.eval(&context.bvs("test", 8)?).is_err());
 

--- a/crates/clarirs_core/src/solver/concrete.rs
+++ b/crates/clarirs_core/src/solver/concrete.rs
@@ -104,8 +104,8 @@ mod tests {
 
         // BV tests
         assert!(
-            solver.eval(&context.add(&context.bvv_prim(1u8)?, &context.bvv_prim(1u8)?)?)?
-                == context.bvv_prim(2u8)?
+            solver.eval(&context.add(&context.bvv(BitVec::from((1u64, 8)))?, &context.bvv(BitVec::from((1u64, 8)))?)?)?
+                == context.bvv(BitVec::from((2u64, 8)))?
         );
         assert!(solver.eval(&context.bvs("test", 8)?).is_err());
 

--- a/crates/clarirs_core/src/solver/hybrid.rs
+++ b/crates/clarirs_core/src/solver/hybrid.rs
@@ -210,11 +210,11 @@ mod tests {
         assert!(!solver.is_true(&f)?);
         assert!(!solver.is_false(&t)?);
 
-        let a = ctx.bvv_prim(10u8)?;
-        let b = ctx.bvv_prim(20u8)?;
+        let a = ctx.bvv(BitVec::from((10u64, 8)))?;
+        let b = ctx.bvv(BitVec::from((20u64, 8)))?;
         let sum = ctx.add(&a, &b)?;
         let result = solver.eval(&sum)?;
-        assert_eq!(result, ctx.bvv_prim(30u8)?);
+        assert_eq!(result, ctx.bvv(BitVec::from((30u64, 8)))?);
 
         assert!(solver.satisfiable()?);
 

--- a/crates/clarirs_core/src/solver/hybrid.rs
+++ b/crates/clarirs_core/src/solver/hybrid.rs
@@ -210,11 +210,11 @@ mod tests {
         assert!(!solver.is_true(&f)?);
         assert!(!solver.is_false(&t)?);
 
-        let a = ctx.bvv(BitVec::from((10u64, 8)))?;
-        let b = ctx.bvv(BitVec::from((20u64, 8)))?;
+        let a = ctx.bvv(BitVec::from((10, 8)))?;
+        let b = ctx.bvv(BitVec::from((20, 8)))?;
         let sum = ctx.add(&a, &b)?;
         let result = solver.eval(&sum)?;
-        assert_eq!(result, ctx.bvv(BitVec::from((30u64, 8)))?);
+        assert_eq!(result, ctx.bvv(BitVec::from((30, 8)))?);
 
         assert!(solver.satisfiable()?);
 

--- a/crates/clarirs_core/src/solver_mixins/concrete_early_resolution.rs
+++ b/crates/clarirs_core/src/solver_mixins/concrete_early_resolution.rs
@@ -280,7 +280,7 @@ mod tests {
         let mut solver = ConcreteEarlyResolutionMixin::new(panicking_solver);
 
         // Test concrete bitvec value - should NOT call underlying solver
-        let value = ctx.bvv_prim(42u64).unwrap();
+        let value = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
         let results = solver.eval_n(&value, 1).unwrap();
 
         assert_eq!(results.len(), 1);
@@ -295,7 +295,7 @@ mod tests {
         let mut solver = ConcreteEarlyResolutionMixin::new(panicking_solver);
 
         // For concrete values, min/max should return the value itself WITHOUT calling solver
-        let value = ctx.bvv_prim(42u64).unwrap();
+        let value = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
 
         let min = solver.min_unsigned(&value).unwrap();
         let max = solver.max_unsigned(&value).unwrap();
@@ -332,7 +332,7 @@ mod tests {
         let mut solver = ConcreteEarlyResolutionMixin::new(panicking_solver);
 
         // Test that requesting 0 results returns empty vec WITHOUT calling solver
-        let value = ctx.bvv_prim(42u64).unwrap();
+        let value = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
         let results = solver.eval_n(&value, 0).unwrap();
 
         assert_eq!(results.len(), 0);

--- a/crates/clarirs_core/src/solver_mixins/concrete_early_resolution.rs
+++ b/crates/clarirs_core/src/solver_mixins/concrete_early_resolution.rs
@@ -280,7 +280,7 @@ mod tests {
         let mut solver = ConcreteEarlyResolutionMixin::new(panicking_solver);
 
         // Test concrete bitvec value - should NOT call underlying solver
-        let value = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
+        let value = ctx.bvv(BitVec::from((42, 64))).unwrap();
         let results = solver.eval_n(&value, 1).unwrap();
 
         assert_eq!(results.len(), 1);
@@ -295,7 +295,7 @@ mod tests {
         let mut solver = ConcreteEarlyResolutionMixin::new(panicking_solver);
 
         // For concrete values, min/max should return the value itself WITHOUT calling solver
-        let value = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
+        let value = ctx.bvv(BitVec::from((42, 64))).unwrap();
 
         let min = solver.min_unsigned(&value).unwrap();
         let max = solver.max_unsigned(&value).unwrap();
@@ -332,7 +332,7 @@ mod tests {
         let mut solver = ConcreteEarlyResolutionMixin::new(panicking_solver);
 
         // Test that requesting 0 results returns empty vec WITHOUT calling solver
-        let value = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
+        let value = ctx.bvv(BitVec::from((42, 64))).unwrap();
         let results = solver.eval_n(&value, 0).unwrap();
 
         assert_eq!(results.len(), 0);

--- a/crates/clarirs_core/src/solver_mixins/replacement.rs
+++ b/crates/clarirs_core/src/solver_mixins/replacement.rs
@@ -207,7 +207,7 @@ mod tests {
         let mut solver = ReplacementSolver::new(inner);
 
         let x = ctx.bvs("x", 8)?;
-        let five = ctx.bvv(BitVec::from((5u64, 8)))?;
+        let five = ctx.bvv(BitVec::from((5, 8)))?;
 
         // Add explicit replacement: x -> 5
         solver.add_replacement(x.clone(), five.clone());
@@ -226,7 +226,7 @@ mod tests {
         let mut solver = ReplacementSolver::new(inner);
 
         let x = ctx.bvs("x", 8)?;
-        let five = ctx.bvv(BitVec::from((5u64, 8)))?;
+        let five = ctx.bvv(BitVec::from((5, 8)))?;
 
         // Add constraint: x == 5 (should auto-extract replacement)
         let eq_constraint = ctx.eq_(&x, &five)?;
@@ -246,8 +246,8 @@ mod tests {
         let mut solver = ReplacementSolver::new(inner);
 
         let x = ctx.bvs("x", 8)?;
-        let five = ctx.bvv(BitVec::from((5u64, 8)))?;
-        let three = ctx.bvv(BitVec::from((3u64, 8)))?;
+        let five = ctx.bvv(BitVec::from((5, 8)))?;
+        let three = ctx.bvv(BitVec::from((3, 8)))?;
 
         // Replace x with 5
         solver.add_replacement(x.clone(), five.clone());
@@ -255,7 +255,7 @@ mod tests {
         // Evaluating x + 3 should return 8
         let expr = ctx.add(&x, &three)?;
         let result = solver.eval(&expr)?;
-        let expected = ctx.bvv(BitVec::from((8u64, 8)))?;
+        let expected = ctx.bvv(BitVec::from((8, 8)))?;
         assert_eq!(result, expected);
 
         Ok(())
@@ -268,7 +268,7 @@ mod tests {
         let mut solver = ReplacementSolver::new(inner);
 
         let x = ctx.bvs("x", 8)?;
-        let five = ctx.bvv(BitVec::from((5u64, 8)))?;
+        let five = ctx.bvv(BitVec::from((5, 8)))?;
 
         solver.add_replacement(x.clone(), five.clone());
         assert!(!solver.replacements().is_empty());

--- a/crates/clarirs_core/src/solver_mixins/replacement.rs
+++ b/crates/clarirs_core/src/solver_mixins/replacement.rs
@@ -207,7 +207,7 @@ mod tests {
         let mut solver = ReplacementSolver::new(inner);
 
         let x = ctx.bvs("x", 8)?;
-        let five = ctx.bvv_prim(5u8)?;
+        let five = ctx.bvv(BitVec::from((5u64, 8)))?;
 
         // Add explicit replacement: x -> 5
         solver.add_replacement(x.clone(), five.clone());
@@ -226,7 +226,7 @@ mod tests {
         let mut solver = ReplacementSolver::new(inner);
 
         let x = ctx.bvs("x", 8)?;
-        let five = ctx.bvv_prim(5u8)?;
+        let five = ctx.bvv(BitVec::from((5u64, 8)))?;
 
         // Add constraint: x == 5 (should auto-extract replacement)
         let eq_constraint = ctx.eq_(&x, &five)?;
@@ -246,8 +246,8 @@ mod tests {
         let mut solver = ReplacementSolver::new(inner);
 
         let x = ctx.bvs("x", 8)?;
-        let five = ctx.bvv_prim(5u8)?;
-        let three = ctx.bvv_prim(3u8)?;
+        let five = ctx.bvv(BitVec::from((5u64, 8)))?;
+        let three = ctx.bvv(BitVec::from((3u64, 8)))?;
 
         // Replace x with 5
         solver.add_replacement(x.clone(), five.clone());
@@ -255,7 +255,7 @@ mod tests {
         // Evaluating x + 3 should return 8
         let expr = ctx.add(&x, &three)?;
         let result = solver.eval(&expr)?;
-        let expected = ctx.bvv_prim(8u8)?;
+        let expected = ctx.bvv(BitVec::from((8u64, 8)))?;
         assert_eq!(result, expected);
 
         Ok(())
@@ -268,7 +268,7 @@ mod tests {
         let mut solver = ReplacementSolver::new(inner);
 
         let x = ctx.bvs("x", 8)?;
-        let five = ctx.bvv_prim(5u8)?;
+        let five = ctx.bvv(BitVec::from((5u64, 8)))?;
 
         solver.add_replacement(x.clone(), five.clone());
         assert!(!solver.replacements().is_empty());

--- a/crates/clarirs_core/src/solver_mixins/simplification.rs
+++ b/crates/clarirs_core/src/solver_mixins/simplification.rs
@@ -111,7 +111,7 @@ mod tests {
         let mut solver = SimplificationMixin::new(base_solver);
 
         // Create an expression that needs simplification: 5 & 5 (should simplify to 5)
-        let five = ctx.bvv_prim(5u64).unwrap();
+        let five = ctx.bvv(BitVec::from((5u64, 64))).unwrap();
         let and_expr = ctx.and2(&five, &five).unwrap();
 
         // The mixin should simplify this to just 5 before evaluation

--- a/crates/clarirs_core/src/solver_mixins/simplification.rs
+++ b/crates/clarirs_core/src/solver_mixins/simplification.rs
@@ -111,7 +111,7 @@ mod tests {
         let mut solver = SimplificationMixin::new(base_solver);
 
         // Create an expression that needs simplification: 5 & 5 (should simplify to 5)
-        let five = ctx.bvv(BitVec::from((5u64, 64))).unwrap();
+        let five = ctx.bvv(BitVec::from((5, 64))).unwrap();
         let and_expr = ctx.and2(&five, &five).unwrap();
 
         // The mixin should simplify this to just 5 before evaluation

--- a/crates/clarirs_num/src/bitvec.rs
+++ b/crates/clarirs_num/src/bitvec.rs
@@ -10,11 +10,9 @@ mod reference_tests;
 mod tests;
 
 use std::fmt::Debug;
-use std::mem::size_of;
 
-use num_bigint::{BigInt, BigUint, Sign};
+use num_bigint::{BigInt, BigUint};
 use num_traits::cast::ToPrimitive;
-use num_traits::{Num, Zero};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -94,72 +92,12 @@ impl BitVec {
         }
     }
 
-    // From Conversions
-
-    pub fn from_prim<T>(value: T) -> Result<Self, BitVecError>
-    where
-        T: Into<u64>,
-    {
-        Self::from_prim_with_size(value, (size_of::<T>() * 8) as u32)
-    }
-
-    pub fn from_prim_with_size<T>(value: T, length: u32) -> Result<Self, BitVecError>
-    where
-        T: Into<u64>,
-    {
-        let value_u64: u64 = value.into();
-
-        // Truncate the value to fit within the given length
-        let truncated_value = if length < 64 {
-            value_u64 & ((1u64 << length) - 1)
-        } else {
-            value_u64
-        };
-
-        let mut words = SmallVec::new();
-        words.push(truncated_value);
-        Self::new(words, length)
-    }
-
-    /// Builds a `BitVec` of `length` bits from `value`, truncating to the low
-    /// `length` bits. Infallible: any `BigUint` maps onto `length` bits.
-    pub fn from_biguint(value: &BigUint, length: u32) -> BitVec {
-        let truncated = if value.bits() as u32 > length {
-            value % (BigUint::from(1u8) << length)
-        } else {
-            value.clone()
-        };
-
-        // A zero value yields an empty digit list, which `new` pads out.
-        let digits: SmallVec<[u64; 1]> = truncated.iter_u64_digits().collect();
-        BitVec::new(digits, length).expect("BitVec::new is infallible")
-    }
-
     /// Creates a `BitVec` from a big-endian byte slice with bit-width equal to the
     /// slice length times eight.
     pub fn from_bytes_be(bytes: &[u8]) -> BitVec {
         let length = (bytes.len() as u32) * 8;
         let big_uint = BigUint::from_bytes_be(bytes);
-        BitVec::from_biguint(&big_uint, length)
-    }
-
-    /// Builds a `BitVec` of `length` bits from a signed `value`, using two's
-    /// complement and truncating to `length` bits. Infallible.
-    pub fn from_bigint(value: &BigInt, length: u32) -> BitVec {
-        let big_uint = if value.sign() == Sign::Minus {
-            // For negative values, compute 2's complement: 2^length - (|value| % 2^length)
-            let modulus = BigUint::from(1u8) << length;
-            let truncated_magnitude = value.magnitude() % &modulus;
-            if truncated_magnitude.is_zero() {
-                BigUint::zero()
-            } else {
-                &modulus - truncated_magnitude
-            }
-        } else {
-            // For positive values, truncate the magnitude
-            value.magnitude() % (BigUint::from(1u8) << length)
-        };
-        BitVec::from_biguint(&big_uint, length)
+        BitVec::from((big_uint, length))
     }
 
     pub fn to_biguint(&self) -> BigUint {
@@ -185,11 +123,6 @@ impl BitVec {
         } else {
             magnitude
         }
-    }
-
-    pub fn from_str(s: &str, length: u32) -> Result<BitVec, BitVecError> {
-        let value = BigUint::from_str_radix(s, 10).map_err(|_| BitVecError::ConversionError)?;
-        Ok(BitVec::from_biguint(&value, length))
     }
 
     #[allow(clippy::len_without_is_empty)]
@@ -433,7 +366,7 @@ impl BitVec {
 
     // Creates and returns a BitVec with these one-filled words.
     pub fn ones(length: u32) -> BitVec {
-        BitVec::from_biguint(&((BigUint::one() << length) - 1u8), length)
+        BitVec::from(((BigUint::one() << length) - 1u8, length))
     }
 }
 
@@ -449,6 +382,7 @@ impl Debug for BitVec {
 #[cfg(test)]
 mod is_mask_tests {
     use super::*;
+    use num_traits::Zero;
 
     #[test]
     fn test_is_mask_all_zeros() {
@@ -477,63 +411,63 @@ mod is_mask_tests {
     #[test]
     fn test_is_mask_single_bit() {
         // Single bit at position 0
-        let bv = BitVec::from_prim_with_size(1u8, 8).unwrap();
+        let bv = BitVec::from((1u64, 8));
         assert_eq!(bv.is_mask(), Some((0, 0)));
 
         // Single bit at position 3
-        let bv = BitVec::from_prim_with_size(0b1000u8, 8).unwrap();
+        let bv = BitVec::from((0b1000u64, 8));
         assert_eq!(bv.is_mask(), Some((3, 3)));
 
         // Single bit at position 7
-        let bv = BitVec::from_prim_with_size(0b10000000u8, 8).unwrap();
+        let bv = BitVec::from((0b10000000u64, 8));
         assert_eq!(bv.is_mask(), Some((7, 7)));
     }
 
     #[test]
     fn test_is_mask_consecutive_low() {
         // Consecutive 1s at low end: 0b00001111
-        let bv = BitVec::from_prim_with_size(0x0Fu8, 8).unwrap();
+        let bv = BitVec::from((0x0Fu64, 8));
         assert_eq!(bv.is_mask(), Some((3, 0)));
 
         // Consecutive 1s at low end: 0b00000111
-        let bv = BitVec::from_prim_with_size(0x07u8, 8).unwrap();
+        let bv = BitVec::from((0x07u64, 8));
         assert_eq!(bv.is_mask(), Some((2, 0)));
     }
 
     #[test]
     fn test_is_mask_consecutive_high() {
         // Consecutive 1s at high end: 0b11110000
-        let bv = BitVec::from_prim_with_size(0xF0u8, 8).unwrap();
+        let bv = BitVec::from((0xF0u64, 8));
         assert_eq!(bv.is_mask(), Some((7, 4)));
 
         // Consecutive 1s at high end: 0b11100000
-        let bv = BitVec::from_prim_with_size(0xE0u8, 8).unwrap();
+        let bv = BitVec::from((0xE0u64, 8));
         assert_eq!(bv.is_mask(), Some((7, 5)));
     }
 
     #[test]
     fn test_is_mask_consecutive_middle() {
         // Consecutive 1s in middle: 0b00111100
-        let bv = BitVec::from_prim_with_size(0x3Cu8, 8).unwrap();
+        let bv = BitVec::from((0x3Cu64, 8));
         assert_eq!(bv.is_mask(), Some((5, 2)));
 
         // Consecutive 1s in middle: 0b01111110
-        let bv = BitVec::from_prim_with_size(0x7Eu8, 8).unwrap();
+        let bv = BitVec::from((0x7Eu64, 8));
         assert_eq!(bv.is_mask(), Some((6, 1)));
     }
 
     #[test]
     fn test_is_mask_non_consecutive() {
         // Non-consecutive: 0b10101010
-        let bv = BitVec::from_prim_with_size(0xAAu8, 8).unwrap();
+        let bv = BitVec::from((0xAAu64, 8));
         assert_eq!(bv.is_mask(), None);
 
         // Non-consecutive: 0b11011011
-        let bv = BitVec::from_prim_with_size(0xDBu8, 8).unwrap();
+        let bv = BitVec::from((0xDBu64, 8));
         assert_eq!(bv.is_mask(), None);
 
         // Gap in middle: 0b11100111
-        let bv = BitVec::from_prim_with_size(0xE7u8, 8).unwrap();
+        let bv = BitVec::from((0xE7u64, 8));
         assert_eq!(bv.is_mask(), None);
     }
 
@@ -545,14 +479,14 @@ mod is_mask_tests {
         for i in 60..=67 {
             value |= BigUint::one() << i;
         }
-        let bv = BitVec::from_biguint(&value, 128);
+        let bv = BitVec::from((value, 128));
         assert_eq!(bv.is_mask(), Some((67, 60)));
 
         // Create a non-consecutive pattern across boundary
         let mut value = BigUint::zero();
         value |= BigUint::one() << 63; // Last bit of first word
         value |= BigUint::one() << 65; // Skip bit 64, non-consecutive
-        let bv = BitVec::from_biguint(&value, 128);
+        let bv = BitVec::from((value, 128));
         assert_eq!(bv.is_mask(), None);
     }
 
@@ -563,7 +497,7 @@ mod is_mask_tests {
         for i in 0..32 {
             value |= BigUint::one() << i;
         }
-        let bv = BitVec::from_biguint(&value, 256);
+        let bv = BitVec::from((value, 256));
         assert_eq!(bv.is_mask(), Some((31, 0)));
 
         // Large BitVec with mask at end
@@ -571,7 +505,7 @@ mod is_mask_tests {
         for i in 224..256 {
             value |= BigUint::one() << i;
         }
-        let bv = BitVec::from_biguint(&value, 256);
+        let bv = BitVec::from((value, 256));
         assert_eq!(bv.is_mask(), Some((255, 224)));
 
         // Large BitVec with mask in middle
@@ -579,7 +513,7 @@ mod is_mask_tests {
         for i in 100..150 {
             value |= BigUint::one() << i;
         }
-        let bv = BitVec::from_biguint(&value, 256);
+        let bv = BitVec::from((value, 256));
         assert_eq!(bv.is_mask(), Some((149, 100)));
     }
 
@@ -590,30 +524,30 @@ mod is_mask_tests {
         assert_eq!(bv.is_mask(), None);
 
         // 1-bit BitVec with 0
-        let bv = BitVec::from_prim_with_size(0u8, 1).unwrap();
+        let bv = BitVec::from((0u64, 1));
         assert_eq!(bv.is_mask(), None);
 
         // 1-bit BitVec with 1
-        let bv = BitVec::from_prim_with_size(1u8, 1).unwrap();
+        let bv = BitVec::from((1u64, 1));
         assert_eq!(bv.is_mask(), Some((0, 0)));
 
         // Exactly 64 bits, all ones
-        let bv = BitVec::from_prim_with_size(u64::MAX, 64).unwrap();
+        let bv = BitVec::from((u64::MAX, 64));
         assert_eq!(bv.is_mask(), Some((63, 0)));
 
         // Exactly 64 bits, mask in middle
-        let bv = BitVec::from_prim_with_size(0x00FFFF0000000000u64, 64).unwrap();
+        let bv = BitVec::from((0x00FFFF0000000000u64, 64));
         assert_eq!(bv.is_mask(), Some((55, 40)));
     }
 
     #[test]
     fn test_is_mask_non_byte_aligned() {
         // 7-bit BitVec, all ones
-        let bv = BitVec::from_prim_with_size(0x7Fu8, 7).unwrap();
+        let bv = BitVec::from((0x7Fu64, 7));
         assert_eq!(bv.is_mask(), Some((6, 0)));
 
         // 13-bit BitVec with mask
-        let bv = BitVec::from_prim_with_size(0x0FC0u16, 13).unwrap(); // bits 6-11 set
+        let bv = BitVec::from((0x0FC0u64, 13)); // bits 6-11 set
         assert_eq!(bv.is_mask(), Some((11, 6)));
 
         // 100-bit BitVec with mask at high end
@@ -621,7 +555,7 @@ mod is_mask_tests {
         for i in 90..100 {
             value |= BigUint::one() << i;
         }
-        let bv = BitVec::from_biguint(&value, 100);
+        let bv = BitVec::from((value, 100));
         assert_eq!(bv.is_mask(), Some((99, 90)));
     }
 }

--- a/crates/clarirs_num/src/bitvec.rs
+++ b/crates/clarirs_num/src/bitvec.rs
@@ -403,63 +403,63 @@ mod is_mask_tests {
     #[test]
     fn test_is_mask_single_bit() {
         // Single bit at position 0
-        let bv = BitVec::from((1u64, 8));
+        let bv = BitVec::from((1, 8));
         assert_eq!(bv.is_mask(), Some((0, 0)));
 
         // Single bit at position 3
-        let bv = BitVec::from((0b1000u64, 8));
+        let bv = BitVec::from((0b1000, 8));
         assert_eq!(bv.is_mask(), Some((3, 3)));
 
         // Single bit at position 7
-        let bv = BitVec::from((0b10000000u64, 8));
+        let bv = BitVec::from((0b10000000, 8));
         assert_eq!(bv.is_mask(), Some((7, 7)));
     }
 
     #[test]
     fn test_is_mask_consecutive_low() {
         // Consecutive 1s at low end: 0b00001111
-        let bv = BitVec::from((0x0Fu64, 8));
+        let bv = BitVec::from((0x0F, 8));
         assert_eq!(bv.is_mask(), Some((3, 0)));
 
         // Consecutive 1s at low end: 0b00000111
-        let bv = BitVec::from((0x07u64, 8));
+        let bv = BitVec::from((0x07, 8));
         assert_eq!(bv.is_mask(), Some((2, 0)));
     }
 
     #[test]
     fn test_is_mask_consecutive_high() {
         // Consecutive 1s at high end: 0b11110000
-        let bv = BitVec::from((0xF0u64, 8));
+        let bv = BitVec::from((0xF0, 8));
         assert_eq!(bv.is_mask(), Some((7, 4)));
 
         // Consecutive 1s at high end: 0b11100000
-        let bv = BitVec::from((0xE0u64, 8));
+        let bv = BitVec::from((0xE0, 8));
         assert_eq!(bv.is_mask(), Some((7, 5)));
     }
 
     #[test]
     fn test_is_mask_consecutive_middle() {
         // Consecutive 1s in middle: 0b00111100
-        let bv = BitVec::from((0x3Cu64, 8));
+        let bv = BitVec::from((0x3C, 8));
         assert_eq!(bv.is_mask(), Some((5, 2)));
 
         // Consecutive 1s in middle: 0b01111110
-        let bv = BitVec::from((0x7Eu64, 8));
+        let bv = BitVec::from((0x7E, 8));
         assert_eq!(bv.is_mask(), Some((6, 1)));
     }
 
     #[test]
     fn test_is_mask_non_consecutive() {
         // Non-consecutive: 0b10101010
-        let bv = BitVec::from((0xAAu64, 8));
+        let bv = BitVec::from((0xAA, 8));
         assert_eq!(bv.is_mask(), None);
 
         // Non-consecutive: 0b11011011
-        let bv = BitVec::from((0xDBu64, 8));
+        let bv = BitVec::from((0xDB, 8));
         assert_eq!(bv.is_mask(), None);
 
         // Gap in middle: 0b11100111
-        let bv = BitVec::from((0xE7u64, 8));
+        let bv = BitVec::from((0xE7, 8));
         assert_eq!(bv.is_mask(), None);
     }
 
@@ -516,11 +516,11 @@ mod is_mask_tests {
         assert_eq!(bv.is_mask(), None);
 
         // 1-bit BitVec with 0
-        let bv = BitVec::from((0u64, 1));
+        let bv = BitVec::from((0, 1));
         assert_eq!(bv.is_mask(), None);
 
         // 1-bit BitVec with 1
-        let bv = BitVec::from((1u64, 1));
+        let bv = BitVec::from((1, 1));
         assert_eq!(bv.is_mask(), Some((0, 0)));
 
         // Exactly 64 bits, all ones
@@ -528,18 +528,18 @@ mod is_mask_tests {
         assert_eq!(bv.is_mask(), Some((63, 0)));
 
         // Exactly 64 bits, mask in middle
-        let bv = BitVec::from((0x00FFFF0000000000u64, 64));
+        let bv = BitVec::from((0x00FFFF0000000000, 64));
         assert_eq!(bv.is_mask(), Some((55, 40)));
     }
 
     #[test]
     fn test_is_mask_non_byte_aligned() {
         // 7-bit BitVec, all ones
-        let bv = BitVec::from((0x7Fu64, 7));
+        let bv = BitVec::from((0x7F, 7));
         assert_eq!(bv.is_mask(), Some((6, 0)));
 
         // 13-bit BitVec with mask
-        let bv = BitVec::from((0x0FC0u64, 13)); // bits 6-11 set
+        let bv = BitVec::from((0x0FC0, 13)); // bits 6-11 set
         assert_eq!(bv.is_mask(), Some((11, 6)));
 
         // 100-bit BitVec with mask at high end

--- a/crates/clarirs_num/src/bitvec.rs
+++ b/crates/clarirs_num/src/bitvec.rs
@@ -92,14 +92,6 @@ impl BitVec {
         }
     }
 
-    /// Creates a `BitVec` from a big-endian byte slice with bit-width equal to the
-    /// slice length times eight.
-    pub fn from_bytes_be(bytes: &[u8]) -> BitVec {
-        let length = (bytes.len() as u32) * 8;
-        let big_uint = BigUint::from_bytes_be(bytes);
-        BitVec::from((big_uint, length))
-    }
-
     pub fn to_biguint(&self) -> BigUint {
         // Convert the BitVec to a BigUint
         // The internal representation of BitVec uses little-endian word order

--- a/crates/clarirs_num/src/bitvec/arithmetic.rs
+++ b/crates/clarirs_num/src/bitvec/arithmetic.rs
@@ -10,7 +10,7 @@ impl Neg for BitVec {
     type Output = Result<Self, BitVecError>;
 
     fn neg(self) -> Self::Output {
-        (!self.clone())? + BitVec::from_prim_with_size(1u64, self.length)?
+        (!self.clone())? + BitVec::from((1u64, self.length))
     }
 }
 
@@ -44,7 +44,7 @@ impl Add<u64> for BitVec {
     type Output = Result<Self, BitVecError>;
 
     fn add(self, rhs: u64) -> Self::Output {
-        BitVec::from_prim_with_size(rhs, self.length)? + self
+        BitVec::from((rhs, self.length)) + self
     }
 }
 
@@ -61,10 +61,7 @@ impl Mul for BitVec {
 
     fn mul(self, rhs: Self) -> Result<Self, BitVecError> {
         self.check_same_length(&rhs)?;
-        Ok(BitVec::from_biguint(
-            &(BigUint::from(&self) * BigUint::from(&rhs)),
-            self.length,
-        ))
+        Ok(BitVec::from((BigUint::from(&self) * BigUint::from(&rhs), self.length)))
     }
 }
 
@@ -76,10 +73,7 @@ impl Div for BitVec {
         if rhs.is_zero() {
             return Err(BitVecError::DivisionByZero);
         }
-        Ok(BitVec::from_biguint(
-            &(BigUint::from(&self) / BigUint::from(&rhs)),
-            self.length,
-        ))
+        Ok(BitVec::from((BigUint::from(&self) / BigUint::from(&rhs), self.length)))
     }
 }
 
@@ -93,10 +87,7 @@ impl Rem for BitVec {
         if rhs.is_zero() {
             return Err(BitVecError::DivisionByZero);
         }
-        Ok(BitVec::from_biguint(
-            &(BigUint::from(&self) % BigUint::from(&rhs)),
-            self.length,
-        ))
+        Ok(BitVec::from((BigUint::from(&self) % BigUint::from(&rhs), self.length)))
     }
 }
 
@@ -107,7 +98,7 @@ impl BitVec {
         }
         let bitwidth = self.len();
         let remainder = self.to_biguint() % other.to_biguint();
-        BitVec::from_biguint(&remainder, bitwidth)
+        BitVec::from((remainder, bitwidth))
     }
 
     pub fn srem(&self, other: &Self) -> Result<Self, BitVecError> {
@@ -120,7 +111,7 @@ impl BitVec {
         let abs_dividend = self.to_biguint_abs();
         let abs_divisor = other.to_biguint_abs();
         let unsigned_remainder = abs_dividend % abs_divisor;
-        let raw_rem = BitVec::from_biguint(&unsigned_remainder, bitwidth);
+        let raw_rem = BitVec::from((unsigned_remainder, bitwidth));
 
         // The remainder takes the sign of the dividend (SMT-LIB bvsrem).
         if self.sign() { -raw_rem } else { Ok(raw_rem) }
@@ -138,7 +129,7 @@ impl BitVec {
         }
 
         let abs_quotient = &abs_dividend / &abs_divisor;
-        let quotient_bv = BitVec::from_biguint(&abs_quotient, bitwidth);
+        let quotient_bv = BitVec::from((abs_quotient, bitwidth));
 
         if result_neg {
             -quotient_bv
@@ -156,22 +147,22 @@ mod tests {
     #[test]
     fn test_add() -> Result<(), BitVecError> {
         // Basic addition
-        let a = BitVec::from(42u64);
-        let b = BitVec::from(58u64);
+        let a = BitVec::from((42u64, 64));
+        let b = BitVec::from((58u64, 64));
         let result = (a + b)?;
         assert_eq!(result.to_u64().unwrap(), 100);
 
         // Addition with overflow within the same bitwidth
-        let a = BitVec::from(0xFFFFFFFFu32);
-        let b = BitVec::from(1u32);
+        let a = BitVec::from((0xFFFFFFFFu64, 32));
+        let b = BitVec::from((1u64, 32));
         let result = (a + b)?;
         assert_eq!(result.len(), 32);
         assert_eq!(result.to_u64().unwrap(), 0);
 
         // Addition with different bit widths
-        let a = BitVec::from_prim_with_size(42u64, 32);
-        let b = BitVec::from_prim_with_size(58u64, 32);
-        let result = (a? + b?)?;
+        let a = BitVec::from((42u64, 32));
+        let b = BitVec::from((58u64, 32));
+        let result = (a + b)?;
         assert_eq!(result.to_u64().unwrap(), 100);
 
         Ok(())
@@ -180,21 +171,21 @@ mod tests {
     #[test]
     fn test_sub() -> Result<(), BitVecError> {
         // Basic subtraction
-        let a = BitVec::from(100u64);
-        let b = BitVec::from(58u64);
+        let a = BitVec::from((100u64, 64));
+        let b = BitVec::from((58u64, 64));
         let result = (a - b)?;
         assert_eq!(result.to_u64().unwrap(), 42);
 
         // Subtraction with underflow
-        let a = BitVec::from(0u64);
-        let b = BitVec::from(1u64);
+        let a = BitVec::from((0u64, 64));
+        let b = BitVec::from((1u64, 64));
         let result = (a - b)?;
         assert_eq!(result.to_u64().unwrap(), u64::MAX);
 
         // Subtraction with different bit widths
-        let a = BitVec::from_prim_with_size(100u64, 32);
-        let b = BitVec::from_prim_with_size(58u64, 32);
-        let result = (a? - b?)?;
+        let a = BitVec::from((100u64, 32));
+        let b = BitVec::from((58u64, 32));
+        let result = (a - b)?;
         assert_eq!(result.to_u64().unwrap(), 42);
 
         Ok(())
@@ -203,20 +194,20 @@ mod tests {
     #[test]
     fn test_mul() -> Result<(), BitVecError> {
         // Basic multiplication
-        let a = BitVec::from(7u64);
-        let b = BitVec::from(6u64);
+        let a = BitVec::from((7u64, 64));
+        let b = BitVec::from((6u64, 64));
         let result = (a * b)?;
         assert_eq!(result.to_u64().unwrap(), 42);
 
         // Multiplication with overflow
-        let a = BitVec::from(0xFFFFFFFFu32);
-        let b = BitVec::from(2u32);
+        let a = BitVec::from((0xFFFFFFFFu64, 32));
+        let b = BitVec::from((2u64, 32));
         let result = (a * b)?;
         assert_eq!(result.to_u64().unwrap(), 0xFFFFFFFE);
 
         // Multiplication with different bit widths
-        let a = BitVec::from_prim_with_size(7u64, 32)?;
-        let b = BitVec::from_prim_with_size(6u64, 32)?;
+        let a = BitVec::from((7u64, 32));
+        let b = BitVec::from((6u64, 32));
         let result = (a * b)?;
         assert_eq!(result.to_u64().unwrap(), 42);
 
@@ -226,26 +217,26 @@ mod tests {
     #[test]
     fn test_div() -> Result<(), BitVecError> {
         // Basic division
-        let a = BitVec::from(42u64);
-        let b = BitVec::from(6u64);
+        let a = BitVec::from((42u64, 64));
+        let b = BitVec::from((6u64, 64));
         let result = (a / b)?;
         assert_eq!(result.to_u64().unwrap(), 7);
 
         // Division with remainder
-        let a = BitVec::from(100u64);
-        let b = BitVec::from(30u64);
+        let a = BitVec::from((100u64, 64));
+        let b = BitVec::from((30u64, 64));
         let result = (a / b)?;
         assert_eq!(result.to_u64().unwrap(), 3);
 
         // Division with different bit widths
-        let a = BitVec::from_prim_with_size(100u64, 32)?;
-        let b = BitVec::from_prim_with_size(30u64, 32)?;
+        let a = BitVec::from((100u64, 32));
+        let b = BitVec::from((30u64, 32));
         let result = (a / b)?;
         assert_eq!(result.to_u64().unwrap(), 3);
 
         // Division by zero
-        let a = BitVec::from(42u64);
-        let b = BitVec::from(0u64);
+        let a = BitVec::from((42u64, 64));
+        let b = BitVec::from((0u64, 64));
         let result = a / b;
 
         assert!(
@@ -264,26 +255,26 @@ mod tests {
     #[test]
     fn test_rem() -> Result<(), BitVecError> {
         // Basic remainder
-        let a = BitVec::from(42u64);
-        let b = BitVec::from(6u64);
+        let a = BitVec::from((42u64, 64));
+        let b = BitVec::from((6u64, 64));
         let result = (a % b)?;
         assert_eq!(result.to_u64().unwrap(), 0);
 
         // Remainder with non-zero result
-        let a = BitVec::from(100u64);
-        let b = BitVec::from(30u64);
+        let a = BitVec::from((100u64, 64));
+        let b = BitVec::from((30u64, 64));
         let result = (a % b)?;
         assert_eq!(result.to_u64().unwrap(), 10);
 
         // Remainder with different bit widths
-        let a = BitVec::from_prim_with_size(100u64, 32)?;
-        let b = BitVec::from_prim_with_size(30u64, 32)?;
+        let a = BitVec::from((100u64, 32));
+        let b = BitVec::from((30u64, 32));
         let result = (a % b)?;
         assert_eq!(result.to_u64().unwrap(), 10);
 
         // Remainder by zero is an error, not a panic (mirrors Div).
-        let a = BitVec::from(42u64);
-        let b = BitVec::from(0u64);
+        let a = BitVec::from((42u64, 64));
+        let b = BitVec::from((0u64, 64));
         assert!(matches!(a % b, Err(BitVecError::DivisionByZero)));
 
         Ok(())
@@ -291,31 +282,31 @@ mod tests {
 
     #[test]
     fn test_signed_arithmetic() -> Result<(), BitVecError> {
-        let neg_42 = BitVec::from(-42i64);
-        let pos_6 = BitVec::from(6u64);
+        let neg_42 = BitVec::from((-42i64 as u64, 64));
+        let pos_6 = BitVec::from((6u64, 64));
 
         // Signed division should give -7
         let result = neg_42.sdiv(&pos_6)?;
         assert!(result.sign()); // Should be negative
-        assert_eq!(result, BitVec::from(-7i64));
+        assert_eq!(result, BitVec::from((-7i64 as u64, 64)));
 
         // Create -100 in 64-bit two's complement
-        let neg_100 = BitVec::from(-100i64);
-        let pos_30 = BitVec::from_prim_with_size(30u64, 64)?;
+        let neg_100 = BitVec::from((-100i64 as u64, 64));
+        let pos_30 = BitVec::from((30u64, 64));
 
         // Signed remainder should give -10
         let result = neg_100.srem(&pos_30)?;
         assert!(result.sign()); // Should be negative
-        assert_eq!(result, BitVec::from(-10i64));
+        assert_eq!(result, BitVec::from((-10i64 as u64, 64)));
 
         // Test division with different signs
-        let pos_100 = BitVec::from_prim_with_size(100u64, 64)?;
-        let neg_30 = BitVec::from(-30i64);
+        let pos_100 = BitVec::from((100u64, 64));
+        let neg_30 = BitVec::from((-30i64 as u64, 64));
 
         // Signed division should give -3
         let result = pos_100.sdiv(&neg_30)?;
         assert!(result.sign()); // Should be negative
-        assert_eq!(result, BitVec::from(-3i64));
+        assert_eq!(result, BitVec::from((-3i64 as u64, 64)));
 
         Ok(())
     }

--- a/crates/clarirs_num/src/bitvec/arithmetic.rs
+++ b/crates/clarirs_num/src/bitvec/arithmetic.rs
@@ -10,7 +10,7 @@ impl Neg for BitVec {
     type Output = Result<Self, BitVecError>;
 
     fn neg(self) -> Self::Output {
-        (!self.clone())? + BitVec::from((1u64, self.length))
+        (!self.clone())? + BitVec::from((1, self.length))
     }
 }
 
@@ -147,21 +147,21 @@ mod tests {
     #[test]
     fn test_add() -> Result<(), BitVecError> {
         // Basic addition
-        let a = BitVec::from((42u64, 64));
-        let b = BitVec::from((58u64, 64));
+        let a = BitVec::from((42, 64));
+        let b = BitVec::from((58, 64));
         let result = (a + b)?;
         assert_eq!(result.to_u64().unwrap(), 100);
 
         // Addition with overflow within the same bitwidth
-        let a = BitVec::from((0xFFFFFFFFu64, 32));
-        let b = BitVec::from((1u64, 32));
+        let a = BitVec::from((0xFFFFFFFF, 32));
+        let b = BitVec::from((1, 32));
         let result = (a + b)?;
         assert_eq!(result.len(), 32);
         assert_eq!(result.to_u64().unwrap(), 0);
 
         // Addition with different bit widths
-        let a = BitVec::from((42u64, 32));
-        let b = BitVec::from((58u64, 32));
+        let a = BitVec::from((42, 32));
+        let b = BitVec::from((58, 32));
         let result = (a + b)?;
         assert_eq!(result.to_u64().unwrap(), 100);
 
@@ -171,20 +171,20 @@ mod tests {
     #[test]
     fn test_sub() -> Result<(), BitVecError> {
         // Basic subtraction
-        let a = BitVec::from((100u64, 64));
-        let b = BitVec::from((58u64, 64));
+        let a = BitVec::from((100, 64));
+        let b = BitVec::from((58, 64));
         let result = (a - b)?;
         assert_eq!(result.to_u64().unwrap(), 42);
 
         // Subtraction with underflow
-        let a = BitVec::from((0u64, 64));
-        let b = BitVec::from((1u64, 64));
+        let a = BitVec::from((0, 64));
+        let b = BitVec::from((1, 64));
         let result = (a - b)?;
         assert_eq!(result.to_u64().unwrap(), u64::MAX);
 
         // Subtraction with different bit widths
-        let a = BitVec::from((100u64, 32));
-        let b = BitVec::from((58u64, 32));
+        let a = BitVec::from((100, 32));
+        let b = BitVec::from((58, 32));
         let result = (a - b)?;
         assert_eq!(result.to_u64().unwrap(), 42);
 
@@ -194,20 +194,20 @@ mod tests {
     #[test]
     fn test_mul() -> Result<(), BitVecError> {
         // Basic multiplication
-        let a = BitVec::from((7u64, 64));
-        let b = BitVec::from((6u64, 64));
+        let a = BitVec::from((7, 64));
+        let b = BitVec::from((6, 64));
         let result = (a * b)?;
         assert_eq!(result.to_u64().unwrap(), 42);
 
         // Multiplication with overflow
-        let a = BitVec::from((0xFFFFFFFFu64, 32));
-        let b = BitVec::from((2u64, 32));
+        let a = BitVec::from((0xFFFFFFFF, 32));
+        let b = BitVec::from((2, 32));
         let result = (a * b)?;
         assert_eq!(result.to_u64().unwrap(), 0xFFFFFFFE);
 
         // Multiplication with different bit widths
-        let a = BitVec::from((7u64, 32));
-        let b = BitVec::from((6u64, 32));
+        let a = BitVec::from((7, 32));
+        let b = BitVec::from((6, 32));
         let result = (a * b)?;
         assert_eq!(result.to_u64().unwrap(), 42);
 
@@ -217,26 +217,26 @@ mod tests {
     #[test]
     fn test_div() -> Result<(), BitVecError> {
         // Basic division
-        let a = BitVec::from((42u64, 64));
-        let b = BitVec::from((6u64, 64));
+        let a = BitVec::from((42, 64));
+        let b = BitVec::from((6, 64));
         let result = (a / b)?;
         assert_eq!(result.to_u64().unwrap(), 7);
 
         // Division with remainder
-        let a = BitVec::from((100u64, 64));
-        let b = BitVec::from((30u64, 64));
+        let a = BitVec::from((100, 64));
+        let b = BitVec::from((30, 64));
         let result = (a / b)?;
         assert_eq!(result.to_u64().unwrap(), 3);
 
         // Division with different bit widths
-        let a = BitVec::from((100u64, 32));
-        let b = BitVec::from((30u64, 32));
+        let a = BitVec::from((100, 32));
+        let b = BitVec::from((30, 32));
         let result = (a / b)?;
         assert_eq!(result.to_u64().unwrap(), 3);
 
         // Division by zero
-        let a = BitVec::from((42u64, 64));
-        let b = BitVec::from((0u64, 64));
+        let a = BitVec::from((42, 64));
+        let b = BitVec::from((0, 64));
         let result = a / b;
 
         assert!(
@@ -255,26 +255,26 @@ mod tests {
     #[test]
     fn test_rem() -> Result<(), BitVecError> {
         // Basic remainder
-        let a = BitVec::from((42u64, 64));
-        let b = BitVec::from((6u64, 64));
+        let a = BitVec::from((42, 64));
+        let b = BitVec::from((6, 64));
         let result = (a % b)?;
         assert_eq!(result.to_u64().unwrap(), 0);
 
         // Remainder with non-zero result
-        let a = BitVec::from((100u64, 64));
-        let b = BitVec::from((30u64, 64));
+        let a = BitVec::from((100, 64));
+        let b = BitVec::from((30, 64));
         let result = (a % b)?;
         assert_eq!(result.to_u64().unwrap(), 10);
 
         // Remainder with different bit widths
-        let a = BitVec::from((100u64, 32));
-        let b = BitVec::from((30u64, 32));
+        let a = BitVec::from((100, 32));
+        let b = BitVec::from((30, 32));
         let result = (a % b)?;
         assert_eq!(result.to_u64().unwrap(), 10);
 
         // Remainder by zero is an error, not a panic (mirrors Div).
-        let a = BitVec::from((42u64, 64));
-        let b = BitVec::from((0u64, 64));
+        let a = BitVec::from((42, 64));
+        let b = BitVec::from((0, 64));
         assert!(matches!(a % b, Err(BitVecError::DivisionByZero)));
 
         Ok(())
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn test_signed_arithmetic() -> Result<(), BitVecError> {
         let neg_42 = BitVec::from((-42i64 as u64, 64));
-        let pos_6 = BitVec::from((6u64, 64));
+        let pos_6 = BitVec::from((6, 64));
 
         // Signed division should give -7
         let result = neg_42.sdiv(&pos_6)?;
@@ -292,7 +292,7 @@ mod tests {
 
         // Create -100 in 64-bit two's complement
         let neg_100 = BitVec::from((-100i64 as u64, 64));
-        let pos_30 = BitVec::from((30u64, 64));
+        let pos_30 = BitVec::from((30, 64));
 
         // Signed remainder should give -10
         let result = neg_100.srem(&pos_30)?;
@@ -300,7 +300,7 @@ mod tests {
         assert_eq!(result, BitVec::from((-10i64 as u64, 64)));
 
         // Test division with different signs
-        let pos_100 = BitVec::from((100u64, 64));
+        let pos_100 = BitVec::from((100, 64));
         let neg_30 = BitVec::from((-30i64 as u64, 64));
 
         // Signed division should give -3

--- a/crates/clarirs_num/src/bitvec/bitwise.rs
+++ b/crates/clarirs_num/src/bitvec/bitwise.rs
@@ -121,12 +121,12 @@ mod tests {
     #[test]
     fn test_not() -> Result<(), BitVecError> {
         // Test 8-bit NOT
-        let bv = BitVec::from((0b10101010u64, 8));
+        let bv = BitVec::from((0b10101010, 8));
         let result = (!bv)?;
         assert_eq!(result.to_u64().unwrap(), 0b01010101);
 
         // Test with non-byte aligned length
-        let bv = BitVec::from((0b101u64, 3));
+        let bv = BitVec::from((0b101, 3));
         let result = (!bv)?;
         assert_eq!(result.to_u64().unwrap(), 0b010);
 
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn test_neg() -> Result<(), BitVecError> {
         // Arithmatic negation
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = (!bv)?;
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 
@@ -151,14 +151,14 @@ mod tests {
     #[test]
     fn test_bitand() -> Result<(), BitVecError> {
         // Test basic AND operation
-        let bv1 = BitVec::from((0b1100u64, 4));
-        let bv2 = BitVec::from((0b1010u64, 4));
+        let bv1 = BitVec::from((0b1100, 4));
+        let bv2 = BitVec::from((0b1010, 4));
         let result = (bv1 & bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b1000);
 
         // Test with different patterns
-        let bv1 = BitVec::from((0b11111111u64, 8));
-        let bv2 = BitVec::from((0b10101010u64, 8));
+        let bv1 = BitVec::from((0b11111111, 8));
+        let bv2 = BitVec::from((0b10101010, 8));
         let result = (bv1 & bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b10101010);
 
@@ -168,14 +168,14 @@ mod tests {
     #[test]
     fn test_bitor() -> Result<(), BitVecError> {
         // Test basic OR operation
-        let bv1 = BitVec::from((0b1100u64, 4));
-        let bv2 = BitVec::from((0b1010u64, 4));
+        let bv1 = BitVec::from((0b1100, 4));
+        let bv2 = BitVec::from((0b1010, 4));
         let result = (bv1 | bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b1110);
 
         // Test with different patterns
-        let bv1 = BitVec::from((0b11110000u64, 8));
-        let bv2 = BitVec::from((0b00001111u64, 8));
+        let bv1 = BitVec::from((0b11110000, 8));
+        let bv2 = BitVec::from((0b00001111, 8));
         let result = (bv1 | bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b11111111);
 
@@ -185,14 +185,14 @@ mod tests {
     #[test]
     fn test_bitxor() -> Result<(), BitVecError> {
         // Test basic XOR operation
-        let bv1 = BitVec::from((0b1100u64, 4));
-        let bv2 = BitVec::from((0b1010u64, 4));
+        let bv1 = BitVec::from((0b1100, 4));
+        let bv2 = BitVec::from((0b1010, 4));
         let result = (bv1 ^ bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b0110);
 
         // Test with different patterns
-        let bv1 = BitVec::from((0b11111111u64, 8));
-        let bv2 = BitVec::from((0b10101010u64, 8));
+        let bv1 = BitVec::from((0b11111111, 8));
+        let bv2 = BitVec::from((0b10101010, 8));
         let result = (bv1 ^ bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b01010101);
 
@@ -202,17 +202,17 @@ mod tests {
     #[test]
     fn test_shl() -> Result<(), BitVecError> {
         // Test basic left shift
-        let bv = BitVec::from((0b1010u64, 8));
+        let bv = BitVec::from((0b1010, 8));
         let result = (bv << 2)?;
         assert_eq!(result.to_u64().unwrap(), 0b101000);
 
         // Test shift with carry across word boundaries
-        let bv = BitVec::from((0b1u64, 64));
+        let bv = BitVec::from((0b1, 64));
         let result = (bv << 63)?;
         assert_eq!(result.to_u64().unwrap(), 1u64 << 63);
 
         // Test shift beyond bit length
-        let bv = BitVec::from((0b1010u64, 8));
+        let bv = BitVec::from((0b1010, 8));
         let result = (bv << 4)?;
         assert_eq!(result.to_u64().unwrap(), 0b10100000);
 
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn test_shr() -> Result<(), BitVecError> {
         // Test basic right shift
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = (bv >> 2)?;
         assert_eq!(result.to_u64().unwrap(), 0b10);
 
@@ -232,7 +232,7 @@ mod tests {
         assert_eq!(result.to_u64().unwrap(), 1);
 
         // Test shift that results in all zeros
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = (bv >> 4)?;
         assert_eq!(result.to_u64().unwrap(), 0);
 
@@ -242,17 +242,17 @@ mod tests {
     #[test]
     fn test_rotate_left() -> Result<(), BitVecError> {
         // Test basic rotation
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.rotate_left(1).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 
         // Test full rotation (should be same as original)
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.rotate_left(4).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b1010);
 
         // Test rotation with amount larger than length
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.rotate_left(5).unwrap(); // Same as rotating left by 1
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 
@@ -262,17 +262,17 @@ mod tests {
     #[test]
     fn test_rotate_right() -> Result<(), BitVecError> {
         // Test basic rotation
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.rotate_right(1).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 
         // Test full rotation (should be same as original)
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.rotate_right(4).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b1010);
 
         // Test rotation with amount larger than length
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.rotate_right(5).unwrap(); // Same as rotating right by 1
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 

--- a/crates/clarirs_num/src/bitvec/bitwise.rs
+++ b/crates/clarirs_num/src/bitvec/bitwise.rs
@@ -66,10 +66,7 @@ impl Shl<u32> for BitVec {
             return Ok(BitVec::zeros(self.length));
         }
         // `from_biguint` truncates to `length`, discarding bits shifted past the top.
-        Ok(BitVec::from_biguint(
-            &(self.to_biguint() << rhs),
-            self.length,
-        ))
+        Ok(BitVec::from((self.to_biguint() << rhs, self.length)))
     }
 }
 
@@ -81,10 +78,7 @@ impl Shr<u32> for BitVec {
         if rhs >= self.length {
             return Ok(BitVec::zeros(self.length));
         }
-        Ok(BitVec::from_biguint(
-            &(self.to_biguint() >> rhs),
-            self.length,
-        ))
+        Ok(BitVec::from((self.to_biguint() >> rhs, self.length)))
     }
 }
 
@@ -108,7 +102,7 @@ impl BitVec {
         };
 
         let rotated = ((&value << left_amount) | (&value >> right_amount)) & &mask;
-        Ok(BitVec::from_biguint(&rotated, bit_length))
+        Ok(BitVec::from((rotated, bit_length)))
     }
 
     pub fn rotate_left(&self, rotate_amount: u32) -> Result<Self, BitVecError> {
@@ -127,17 +121,17 @@ mod tests {
     #[test]
     fn test_not() -> Result<(), BitVecError> {
         // Test 8-bit NOT
-        let bv = BitVec::from_prim_with_size(0b10101010u8, 8)?;
+        let bv = BitVec::from((0b10101010u64, 8));
         let result = (!bv)?;
         assert_eq!(result.to_u64().unwrap(), 0b01010101);
 
         // Test with non-byte aligned length
-        let bv = BitVec::from_prim_with_size(0b101u8, 3)?;
+        let bv = BitVec::from((0b101u64, 3));
         let result = (!bv)?;
         assert_eq!(result.to_u64().unwrap(), 0b010);
 
         // Test with multiple words
-        let bv = BitVec::from_prim_with_size(u64::MAX, 64)?;
+        let bv = BitVec::from((u64::MAX, 64));
         let result = (!bv)?;
         assert_eq!(result.to_u64().unwrap(), 0);
 
@@ -147,7 +141,7 @@ mod tests {
     #[test]
     fn test_neg() -> Result<(), BitVecError> {
         // Arithmatic negation
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = (!bv)?;
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 
@@ -157,14 +151,14 @@ mod tests {
     #[test]
     fn test_bitand() -> Result<(), BitVecError> {
         // Test basic AND operation
-        let bv1 = BitVec::from_prim_with_size(0b1100u8, 4)?;
-        let bv2 = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv1 = BitVec::from((0b1100u64, 4));
+        let bv2 = BitVec::from((0b1010u64, 4));
         let result = (bv1 & bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b1000);
 
         // Test with different patterns
-        let bv1 = BitVec::from_prim_with_size(0b11111111u8, 8)?;
-        let bv2 = BitVec::from_prim_with_size(0b10101010u8, 8)?;
+        let bv1 = BitVec::from((0b11111111u64, 8));
+        let bv2 = BitVec::from((0b10101010u64, 8));
         let result = (bv1 & bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b10101010);
 
@@ -174,14 +168,14 @@ mod tests {
     #[test]
     fn test_bitor() -> Result<(), BitVecError> {
         // Test basic OR operation
-        let bv1 = BitVec::from_prim_with_size(0b1100u8, 4)?;
-        let bv2 = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv1 = BitVec::from((0b1100u64, 4));
+        let bv2 = BitVec::from((0b1010u64, 4));
         let result = (bv1 | bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b1110);
 
         // Test with different patterns
-        let bv1 = BitVec::from_prim_with_size(0b11110000u8, 8)?;
-        let bv2 = BitVec::from_prim_with_size(0b00001111u8, 8)?;
+        let bv1 = BitVec::from((0b11110000u64, 8));
+        let bv2 = BitVec::from((0b00001111u64, 8));
         let result = (bv1 | bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b11111111);
 
@@ -191,14 +185,14 @@ mod tests {
     #[test]
     fn test_bitxor() -> Result<(), BitVecError> {
         // Test basic XOR operation
-        let bv1 = BitVec::from_prim_with_size(0b1100u8, 4)?;
-        let bv2 = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv1 = BitVec::from((0b1100u64, 4));
+        let bv2 = BitVec::from((0b1010u64, 4));
         let result = (bv1 ^ bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b0110);
 
         // Test with different patterns
-        let bv1 = BitVec::from_prim_with_size(0b11111111u8, 8)?;
-        let bv2 = BitVec::from_prim_with_size(0b10101010u8, 8)?;
+        let bv1 = BitVec::from((0b11111111u64, 8));
+        let bv2 = BitVec::from((0b10101010u64, 8));
         let result = (bv1 ^ bv2)?;
         assert_eq!(result.to_u64().unwrap(), 0b01010101);
 
@@ -208,17 +202,17 @@ mod tests {
     #[test]
     fn test_shl() -> Result<(), BitVecError> {
         // Test basic left shift
-        let bv = BitVec::from_prim_with_size(0b1010u8, 8)?;
+        let bv = BitVec::from((0b1010u64, 8));
         let result = (bv << 2)?;
         assert_eq!(result.to_u64().unwrap(), 0b101000);
 
         // Test shift with carry across word boundaries
-        let bv = BitVec::from_prim_with_size(0b1u8, 64)?;
+        let bv = BitVec::from((0b1u64, 64));
         let result = (bv << 63)?;
         assert_eq!(result.to_u64().unwrap(), 1u64 << 63);
 
         // Test shift beyond bit length
-        let bv = BitVec::from_prim_with_size(0b1010u8, 8)?;
+        let bv = BitVec::from((0b1010u64, 8));
         let result = (bv << 4)?;
         assert_eq!(result.to_u64().unwrap(), 0b10100000);
 
@@ -228,17 +222,17 @@ mod tests {
     #[test]
     fn test_shr() -> Result<(), BitVecError> {
         // Test basic right shift
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = (bv >> 2)?;
         assert_eq!(result.to_u64().unwrap(), 0b10);
 
         // Test shift with carry across word boundaries
-        let bv = BitVec::from_prim_with_size(1u64 << 63, 64)?;
+        let bv = BitVec::from((1u64 << 63, 64));
         let result = (bv >> 63)?;
         assert_eq!(result.to_u64().unwrap(), 1);
 
         // Test shift that results in all zeros
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = (bv >> 4)?;
         assert_eq!(result.to_u64().unwrap(), 0);
 
@@ -248,17 +242,17 @@ mod tests {
     #[test]
     fn test_rotate_left() -> Result<(), BitVecError> {
         // Test basic rotation
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.rotate_left(1).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 
         // Test full rotation (should be same as original)
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.rotate_left(4).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b1010);
 
         // Test rotation with amount larger than length
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.rotate_left(5).unwrap(); // Same as rotating left by 1
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 
@@ -268,17 +262,17 @@ mod tests {
     #[test]
     fn test_rotate_right() -> Result<(), BitVecError> {
         // Test basic rotation
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.rotate_right(1).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 
         // Test full rotation (should be same as original)
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.rotate_right(4).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b1010);
 
         // Test rotation with amount larger than length
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.rotate_right(5).unwrap(); // Same as rotating right by 1
         assert_eq!(result.to_u64().unwrap(), 0b0101);
 

--- a/crates/clarirs_num/src/bitvec/comparison.rs
+++ b/crates/clarirs_num/src/bitvec/comparison.rs
@@ -55,22 +55,22 @@ mod tests {
     #[test]
     fn test_unsigned_comparison() -> Result<(), BitVecError> {
         // Test basic ordering
-        let bv1 = BitVec::from_prim_with_size(5u8, 8)?;
-        let bv2 = BitVec::from_prim_with_size(10u8, 8)?;
+        let bv1 = BitVec::from((5u64, 8));
+        let bv2 = BitVec::from((10u64, 8));
         assert!(bv1 < bv2);
         assert!(bv1 <= bv2);
         assert!(bv2 > bv1);
         assert!(bv2 >= bv1);
 
         // Test equality
-        let bv3 = BitVec::from_prim_with_size(5u8, 8)?;
+        let bv3 = BitVec::from((5u64, 8));
         assert!(bv1 == bv3);
         assert!(bv1 <= bv3);
         assert!(bv1 >= bv3);
 
         // Test with larger numbers
-        let bv4 = BitVec::from_prim_with_size(0xFFFFu16, 16)?;
-        let bv5 = BitVec::from_prim_with_size(0x0000u16, 16)?;
+        let bv4 = BitVec::from((0xFFFFu64, 16));
+        let bv5 = BitVec::from((0x0000u64, 16));
         assert!(bv4 > bv5);
         assert!(bv5 < bv4);
 
@@ -80,8 +80,8 @@ mod tests {
     #[test]
     fn test_unsigned_comparison_multi_word() -> Result<(), BitVecError> {
         // Test with 128-bit values where the difference is in the lower word
-        let bv1 = BitVec::from_biguint(&1u32.into(), 128);
-        let bv2 = BitVec::from_biguint(&2u32.into(), 128);
+        let bv1 = BitVec::from((1u64, 128));
+        let bv2 = BitVec::from((2u64, 128));
         assert!(bv1 < bv2, "1 < 2 in 128-bit should be true");
         assert!(bv2 > bv1, "2 > 1 in 128-bit should be true");
         assert!(bv1 != bv2, "1 != 2 in 128-bit");
@@ -89,8 +89,8 @@ mod tests {
         // Test with values that differ in the upper word
         let big1 = num_bigint::BigUint::from(1u64) << 64;
         let big2 = num_bigint::BigUint::from(2u64) << 64;
-        let bv3 = BitVec::from_biguint(&big1, 128);
-        let bv4 = BitVec::from_biguint(&big2, 128);
+        let bv3 = BitVec::from((big1, 128u32));
+        let bv4 = BitVec::from((big2, 128u32));
         assert!(bv3 < bv4, "1<<64 < 2<<64 in 128-bit should be true");
         assert!(bv4 > bv3, "2<<64 > 1<<64 in 128-bit should be true");
 
@@ -100,15 +100,15 @@ mod tests {
     #[test]
     fn test_signed_lt() -> Result<(), BitVecError> {
         // Test positive numbers (5 and 10 in 8-bit)
-        let pos1 = BitVec::from_prim_with_size(0x05u8, 8)?;
-        let pos2 = BitVec::from_prim_with_size(0x0Au8, 8)?;
+        let pos1 = BitVec::from((0x05u64, 8));
+        let pos2 = BitVec::from((0x0Au64, 8));
         assert!(pos1.signed_lt(&pos2)?);
         assert!(!pos2.signed_lt(&pos1)?);
 
         // Test negative numbers (-5 = 0xFB and -10 = 0xF6 in 8-bit two's complement)
         // -10 < -5 because -10 is more negative (further from zero)
-        let neg5 = BitVec::from_prim_with_size(0xFBu8, 8)?; // -5
-        let neg10 = BitVec::from_prim_with_size(0xF6u8, 8)?; // -10
+        let neg5 = BitVec::from((0xFBu64, 8)); // -5
+        let neg10 = BitVec::from((0xF6u64, 8)); // -10
         assert!(neg10.signed_lt(&neg5)?); // -10 < -5
         assert!(!neg5.signed_lt(&neg10)?); // -5 NOT< -10
 
@@ -117,7 +117,7 @@ mod tests {
         assert!(!pos1.signed_lt(&neg5)?); // 5 NOT< -5
 
         // Test equality
-        let pos1_dup = BitVec::from_prim_with_size(0x05u8, 8)?;
+        let pos1_dup = BitVec::from((0x05u64, 8));
         assert!(!pos1.signed_lt(&pos1_dup)?);
         assert!(!pos1_dup.signed_lt(&pos1)?);
 
@@ -127,19 +127,19 @@ mod tests {
     #[test]
     fn test_signed_le() -> Result<(), BitVecError> {
         // Test positive numbers (5 and 10 in 8-bit)
-        let pos1 = BitVec::from_prim_with_size(0x05u8, 8)?;
-        let pos2 = BitVec::from_prim_with_size(0x0Au8, 8)?;
+        let pos1 = BitVec::from((0x05u64, 8));
+        let pos2 = BitVec::from((0x0Au64, 8));
         assert!(pos1.signed_le(&pos2)?);
         assert!(!pos2.signed_le(&pos1)?);
 
         // Test negative numbers (-5 = 0xFB and -10 = 0xF6 in 8-bit two's complement)
-        let neg5 = BitVec::from_prim_with_size(0xFBu8, 8)?; // -5
-        let neg10 = BitVec::from_prim_with_size(0xF6u8, 8)?; // -10
+        let neg5 = BitVec::from((0xFBu64, 8)); // -5
+        let neg10 = BitVec::from((0xF6u64, 8)); // -10
         assert!(neg10.signed_le(&neg5)?); // -10 <= -5
         assert!(!neg5.signed_le(&neg10)?); // -5 NOT<= -10
 
         // Test equality
-        let pos1_dup = BitVec::from_prim_with_size(0x05u8, 8)?;
+        let pos1_dup = BitVec::from((0x05u64, 8));
         assert!(pos1.signed_le(&pos1_dup)?);
         assert!(pos1_dup.signed_le(&pos1)?);
 
@@ -149,14 +149,14 @@ mod tests {
     #[test]
     fn test_signed_gt() -> Result<(), BitVecError> {
         // Test positive numbers (5 and 10 in 8-bit)
-        let pos1 = BitVec::from_prim_with_size(0x05u8, 8)?;
-        let pos2 = BitVec::from_prim_with_size(0x0Au8, 8)?;
+        let pos1 = BitVec::from((0x05u64, 8));
+        let pos2 = BitVec::from((0x0Au64, 8));
         assert!(!pos1.signed_gt(&pos2)?);
         assert!(pos2.signed_gt(&pos1)?);
 
         // Test negative numbers (-5 = 0xFB and -10 = 0xF6 in 8-bit two's complement)
-        let neg5 = BitVec::from_prim_with_size(0xFBu8, 8)?; // -5
-        let neg10 = BitVec::from_prim_with_size(0xF6u8, 8)?; // -10
+        let neg5 = BitVec::from((0xFBu64, 8)); // -5
+        let neg10 = BitVec::from((0xF6u64, 8)); // -10
         assert!(neg5.signed_gt(&neg10)?); // -5 > -10
         assert!(!neg10.signed_gt(&neg5)?); // -10 NOT> -5
 
@@ -165,7 +165,7 @@ mod tests {
         assert!(!neg5.signed_gt(&pos1)?); // -5 NOT> 5
 
         // Test equality
-        let pos1_dup = BitVec::from_prim_with_size(0x05u8, 8)?;
+        let pos1_dup = BitVec::from((0x05u64, 8));
         assert!(!pos1.signed_gt(&pos1_dup)?);
         assert!(!pos1_dup.signed_gt(&pos1)?);
 
@@ -175,19 +175,19 @@ mod tests {
     #[test]
     fn test_signed_ge() -> Result<(), BitVecError> {
         // Test positive numbers (5 and 10 in 8-bit)
-        let pos1 = BitVec::from_prim_with_size(0x05u8, 8)?;
-        let pos2 = BitVec::from_prim_with_size(0x0Au8, 8)?;
+        let pos1 = BitVec::from((0x05u64, 8));
+        let pos2 = BitVec::from((0x0Au64, 8));
         assert!(!pos1.signed_ge(&pos2)?);
         assert!(pos2.signed_ge(&pos1)?);
 
         // Test negative numbers (-5 = 0xFB and -10 = 0xF6 in 8-bit two's complement)
-        let neg5 = BitVec::from_prim_with_size(0xFBu8, 8)?; // -5
-        let neg10 = BitVec::from_prim_with_size(0xF6u8, 8)?; // -10
+        let neg5 = BitVec::from((0xFBu64, 8)); // -5
+        let neg10 = BitVec::from((0xF6u64, 8)); // -10
         assert!(neg5.signed_ge(&neg10)?); // -5 >= -10
         assert!(!neg10.signed_ge(&neg5)?); // -10 NOT>= -5
 
         // Test equality
-        let pos1_dup = BitVec::from_prim_with_size(0x05u8, 8)?;
+        let pos1_dup = BitVec::from((0x05u64, 8));
         assert!(pos1.signed_ge(&pos1_dup)?);
         assert!(pos1_dup.signed_ge(&pos1)?);
 
@@ -196,8 +196,8 @@ mod tests {
 
     #[test]
     fn test_signed_comparison_different_lengths() {
-        let bv1 = BitVec::from_prim_with_size(0x05u8, 8).unwrap();
-        let bv2 = BitVec::from_prim_with_size(0x0005u16, 16).unwrap();
+        let bv1 = BitVec::from((0x05u64, 8));
+        let bv2 = BitVec::from((0x0005u64, 16));
         assert!(matches!(
             bv1.signed_lt(&bv2),
             Err(BitVecError::MismatchedLengths { left: 8, right: 16 })

--- a/crates/clarirs_num/src/bitvec/comparison.rs
+++ b/crates/clarirs_num/src/bitvec/comparison.rs
@@ -55,22 +55,22 @@ mod tests {
     #[test]
     fn test_unsigned_comparison() -> Result<(), BitVecError> {
         // Test basic ordering
-        let bv1 = BitVec::from((5u64, 8));
-        let bv2 = BitVec::from((10u64, 8));
+        let bv1 = BitVec::from((5, 8));
+        let bv2 = BitVec::from((10, 8));
         assert!(bv1 < bv2);
         assert!(bv1 <= bv2);
         assert!(bv2 > bv1);
         assert!(bv2 >= bv1);
 
         // Test equality
-        let bv3 = BitVec::from((5u64, 8));
+        let bv3 = BitVec::from((5, 8));
         assert!(bv1 == bv3);
         assert!(bv1 <= bv3);
         assert!(bv1 >= bv3);
 
         // Test with larger numbers
-        let bv4 = BitVec::from((0xFFFFu64, 16));
-        let bv5 = BitVec::from((0x0000u64, 16));
+        let bv4 = BitVec::from((0xFFFF, 16));
+        let bv5 = BitVec::from((0x0000, 16));
         assert!(bv4 > bv5);
         assert!(bv5 < bv4);
 
@@ -80,8 +80,8 @@ mod tests {
     #[test]
     fn test_unsigned_comparison_multi_word() -> Result<(), BitVecError> {
         // Test with 128-bit values where the difference is in the lower word
-        let bv1 = BitVec::from((1u64, 128));
-        let bv2 = BitVec::from((2u64, 128));
+        let bv1 = BitVec::from((1, 128));
+        let bv2 = BitVec::from((2, 128));
         assert!(bv1 < bv2, "1 < 2 in 128-bit should be true");
         assert!(bv2 > bv1, "2 > 1 in 128-bit should be true");
         assert!(bv1 != bv2, "1 != 2 in 128-bit");
@@ -100,15 +100,15 @@ mod tests {
     #[test]
     fn test_signed_lt() -> Result<(), BitVecError> {
         // Test positive numbers (5 and 10 in 8-bit)
-        let pos1 = BitVec::from((0x05u64, 8));
-        let pos2 = BitVec::from((0x0Au64, 8));
+        let pos1 = BitVec::from((0x05, 8));
+        let pos2 = BitVec::from((0x0A, 8));
         assert!(pos1.signed_lt(&pos2)?);
         assert!(!pos2.signed_lt(&pos1)?);
 
         // Test negative numbers (-5 = 0xFB and -10 = 0xF6 in 8-bit two's complement)
         // -10 < -5 because -10 is more negative (further from zero)
-        let neg5 = BitVec::from((0xFBu64, 8)); // -5
-        let neg10 = BitVec::from((0xF6u64, 8)); // -10
+        let neg5 = BitVec::from((0xFB, 8)); // -5
+        let neg10 = BitVec::from((0xF6, 8)); // -10
         assert!(neg10.signed_lt(&neg5)?); // -10 < -5
         assert!(!neg5.signed_lt(&neg10)?); // -5 NOT< -10
 
@@ -117,7 +117,7 @@ mod tests {
         assert!(!pos1.signed_lt(&neg5)?); // 5 NOT< -5
 
         // Test equality
-        let pos1_dup = BitVec::from((0x05u64, 8));
+        let pos1_dup = BitVec::from((0x05, 8));
         assert!(!pos1.signed_lt(&pos1_dup)?);
         assert!(!pos1_dup.signed_lt(&pos1)?);
 
@@ -127,19 +127,19 @@ mod tests {
     #[test]
     fn test_signed_le() -> Result<(), BitVecError> {
         // Test positive numbers (5 and 10 in 8-bit)
-        let pos1 = BitVec::from((0x05u64, 8));
-        let pos2 = BitVec::from((0x0Au64, 8));
+        let pos1 = BitVec::from((0x05, 8));
+        let pos2 = BitVec::from((0x0A, 8));
         assert!(pos1.signed_le(&pos2)?);
         assert!(!pos2.signed_le(&pos1)?);
 
         // Test negative numbers (-5 = 0xFB and -10 = 0xF6 in 8-bit two's complement)
-        let neg5 = BitVec::from((0xFBu64, 8)); // -5
-        let neg10 = BitVec::from((0xF6u64, 8)); // -10
+        let neg5 = BitVec::from((0xFB, 8)); // -5
+        let neg10 = BitVec::from((0xF6, 8)); // -10
         assert!(neg10.signed_le(&neg5)?); // -10 <= -5
         assert!(!neg5.signed_le(&neg10)?); // -5 NOT<= -10
 
         // Test equality
-        let pos1_dup = BitVec::from((0x05u64, 8));
+        let pos1_dup = BitVec::from((0x05, 8));
         assert!(pos1.signed_le(&pos1_dup)?);
         assert!(pos1_dup.signed_le(&pos1)?);
 
@@ -149,14 +149,14 @@ mod tests {
     #[test]
     fn test_signed_gt() -> Result<(), BitVecError> {
         // Test positive numbers (5 and 10 in 8-bit)
-        let pos1 = BitVec::from((0x05u64, 8));
-        let pos2 = BitVec::from((0x0Au64, 8));
+        let pos1 = BitVec::from((0x05, 8));
+        let pos2 = BitVec::from((0x0A, 8));
         assert!(!pos1.signed_gt(&pos2)?);
         assert!(pos2.signed_gt(&pos1)?);
 
         // Test negative numbers (-5 = 0xFB and -10 = 0xF6 in 8-bit two's complement)
-        let neg5 = BitVec::from((0xFBu64, 8)); // -5
-        let neg10 = BitVec::from((0xF6u64, 8)); // -10
+        let neg5 = BitVec::from((0xFB, 8)); // -5
+        let neg10 = BitVec::from((0xF6, 8)); // -10
         assert!(neg5.signed_gt(&neg10)?); // -5 > -10
         assert!(!neg10.signed_gt(&neg5)?); // -10 NOT> -5
 
@@ -165,7 +165,7 @@ mod tests {
         assert!(!neg5.signed_gt(&pos1)?); // -5 NOT> 5
 
         // Test equality
-        let pos1_dup = BitVec::from((0x05u64, 8));
+        let pos1_dup = BitVec::from((0x05, 8));
         assert!(!pos1.signed_gt(&pos1_dup)?);
         assert!(!pos1_dup.signed_gt(&pos1)?);
 
@@ -175,19 +175,19 @@ mod tests {
     #[test]
     fn test_signed_ge() -> Result<(), BitVecError> {
         // Test positive numbers (5 and 10 in 8-bit)
-        let pos1 = BitVec::from((0x05u64, 8));
-        let pos2 = BitVec::from((0x0Au64, 8));
+        let pos1 = BitVec::from((0x05, 8));
+        let pos2 = BitVec::from((0x0A, 8));
         assert!(!pos1.signed_ge(&pos2)?);
         assert!(pos2.signed_ge(&pos1)?);
 
         // Test negative numbers (-5 = 0xFB and -10 = 0xF6 in 8-bit two's complement)
-        let neg5 = BitVec::from((0xFBu64, 8)); // -5
-        let neg10 = BitVec::from((0xF6u64, 8)); // -10
+        let neg5 = BitVec::from((0xFB, 8)); // -5
+        let neg10 = BitVec::from((0xF6, 8)); // -10
         assert!(neg5.signed_ge(&neg10)?); // -5 >= -10
         assert!(!neg10.signed_ge(&neg5)?); // -10 NOT>= -5
 
         // Test equality
-        let pos1_dup = BitVec::from((0x05u64, 8));
+        let pos1_dup = BitVec::from((0x05, 8));
         assert!(pos1.signed_ge(&pos1_dup)?);
         assert!(pos1_dup.signed_ge(&pos1)?);
 
@@ -196,8 +196,8 @@ mod tests {
 
     #[test]
     fn test_signed_comparison_different_lengths() {
-        let bv1 = BitVec::from((0x05u64, 8));
-        let bv2 = BitVec::from((0x0005u64, 16));
+        let bv1 = BitVec::from((0x05, 8));
+        let bv2 = BitVec::from((0x0005, 16));
         assert!(matches!(
             bv1.signed_lt(&bv2),
             Err(BitVecError::MismatchedLengths { left: 8, right: 16 })

--- a/crates/clarirs_num/src/bitvec/conversion.rs
+++ b/crates/clarirs_num/src/bitvec/conversion.rs
@@ -96,14 +96,14 @@ mod tests {
         assert_eq!(bv.to_biguint(), BigUint::zero());
 
         // Test various positive values
-        let bv = BitVec::from((42u64, 64));
+        let bv = BitVec::from((42, 64));
         assert_eq!(bv.to_biguint(), BigUint::from(42u64));
 
         // Test different widths
-        let bv = BitVec::from((0xFFu64, 8));
+        let bv = BitVec::from((0xFF, 8));
         assert_eq!(bv.to_biguint(), BigUint::from(0xFFu64));
 
-        let bv = BitVec::from((0xFFFFu64, 16));
+        let bv = BitVec::from((0xFFFF, 16));
         assert_eq!(bv.to_biguint(), BigUint::from(0xFFFFu64));
 
         // Test maximum value for width
@@ -116,7 +116,7 @@ mod tests {
         assert_eq!(bv.to_biguint(), value);
 
         // Test single-bit vector
-        let bv = BitVec::from((1u64, 1));
+        let bv = BitVec::from((1, 1));
         assert_eq!(bv.to_biguint(), BigUint::one());
 
         // Test zero-width vector
@@ -179,7 +179,7 @@ mod tests {
         assert_eq!(bv.to_u64().unwrap(), 0);
 
         // Test conversion of various values
-        let bv = BitVec::from((42u64, 64));
+        let bv = BitVec::from((42, 64));
         assert_eq!(bv.to_u64().unwrap(), 42);
 
         // Test width > 64 (should error)
@@ -187,10 +187,10 @@ mod tests {
         assert!(bv.to_u64().is_none());
 
         // Test different widths
-        let bv = BitVec::from((0xFFu64, 8));
+        let bv = BitVec::from((0xFF, 8));
         assert_eq!(bv.to_u64().unwrap(), 0xFF);
 
-        let bv = BitVec::from((0xFFFFu64, 16));
+        let bv = BitVec::from((0xFFFF, 16));
         assert_eq!(bv.to_u64().unwrap(), 0xFFFF);
 
         // Test maximum value for width
@@ -198,11 +198,11 @@ mod tests {
         assert_eq!(bv.to_u64().unwrap(), u32::MAX as u64);
 
         // Test odd-sized vectors
-        let bv = BitVec::from((0x1Fu64, 5)); // 5 bits
+        let bv = BitVec::from((0x1F, 5)); // 5 bits
         assert_eq!(bv.to_u64().unwrap(), 0x1F);
 
         // Test single-bit vector
-        let bv = BitVec::from((1u64, 1));
+        let bv = BitVec::from((1, 1));
         assert_eq!(bv.to_u64().unwrap(), 1);
     }
 
@@ -213,7 +213,7 @@ mod tests {
         assert_eq!(bv.to_usize().unwrap(), 0);
 
         // Test conversion of various values
-        let bv = BitVec::from((42u64, 64));
+        let bv = BitVec::from((42, 64));
         assert_eq!(bv.to_usize().unwrap(), 42);
 
         // Test width > usize::BITS (should error)
@@ -221,10 +221,10 @@ mod tests {
         assert!(bv.to_usize().is_none());
 
         // Test different widths
-        let bv = BitVec::from((0xFFu64, 8));
+        let bv = BitVec::from((0xFF, 8));
         assert_eq!(bv.to_usize().unwrap(), 0xFF);
 
-        let bv = BitVec::from((0xFFFFu64, 16));
+        let bv = BitVec::from((0xFFFF, 16));
         assert_eq!(bv.to_usize().unwrap(), 0xFFFF);
 
         // Test maximum value for width
@@ -236,36 +236,36 @@ mod tests {
         }
 
         // Test odd-sized vectors
-        let bv = BitVec::from((0x1Fu64, 5)); // 5 bits
+        let bv = BitVec::from((0x1F, 5)); // 5 bits
         assert_eq!(bv.to_usize().unwrap(), 0x1F);
 
         // Test single-bit vector
-        let bv = BitVec::from((1u64, 1));
+        let bv = BitVec::from((1, 1));
         assert_eq!(bv.to_usize().unwrap(), 1);
     }
 
     #[test]
     fn test_from_u8() {
-        let bv = BitVec::from((42u64, 8));
+        let bv = BitVec::from((42, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 42);
 
-        let bv = BitVec::from((0u64, 8));
+        let bv = BitVec::from((0, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
-        let bv = BitVec::from((255u64, 8));
+        let bv = BitVec::from((255, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 255);
     }
 
     #[test]
     fn test_from_u16() {
-        let bv = BitVec::from((4242u64, 16));
+        let bv = BitVec::from((4242, 16));
         assert_eq!(bv.len(), 16);
         assert_eq!(bv.to_u64().unwrap(), 4242);
 
-        let bv = BitVec::from((0u64, 16));
+        let bv = BitVec::from((0, 16));
         assert_eq!(bv.len(), 16);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
@@ -276,11 +276,11 @@ mod tests {
 
     #[test]
     fn test_from_u32() {
-        let bv = BitVec::from((424242u64, 32));
+        let bv = BitVec::from((424242, 32));
         assert_eq!(bv.len(), 32);
         assert_eq!(bv.to_u64().unwrap(), 424242);
 
-        let bv = BitVec::from((0u64, 32));
+        let bv = BitVec::from((0, 32));
         assert_eq!(bv.len(), 32);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
@@ -291,11 +291,11 @@ mod tests {
 
     #[test]
     fn test_from_u64() {
-        let bv = BitVec::from((42424242u64, 64));
+        let bv = BitVec::from((42424242, 64));
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), 42424242);
 
-        let bv = BitVec::from((0u64, 64));
+        let bv = BitVec::from((0, 64));
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), 0);
 

--- a/crates/clarirs_num/src/bitvec/conversion.rs
+++ b/crates/clarirs_num/src/bitvec/conversion.rs
@@ -1,29 +1,72 @@
-use num_bigint::{BigInt, BigUint};
+use num_bigint::{BigInt, BigUint, Sign};
+use num_traits::{Num, Zero};
+use smallvec::SmallVec;
 
-use super::BitVec;
+use super::{BitVec, BitVecError};
 
-macro_rules! impl_from_unsigned {
-    ($($ty:ty => $bits:expr),+ $(,)?) => {
-        $(impl From<$ty> for BitVec {
-            fn from(value: $ty) -> BitVec {
-                Self::from_biguint(&BigUint::from(value), $bits)
-            }
-        })+
-    };
+impl From<(u64, u32)> for BitVec {
+    /// Builds a `BitVec` of `length` bits from `value`, truncating to the low
+    /// `length` bits.
+    fn from((value, length): (u64, u32)) -> Self {
+        // Truncate the value to fit within the given length.
+        let truncated_value = if length < 64 {
+            value & ((1u64 << length) - 1)
+        } else {
+            value
+        };
+
+        let mut words = SmallVec::new();
+        words.push(truncated_value);
+        BitVec::new(words, length).expect("BitVec::new is infallible")
+    }
 }
 
-macro_rules! impl_from_signed {
-    ($($ty:ty => $bits:expr),+ $(,)?) => {
-        $(impl From<$ty> for BitVec {
-            fn from(value: $ty) -> BitVec {
-                Self::from_bigint(&BigInt::from(value), $bits)
-            }
-        })+
-    };
+impl From<(BigUint, u32)> for BitVec {
+    /// Builds a `BitVec` of `length` bits from `value`, truncating to the low
+    /// `length` bits.
+    fn from((value, length): (BigUint, u32)) -> Self {
+        let truncated = if value.bits() as u32 > length {
+            value % (BigUint::from(1u8) << length)
+        } else {
+            value
+        };
+
+        // A zero value yields an empty digit list, which `new` pads out.
+        let digits: SmallVec<[u64; 1]> = truncated.iter_u64_digits().collect();
+        BitVec::new(digits, length).expect("BitVec::new is infallible")
+    }
 }
 
-impl_from_unsigned!(u8 => 8, u16 => 16, u32 => 32, u64 => 64, u128 => 128);
-impl_from_signed!(i8 => 8, i16 => 16, i32 => 32, i64 => 64, i128 => 128);
+impl From<(BigInt, u32)> for BitVec {
+    /// Builds a `BitVec` of `length` bits from a signed `value`, using two's
+    /// complement and truncating to `length` bits.
+    fn from((value, length): (BigInt, u32)) -> Self {
+        let big_uint = if value.sign() == Sign::Minus {
+            // For negative values, compute 2's complement: 2^length - (|value| % 2^length)
+            let modulus = BigUint::from(1u8) << length;
+            let truncated_magnitude = value.magnitude() % &modulus;
+            if truncated_magnitude.is_zero() {
+                BigUint::zero()
+            } else {
+                &modulus - truncated_magnitude
+            }
+        } else {
+            // For positive values, truncate the magnitude
+            value.magnitude() % (BigUint::from(1u8) << length)
+        };
+        BitVec::from((big_uint, length))
+    }
+}
+
+impl TryFrom<(String, u32)> for BitVec {
+    type Error = BitVecError;
+
+    /// Parses a base-10 string into a `BitVec` of `length` bits.
+    fn try_from((s, length): (String, u32)) -> Result<Self, Self::Error> {
+        let value = BigUint::from_str_radix(&s, 10).map_err(|_| BitVecError::ConversionError)?;
+        Ok(BitVec::from((value, length)))
+    }
+}
 
 impl From<BitVec> for BigUint {
     fn from(bv: BitVec) -> Self {
@@ -53,27 +96,27 @@ mod tests {
         assert_eq!(bv.to_biguint(), BigUint::zero());
 
         // Test various positive values
-        let bv = BitVec::from(42u64);
+        let bv = BitVec::from((42u64, 64));
         assert_eq!(bv.to_biguint(), BigUint::from(42u64));
 
         // Test different widths
-        let bv = BitVec::from(0xFFu8);
+        let bv = BitVec::from((0xFFu64, 8));
         assert_eq!(bv.to_biguint(), BigUint::from(0xFFu64));
 
-        let bv = BitVec::from(0xFFFFu16);
+        let bv = BitVec::from((0xFFFFu64, 16));
         assert_eq!(bv.to_biguint(), BigUint::from(0xFFFFu64));
 
         // Test maximum value for width
-        let bv = BitVec::from(u32::MAX);
+        let bv = BitVec::from((u32::MAX as u64, 32));
         assert_eq!(bv.to_biguint(), BigUint::from(u32::MAX));
 
         // Test odd-sized vectors (e.g., 17 bits)
         let value = BigUint::from(0x1FFFFu64); // 17 bits set
-        let bv = BitVec::from_biguint(&value, 17);
+        let bv = BitVec::from((value.clone(), 17));
         assert_eq!(bv.to_biguint(), value);
 
         // Test single-bit vector
-        let bv = BitVec::from_prim_with_size(1u8, 1).unwrap();
+        let bv = BitVec::from((1u64, 1));
         assert_eq!(bv.to_biguint(), BigUint::one());
 
         // Test zero-width vector
@@ -82,7 +125,7 @@ mod tests {
 
         // Test 72-bit vector
         let value = (BigUint::one() << 72u32) - BigUint::one(); // 2^72 - 1
-        let bv = BitVec::from_biguint(&value, 72);
+        let bv = BitVec::from((value.clone(), 72));
         assert_eq!(bv.to_biguint(), value);
     }
 
@@ -92,40 +135,40 @@ mod tests {
         use num_traits::One;
 
         // Test conversion from zero
-        let bv = BitVec::from_biguint(&BigUint::zero(), 64);
+        let bv = BitVec::from((BigUint::zero(), 64));
         assert_eq!(bv.to_u64().unwrap(), 0);
 
         // Test various positive values
         let value = BigUint::from(42u64);
-        let bv = BitVec::from_biguint(&value, 64);
+        let bv = BitVec::from((value, 64));
         assert_eq!(bv.to_u64().unwrap(), 42);
 
         // Test value truncation
         let value = BigUint::from(0xFFu64);
-        let bv = BitVec::from_biguint(&value, 4);
+        let bv = BitVec::from((value, 4));
         assert_eq!(bv.to_u64().unwrap(), 0xF); // 0xFF truncated to 4 bits = 0xF
 
         // Test explicit truncation function
         let value = BigUint::from(0xFFu64);
-        let bv = BitVec::from_biguint(&value, 4);
+        let bv = BitVec::from((value, 4));
         assert_eq!(bv.to_u64().unwrap() & 0xF, 0xF); // Only compare the lowest 4 bits
 
         // Test different widths
         let value = BigUint::from(0xFFu64);
-        let bv = BitVec::from_biguint(&value, 8);
+        let bv = BitVec::from((value, 8));
         assert_eq!(bv.to_u64().unwrap(), 0xFF);
 
         // Test odd-sized vectors
         let value = BigUint::from(0x1Fu64); // 5 bits
-        let bv = BitVec::from_biguint(&value, 5);
+        let bv = BitVec::from((value, 5));
         assert_eq!(bv.to_u64().unwrap(), 0x1F);
 
         // Test single-bit vector
-        let bv = BitVec::from_biguint(&BigUint::one(), 1);
+        let bv = BitVec::from((BigUint::one(), 1));
         assert_eq!(bv.to_u64().unwrap(), 1);
 
         // Test zero-width vector
-        let bv = BitVec::from_biguint(&BigUint::zero(), 0);
+        let bv = BitVec::from((BigUint::zero(), 0));
         assert_eq!(bv.len(), 0);
     }
 
@@ -136,7 +179,7 @@ mod tests {
         assert_eq!(bv.to_u64().unwrap(), 0);
 
         // Test conversion of various values
-        let bv = BitVec::from(42u64);
+        let bv = BitVec::from((42u64, 64));
         assert_eq!(bv.to_u64().unwrap(), 42);
 
         // Test width > 64 (should error)
@@ -144,22 +187,22 @@ mod tests {
         assert!(bv.to_u64().is_none());
 
         // Test different widths
-        let bv = BitVec::from(0xFFu8);
+        let bv = BitVec::from((0xFFu64, 8));
         assert_eq!(bv.to_u64().unwrap(), 0xFF);
 
-        let bv = BitVec::from(0xFFFFu16);
+        let bv = BitVec::from((0xFFFFu64, 16));
         assert_eq!(bv.to_u64().unwrap(), 0xFFFF);
 
         // Test maximum value for width
-        let bv = BitVec::from(u32::MAX);
+        let bv = BitVec::from((u32::MAX as u64, 32));
         assert_eq!(bv.to_u64().unwrap(), u32::MAX as u64);
 
         // Test odd-sized vectors
-        let bv = BitVec::from_prim_with_size(0x1Fu8, 5).unwrap(); // 5 bits
+        let bv = BitVec::from((0x1Fu64, 5)); // 5 bits
         assert_eq!(bv.to_u64().unwrap(), 0x1F);
 
         // Test single-bit vector
-        let bv = BitVec::from_prim_with_size(1u8, 1).unwrap();
+        let bv = BitVec::from((1u64, 1));
         assert_eq!(bv.to_u64().unwrap(), 1);
     }
 
@@ -170,7 +213,7 @@ mod tests {
         assert_eq!(bv.to_usize().unwrap(), 0);
 
         // Test conversion of various values
-        let bv = BitVec::from(42u64);
+        let bv = BitVec::from((42u64, 64));
         assert_eq!(bv.to_usize().unwrap(), 42);
 
         // Test width > usize::BITS (should error)
@@ -178,14 +221,14 @@ mod tests {
         assert!(bv.to_usize().is_none());
 
         // Test different widths
-        let bv = BitVec::from(0xFFu8);
+        let bv = BitVec::from((0xFFu64, 8));
         assert_eq!(bv.to_usize().unwrap(), 0xFF);
 
-        let bv = BitVec::from(0xFFFFu16);
+        let bv = BitVec::from((0xFFFFu64, 16));
         assert_eq!(bv.to_usize().unwrap(), 0xFFFF);
 
         // Test maximum value for width
-        let max_32bit = BitVec::from(u32::MAX);
+        let max_32bit = BitVec::from((u32::MAX as u64, 32));
         if usize::BITS >= 32 {
             assert_eq!(max_32bit.to_usize().unwrap(), u32::MAX as usize);
         } else {
@@ -193,77 +236,77 @@ mod tests {
         }
 
         // Test odd-sized vectors
-        let bv = BitVec::from_prim_with_size(0x1Fu8, 5).unwrap(); // 5 bits
+        let bv = BitVec::from((0x1Fu64, 5)); // 5 bits
         assert_eq!(bv.to_usize().unwrap(), 0x1F);
 
         // Test single-bit vector
-        let bv = BitVec::from_prim_with_size(1u8, 1).unwrap();
+        let bv = BitVec::from((1u64, 1));
         assert_eq!(bv.to_usize().unwrap(), 1);
     }
 
     #[test]
     fn test_from_u8() {
-        let bv = BitVec::from(42u8);
+        let bv = BitVec::from((42u64, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 42);
 
-        let bv = BitVec::from(0u8);
+        let bv = BitVec::from((0u64, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
-        let bv = BitVec::from(255u8);
+        let bv = BitVec::from((255u64, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 255);
     }
 
     #[test]
     fn test_from_u16() {
-        let bv = BitVec::from(4242u16);
+        let bv = BitVec::from((4242u64, 16));
         assert_eq!(bv.len(), 16);
         assert_eq!(bv.to_u64().unwrap(), 4242);
 
-        let bv = BitVec::from(0u16);
+        let bv = BitVec::from((0u64, 16));
         assert_eq!(bv.len(), 16);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
-        let bv = BitVec::from(u16::MAX);
+        let bv = BitVec::from((u16::MAX as u64, 16));
         assert_eq!(bv.len(), 16);
         assert_eq!(bv.to_u64().unwrap(), u16::MAX as u64);
     }
 
     #[test]
     fn test_from_u32() {
-        let bv = BitVec::from(424242u32);
+        let bv = BitVec::from((424242u64, 32));
         assert_eq!(bv.len(), 32);
         assert_eq!(bv.to_u64().unwrap(), 424242);
 
-        let bv = BitVec::from(0u32);
+        let bv = BitVec::from((0u64, 32));
         assert_eq!(bv.len(), 32);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
-        let bv = BitVec::from(u32::MAX);
+        let bv = BitVec::from((u32::MAX as u64, 32));
         assert_eq!(bv.len(), 32);
         assert_eq!(bv.to_u64().unwrap(), u32::MAX as u64);
     }
 
     #[test]
     fn test_from_u64() {
-        let bv = BitVec::from(42424242u64);
+        let bv = BitVec::from((42424242u64, 64));
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), 42424242);
 
-        let bv = BitVec::from(0u64);
+        let bv = BitVec::from((0u64, 64));
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
-        let bv = BitVec::from(u64::MAX);
+        let bv = BitVec::from((u64::MAX as u64, 64));
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), u64::MAX);
     }
 
     #[test]
     fn test_from_u128() {
-        let bv = BitVec::from(4242424242424242u128);
+        let bv = BitVec::from((BigUint::from(4242424242424242u128), 128));
         assert_eq!(bv.len(), 128);
         assert!(bv.to_u64().is_none()); // Too large for u64
         assert_eq!(
@@ -271,11 +314,11 @@ mod tests {
             num_bigint::BigUint::from(4242424242424242u128)
         );
 
-        let bv = BitVec::from(0u128);
+        let bv = BitVec::from((BigUint::from(0u128), 128));
         assert_eq!(bv.len(), 128);
         assert!(bv.to_u64().is_none()); // Even 0 should return None for 128-bit vectors
 
-        let bv = BitVec::from(u128::MAX);
+        let bv = BitVec::from((BigUint::from(u128::MAX), 128));
         assert_eq!(bv.len(), 128);
         assert!(bv.to_u64().is_none());
         assert_eq!(bv.to_biguint(), num_bigint::BigUint::from(u128::MAX));
@@ -283,59 +326,59 @@ mod tests {
 
     #[test]
     fn test_from_i8() {
-        let bv = BitVec::from(42i8);
+        let bv = BitVec::from((42i8 as u64, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 42);
 
-        let bv = BitVec::from(0i8);
+        let bv = BitVec::from((0i8 as u64, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
-        let bv = BitVec::from(-42i8);
+        let bv = BitVec::from((-42i8 as u64, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap() & 0xFF, 214u64); // -42i8 as u8 = 214, mask to 8 bits
 
-        let bv = BitVec::from(-1i8);
+        let bv = BitVec::from((-1i8 as u64, 8));
         assert_eq!(bv.len(), 8);
         assert_eq!(bv.to_u64().unwrap(), 255);
     }
 
     #[test]
     fn test_from_i16() {
-        let bv = BitVec::from(4242i16);
+        let bv = BitVec::from((4242i16 as u64, 16));
         assert_eq!(bv.len(), 16);
         assert_eq!(bv.to_u64().unwrap(), 4242);
 
-        let bv = BitVec::from(-4242i16);
+        let bv = BitVec::from((-4242i16 as u64, 16));
         assert_eq!(bv.len(), 16);
         assert_eq!(bv.to_u64().unwrap() & 0xFFFF, 61294u64); // -4242i16 as u16 = 61294, mask to 16 bits
     }
 
     #[test]
     fn test_from_i32() {
-        let bv = BitVec::from(424242i32);
+        let bv = BitVec::from((424242i32 as u64, 32));
         assert_eq!(bv.len(), 32);
         assert_eq!(bv.to_u64().unwrap(), 424242);
 
-        let bv = BitVec::from(-424242i32);
+        let bv = BitVec::from((-424242i32 as u64, 32));
         assert_eq!(bv.len(), 32);
         assert_eq!(bv.to_u64().unwrap() & 0xFFFFFFFF, 4294543054u64); // -424242i32 as u32 = 4294543054, mask to 32 bits
     }
 
     #[test]
     fn test_from_i64() {
-        let bv = BitVec::from(42424242i64);
+        let bv = BitVec::from((42424242i64 as u64, 64));
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), 42424242);
 
-        let bv = BitVec::from(-42424242i64);
+        let bv = BitVec::from((-42424242i64 as u64, 64));
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), (-42424242i64) as u64);
     }
 
     #[test]
     fn test_from_i128() {
-        let bv = BitVec::from(4242424242424242i128);
+        let bv = BitVec::from((BigInt::from(4242424242424242i128), 128));
         assert_eq!(bv.len(), 128);
         assert!(bv.to_u64().is_none()); // Too large for u64
         assert_eq!(
@@ -343,7 +386,7 @@ mod tests {
             num_bigint::BigUint::from(4242424242424242u128)
         );
 
-        let bv = BitVec::from(-4242424242424242i128);
+        let bv = BitVec::from((BigInt::from(-4242424242424242i128), 128));
         assert_eq!(bv.len(), 128);
         assert!(bv.to_u64().is_none());
         assert_eq!(

--- a/crates/clarirs_num/src/bitvec/extension.rs
+++ b/crates/clarirs_num/src/bitvec/extension.rs
@@ -99,7 +99,7 @@ impl BitVec {
     }
 
     pub fn zero_extend(&self, additional_bits: u32) -> Result<BitVec, BitVecError> {
-        BitVec::from((0u64, additional_bits)).concat(self)
+        BitVec::from((0, additional_bits)).concat(self)
     }
 
     pub fn sign_extend(&self, additional_bits: u32) -> Result<BitVec, BitVecError> {
@@ -120,42 +120,42 @@ mod tests {
     #[test]
     fn test_concat() -> Result<(), BitVecError> {
         // Test basic concatenation
-        let bv1 = BitVec::from((0b1100u64, 4));
-        let bv2 = BitVec::from((0b1010u64, 4));
+        let bv1 = BitVec::from((0b1100, 4));
+        let bv2 = BitVec::from((0b1010, 4));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b11001010);
         assert_eq!(result.len(), 8);
 
         // Test concatenation with zero
-        let bv1 = BitVec::from((0b1111u64, 4));
-        let bv2 = BitVec::from((0b0000u64, 4));
+        let bv1 = BitVec::from((0b1111, 4));
+        let bv2 = BitVec::from((0b0000, 4));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b11110000);
 
         // Test concatenation of different widths
-        let bv1 = BitVec::from((0b111u64, 3));
-        let bv2 = BitVec::from((0b10u64, 2));
+        let bv1 = BitVec::from((0b111, 3));
+        let bv2 = BitVec::from((0b10, 2));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b11110);
         assert_eq!(result.len(), 5);
 
         // Test concatenation of single-bit vectors
-        let bv1 = BitVec::from((1u64, 1));
-        let bv2 = BitVec::from((0u64, 1));
+        let bv1 = BitVec::from((1, 1));
+        let bv2 = BitVec::from((0, 1));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b10);
         assert_eq!(result.len(), 2);
 
         // Test concatenation of odd-sized vectors
-        let bv1 = BitVec::from((0b10101u64, 5));
-        let bv2 = BitVec::from((0b111u64, 3));
+        let bv1 = BitVec::from((0b10101, 5));
+        let bv2 = BitVec::from((0b111, 3));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b10101111);
         assert_eq!(result.len(), 8);
 
         // Test concatenation producing 72-bit vectors
         let bv1 = BitVec::from((u64::MAX, 64));
-        let bv2 = BitVec::from((0b11111111u64, 8));
+        let bv2 = BitVec::from((0b11111111, 8));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.len(), 72);
 
@@ -165,43 +165,43 @@ mod tests {
     #[test]
     fn test_extract() -> Result<(), BitVecError> {
         // Test basic extraction
-        let bv = BitVec::from((0b11001010u64, 8));
+        let bv = BitVec::from((0b11001010, 8));
         let result = bv.extract(2, 5).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b0010);
         assert_eq!(result.len(), 4);
 
         // Test extraction of entire vector
-        let bv = BitVec::from((0b1111u64, 4));
+        let bv = BitVec::from((0b1111, 4));
         let result = bv.extract(0, 3).unwrap();
         assert_eq!(result.to_u64().unwrap() & 0b1111, 0b1111); // Mask to 4 bits
         assert_eq!(result.len(), 4);
 
         // Test extraction of single bit
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.extract(1, 1).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b1);
         assert_eq!(result.len(), 1);
 
         // Test extraction with invalid range (should error)
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         assert!(bv.extract(2, 1).is_err()); // from > to
         assert!(bv.extract(0, 5).is_err()); // to > len
 
         // Test extraction from different widths
-        let bv = BitVec::from((0b110011u64, 6));
+        let bv = BitVec::from((0b110011, 6));
         let result = bv.extract(1, 4).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b1001);
         assert_eq!(result.len(), 4);
 
         // Test extraction from odd-sized vectors
-        let bv = BitVec::from((0b10101u64, 5));
+        let bv = BitVec::from((0b10101, 5));
         let result = bv.extract(1, 3).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b010);
         assert_eq!(result.len(), 3);
 
         // Test extraction from 72-bit vectors
         let mut bv = BitVec::from((u64::MAX, 64));
-        bv = bv.concat(&(BitVec::from((0b11111111u64, 8))))?;
+        bv = bv.concat(&(BitVec::from((0b11111111, 8))))?;
         let result = bv.extract(60, 67).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b11111111);
         assert_eq!(result.len(), 8);
@@ -212,37 +212,37 @@ mod tests {
     #[test]
     fn test_zero_extend() -> Result<(), BitVecError> {
         // Test extending positive number
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.zero_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0b00001010);
         assert_eq!(result.len(), 8);
 
         // Test extending zero
-        let bv = BitVec::from((0u64, 4));
+        let bv = BitVec::from((0, 4));
         let result = bv.zero_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0);
         assert_eq!(result.len(), 8);
 
         // Test extending to same width (no change)
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.zero_extend(0)?;
         assert_eq!(result.to_u64().unwrap(), 0b1010);
         assert_eq!(result.len(), 4);
 
         // Test extending from odd-sized vector
-        let bv = BitVec::from((0b101u64, 3));
+        let bv = BitVec::from((0b101, 3));
         let result = bv.zero_extend(5)?;
         assert_eq!(result.to_u64().unwrap(), 0b00000101);
         assert_eq!(result.len(), 8);
 
         // Test extending single-bit vector
-        let bv = BitVec::from((1u64, 1));
+        let bv = BitVec::from((1, 1));
         let result = bv.zero_extend(7)?;
         assert_eq!(result.to_u64().unwrap(), 0b00000001);
         assert_eq!(result.len(), 8);
 
         // Test extending to 72-bit vectors
-        let bv = BitVec::from((0xFFFFFFFFu64, 32));
+        let bv = BitVec::from((0xFFFFFFFF, 32));
         let result = bv.zero_extend(40)?;
         assert_eq!(result.len(), 72);
 
@@ -252,43 +252,43 @@ mod tests {
     #[test]
     fn test_sign_extend() -> Result<(), BitVecError> {
         // Test extending positive number
-        let bv = BitVec::from((0b0010u64, 4));
+        let bv = BitVec::from((0b0010, 4));
         let result = bv.sign_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0b00000010);
         assert_eq!(result.len(), 8);
 
         // Test extending negative number
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.sign_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0b11111010);
         assert_eq!(result.len(), 8);
 
         // Test extending zero
-        let bv = BitVec::from((0u64, 4));
+        let bv = BitVec::from((0, 4));
         let result = bv.sign_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0);
         assert_eq!(result.len(), 8);
 
         // Test extending to same width (no change)
-        let bv = BitVec::from((0b1010u64, 4));
+        let bv = BitVec::from((0b1010, 4));
         let result = bv.sign_extend(0)?;
         assert_eq!(result.to_u64().unwrap(), 0b1010);
         assert_eq!(result.len(), 4);
 
         // Test extending from odd-sized vector
-        let bv = BitVec::from((0b101u64, 3)); // 101 is negative in 3 bits
+        let bv = BitVec::from((0b101, 3)); // 101 is negative in 3 bits
         let result = bv.sign_extend(5)?;
         assert_eq!(result.to_u64().unwrap(), 0b11111101); // Sign extended to 8 bits
         assert_eq!(result.len(), 8);
 
         // Test extending single-bit vector
-        let bv = BitVec::from((1u64, 1));
+        let bv = BitVec::from((1, 1));
         let result = bv.sign_extend(7)?;
         assert_eq!(result.to_u64().unwrap(), 0b11111111);
         assert_eq!(result.len(), 8);
 
         // Test extending to 72-bit vectors
-        let bv = BitVec::from((0xFFFFFFFFu64, 32));
+        let bv = BitVec::from((0xFFFFFFFF, 32));
         let result = bv.sign_extend(40)?;
         assert_eq!(result.len(), 72);
 

--- a/crates/clarirs_num/src/bitvec/extension.rs
+++ b/crates/clarirs_num/src/bitvec/extension.rs
@@ -99,17 +99,14 @@ impl BitVec {
     }
 
     pub fn zero_extend(&self, additional_bits: u32) -> Result<BitVec, BitVecError> {
-        BitVec::from_prim_with_size(0u8, additional_bits)?.concat(self)
+        BitVec::from((0u64, additional_bits)).concat(self)
     }
 
     pub fn sign_extend(&self, additional_bits: u32) -> Result<BitVec, BitVecError> {
         let extension = if self.sign() {
-            BitVec::from_biguint(
-                &((BigUint::from(1u8) << additional_bits) - 1u8),
-                additional_bits,
-            )
+            BitVec::from(((BigUint::from(1u8) << additional_bits) - 1u8, additional_bits))
         } else {
-            BitVec::from_biguint(&BigUint::zero(), additional_bits)
+            BitVec::from((BigUint::zero(), additional_bits))
         };
         extension.concat(self)
     }
@@ -123,42 +120,42 @@ mod tests {
     #[test]
     fn test_concat() -> Result<(), BitVecError> {
         // Test basic concatenation
-        let bv1 = BitVec::from_prim_with_size(0b1100u8, 4)?;
-        let bv2 = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv1 = BitVec::from((0b1100u64, 4));
+        let bv2 = BitVec::from((0b1010u64, 4));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b11001010);
         assert_eq!(result.len(), 8);
 
         // Test concatenation with zero
-        let bv1 = BitVec::from_prim_with_size(0b1111u8, 4)?;
-        let bv2 = BitVec::from_prim_with_size(0b0000u8, 4)?;
+        let bv1 = BitVec::from((0b1111u64, 4));
+        let bv2 = BitVec::from((0b0000u64, 4));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b11110000);
 
         // Test concatenation of different widths
-        let bv1 = BitVec::from_prim_with_size(0b111u8, 3)?;
-        let bv2 = BitVec::from_prim_with_size(0b10u8, 2)?;
+        let bv1 = BitVec::from((0b111u64, 3));
+        let bv2 = BitVec::from((0b10u64, 2));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b11110);
         assert_eq!(result.len(), 5);
 
         // Test concatenation of single-bit vectors
-        let bv1 = BitVec::from_prim_with_size(1u8, 1)?;
-        let bv2 = BitVec::from_prim_with_size(0u8, 1)?;
+        let bv1 = BitVec::from((1u64, 1));
+        let bv2 = BitVec::from((0u64, 1));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b10);
         assert_eq!(result.len(), 2);
 
         // Test concatenation of odd-sized vectors
-        let bv1 = BitVec::from_prim_with_size(0b10101u8, 5)?;
-        let bv2 = BitVec::from_prim_with_size(0b111u8, 3)?;
+        let bv1 = BitVec::from((0b10101u64, 5));
+        let bv2 = BitVec::from((0b111u64, 3));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.to_u64().unwrap(), 0b10101111);
         assert_eq!(result.len(), 8);
 
         // Test concatenation producing 72-bit vectors
-        let bv1 = BitVec::from_prim_with_size(u64::MAX, 64)?;
-        let bv2 = BitVec::from_prim_with_size(0b11111111u8, 8)?;
+        let bv1 = BitVec::from((u64::MAX, 64));
+        let bv2 = BitVec::from((0b11111111u64, 8));
         let result = (bv1.concat(&bv2))?;
         assert_eq!(result.len(), 72);
 
@@ -168,43 +165,43 @@ mod tests {
     #[test]
     fn test_extract() -> Result<(), BitVecError> {
         // Test basic extraction
-        let bv = BitVec::from_prim_with_size(0b11001010u8, 8)?;
+        let bv = BitVec::from((0b11001010u64, 8));
         let result = bv.extract(2, 5).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b0010);
         assert_eq!(result.len(), 4);
 
         // Test extraction of entire vector
-        let bv = BitVec::from_prim_with_size(0b1111u8, 4)?;
+        let bv = BitVec::from((0b1111u64, 4));
         let result = bv.extract(0, 3).unwrap();
         assert_eq!(result.to_u64().unwrap() & 0b1111, 0b1111); // Mask to 4 bits
         assert_eq!(result.len(), 4);
 
         // Test extraction of single bit
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.extract(1, 1).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b1);
         assert_eq!(result.len(), 1);
 
         // Test extraction with invalid range (should error)
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         assert!(bv.extract(2, 1).is_err()); // from > to
         assert!(bv.extract(0, 5).is_err()); // to > len
 
         // Test extraction from different widths
-        let bv = BitVec::from_prim_with_size(0b110011u8, 6)?;
+        let bv = BitVec::from((0b110011u64, 6));
         let result = bv.extract(1, 4).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b1001);
         assert_eq!(result.len(), 4);
 
         // Test extraction from odd-sized vectors
-        let bv = BitVec::from_prim_with_size(0b10101u8, 5)?;
+        let bv = BitVec::from((0b10101u64, 5));
         let result = bv.extract(1, 3).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b010);
         assert_eq!(result.len(), 3);
 
         // Test extraction from 72-bit vectors
-        let mut bv = BitVec::from_prim_with_size(u64::MAX, 64)?;
-        bv = bv.concat(&(BitVec::from_prim_with_size(0b11111111u8, 8)?))?;
+        let mut bv = BitVec::from((u64::MAX, 64));
+        bv = bv.concat(&(BitVec::from((0b11111111u64, 8))))?;
         let result = bv.extract(60, 67).unwrap();
         assert_eq!(result.to_u64().unwrap(), 0b11111111);
         assert_eq!(result.len(), 8);
@@ -215,37 +212,37 @@ mod tests {
     #[test]
     fn test_zero_extend() -> Result<(), BitVecError> {
         // Test extending positive number
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.zero_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0b00001010);
         assert_eq!(result.len(), 8);
 
         // Test extending zero
-        let bv = BitVec::from_prim_with_size(0u8, 4)?;
+        let bv = BitVec::from((0u64, 4));
         let result = bv.zero_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0);
         assert_eq!(result.len(), 8);
 
         // Test extending to same width (no change)
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.zero_extend(0)?;
         assert_eq!(result.to_u64().unwrap(), 0b1010);
         assert_eq!(result.len(), 4);
 
         // Test extending from odd-sized vector
-        let bv = BitVec::from_prim_with_size(0b101u8, 3)?;
+        let bv = BitVec::from((0b101u64, 3));
         let result = bv.zero_extend(5)?;
         assert_eq!(result.to_u64().unwrap(), 0b00000101);
         assert_eq!(result.len(), 8);
 
         // Test extending single-bit vector
-        let bv = BitVec::from_prim_with_size(1u8, 1)?;
+        let bv = BitVec::from((1u64, 1));
         let result = bv.zero_extend(7)?;
         assert_eq!(result.to_u64().unwrap(), 0b00000001);
         assert_eq!(result.len(), 8);
 
         // Test extending to 72-bit vectors
-        let bv = BitVec::from_prim_with_size(0xFFFFFFFFu32, 32)?;
+        let bv = BitVec::from((0xFFFFFFFFu64, 32));
         let result = bv.zero_extend(40)?;
         assert_eq!(result.len(), 72);
 
@@ -255,43 +252,43 @@ mod tests {
     #[test]
     fn test_sign_extend() -> Result<(), BitVecError> {
         // Test extending positive number
-        let bv = BitVec::from_prim_with_size(0b0010u8, 4)?;
+        let bv = BitVec::from((0b0010u64, 4));
         let result = bv.sign_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0b00000010);
         assert_eq!(result.len(), 8);
 
         // Test extending negative number
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.sign_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0b11111010);
         assert_eq!(result.len(), 8);
 
         // Test extending zero
-        let bv = BitVec::from_prim_with_size(0u8, 4)?;
+        let bv = BitVec::from((0u64, 4));
         let result = bv.sign_extend(4)?;
         assert_eq!(result.to_u64().unwrap(), 0);
         assert_eq!(result.len(), 8);
 
         // Test extending to same width (no change)
-        let bv = BitVec::from_prim_with_size(0b1010u8, 4)?;
+        let bv = BitVec::from((0b1010u64, 4));
         let result = bv.sign_extend(0)?;
         assert_eq!(result.to_u64().unwrap(), 0b1010);
         assert_eq!(result.len(), 4);
 
         // Test extending from odd-sized vector
-        let bv = BitVec::from_prim_with_size(0b101u8, 3)?; // 101 is negative in 3 bits
+        let bv = BitVec::from((0b101u64, 3)); // 101 is negative in 3 bits
         let result = bv.sign_extend(5)?;
         assert_eq!(result.to_u64().unwrap(), 0b11111101); // Sign extended to 8 bits
         assert_eq!(result.len(), 8);
 
         // Test extending single-bit vector
-        let bv = BitVec::from_prim_with_size(1u8, 1)?;
+        let bv = BitVec::from((1u64, 1));
         let result = bv.sign_extend(7)?;
         assert_eq!(result.to_u64().unwrap(), 0b11111111);
         assert_eq!(result.len(), 8);
 
         // Test extending to 72-bit vectors
-        let bv = BitVec::from_prim_with_size(0xFFFFFFFFu32, 32)?;
+        let bv = BitVec::from((0xFFFFFFFFu64, 32));
         let result = bv.sign_extend(40)?;
         assert_eq!(result.len(), 72);
 

--- a/crates/clarirs_num/src/bitvec/reference_tests.rs
+++ b/crates/clarirs_num/src/bitvec/reference_tests.rs
@@ -61,7 +61,7 @@ fn signed_val(value: &BigUint, width: u32) -> BigInt {
 }
 
 fn bv_u(value: &BigUint, width: u32) -> BitVec {
-    BitVec::from_biguint(value, width)
+    BitVec::from((value.clone(), width))
 }
 
 // ----------------------------------------------------------------------------
@@ -100,7 +100,7 @@ fn regression_shift_by_ge_width_is_zero() {
 #[test]
 fn regression_shift_by_zero_is_identity() {
     for &width in WIDTHS {
-        let v = BitVec::from_biguint(&(modulus(width) - 1u8 - 1u8), width);
+        let v = BitVec::from((modulus(width) - 1u8 - 1u8, width));
         assert_eq!((v.clone() << 0).unwrap(), v);
         assert_eq!((v.clone() >> 0).unwrap(), v);
     }
@@ -108,14 +108,14 @@ fn regression_shift_by_zero_is_identity() {
 
 #[test]
 fn regression_rem_by_zero_is_error_not_panic() {
-    let a = BitVec::from(42u64);
-    let b = BitVec::from(0u64);
+    let a = BitVec::from((42u64, 64));
+    let b = BitVec::from((0u64, 64));
     assert!(matches!(a % b, Err(BitVecError::DivisionByZero)));
 }
 
 #[test]
 fn regression_zero_length_is_canonical() {
-    let from_prim = BitVec::from_prim_with_size(0u8, 0).unwrap();
+    let from_prim = BitVec::from((0u64, 0));
     let zeros = BitVec::zeros(0);
     assert_eq!(from_prim, zeros);
     assert_eq!(from_prim.is_all_ones(), zeros.is_all_ones());
@@ -164,7 +164,7 @@ fn reference_sweep_unsigned() {
             );
             assert_eq!(
                 (bv_a.clone() - bv_b.clone()).unwrap(),
-                BitVec::from_bigint(&(BigInt::from(a.clone()) - BigInt::from(b.clone())), width),
+                BitVec::from((BigInt::from(a.clone()) - BigInt::from(b.clone()), width)),
                 "sub w={width} a={a} b={b}"
             );
             assert_eq!(
@@ -174,7 +174,7 @@ fn reference_sweep_unsigned() {
             );
             assert_eq!(
                 (-bv_a.clone()).unwrap(),
-                BitVec::from_bigint(&(-BigInt::from(a.clone())), width),
+                BitVec::from((-BigInt::from(a.clone()), width)),
                 "neg w={width} a={a}"
             );
 
@@ -218,12 +218,12 @@ fn reference_sweep_unsigned() {
             let (sa, sb) = (signed_val(&a, width), signed_val(&b, width));
             assert_eq!(
                 bv_a.sdiv(&bv_b).unwrap(),
-                BitVec::from_bigint(&(&sa / &sb), width),
+                BitVec::from((&sa / &sb, width)),
                 "sdiv w={width} a={a} b={b}"
             );
             assert_eq!(
                 bv_a.srem(&bv_b).unwrap(),
-                BitVec::from_bigint(&(&sa % &sb), width),
+                BitVec::from((&sa % &sb, width)),
                 "srem w={width} a={a} b={b}"
             );
 
@@ -318,7 +318,7 @@ fn reference_sweep_unsigned() {
             );
             assert_eq!(
                 bv_a.sign_extend(n).unwrap(),
-                BitVec::from_bigint(&sa, width + n),
+                BitVec::from((sa, width + n)),
                 "sext w={width} a={a} n={n}"
             );
 

--- a/crates/clarirs_num/src/bitvec/reference_tests.rs
+++ b/crates/clarirs_num/src/bitvec/reference_tests.rs
@@ -108,14 +108,14 @@ fn regression_shift_by_zero_is_identity() {
 
 #[test]
 fn regression_rem_by_zero_is_error_not_panic() {
-    let a = BitVec::from((42u64, 64));
-    let b = BitVec::from((0u64, 64));
+    let a = BitVec::from((42, 64));
+    let b = BitVec::from((0, 64));
     assert!(matches!(a % b, Err(BitVecError::DivisionByZero)));
 }
 
 #[test]
 fn regression_zero_length_is_canonical() {
-    let from_prim = BitVec::from((0u64, 0));
+    let from_prim = BitVec::from((0, 0));
     let zeros = BitVec::zeros(0);
     assert_eq!(from_prim, zeros);
     assert_eq!(from_prim.is_all_ones(), zeros.is_all_ones());

--- a/crates/clarirs_num/src/bitvec/tests.rs
+++ b/crates/clarirs_num/src/bitvec/tests.rs
@@ -12,21 +12,21 @@ fn test_leading_zeros() -> Result<(), BitVecError> {
     assert_eq!(bv.leading_zeros(), 64);
 
     // Test all ones (no leading zeros)
-    let bv = BitVec::from_prim_with_size(0xFFu8, 8)?;
+    let bv = BitVec::from((0xFFu64, 8));
     assert_eq!(bv.leading_zeros(), 0);
 
     // Test single one at different positions
-    let bv = BitVec::from_prim_with_size(0b00000001u8, 8)?;
+    let bv = BitVec::from((0b00000001u64, 8));
     assert_eq!(bv.leading_zeros(), 7);
-    let bv = BitVec::from_prim_with_size(0b00000100u8, 8)?;
+    let bv = BitVec::from((0b00000100u64, 8));
     assert_eq!(bv.leading_zeros(), 5);
-    let bv = BitVec::from_prim_with_size(0b10000000u8, 8)?;
+    let bv = BitVec::from((0b10000000u64, 8));
     assert_eq!(bv.leading_zeros(), 0);
 
     // Test different widths
-    let bv = BitVec::from_prim_with_size(0b00001111u8, 8)?;
+    let bv = BitVec::from((0b00001111u64, 8));
     assert_eq!(bv.leading_zeros(), 4);
-    let bv = BitVec::from_prim_with_size(0b0000111100001111u16, 16)?;
+    let bv = BitVec::from((0b0000111100001111u64, 16));
     assert_eq!(bv.leading_zeros(), 4);
 
     // Test zero-width vector
@@ -34,7 +34,7 @@ fn test_leading_zeros() -> Result<(), BitVecError> {
     assert_eq!(bv.leading_zeros(), 0);
 
     // Test odd-sized vectors
-    let bv = BitVec::from_prim_with_size(0b010u8, 3)?; // Only 3 bits: 010
+    let bv = BitVec::from((0b010u64, 3)); // Only 3 bits: 010
     assert_eq!(bv.leading_zeros(), 1);
 
     // Test 72-bit vectors
@@ -57,55 +57,55 @@ fn test_leading_zeros() -> Result<(), BitVecError> {
 fn test_from_bigint() -> Result<(), BitVecError> {
     // Test positive values
     let value = BigInt::from(42i32);
-    let bv = BitVec::from_bigint(&value, 32);
+    let bv = BitVec::from((value, 32));
     assert_eq!(bv.len(), 32);
     assert_eq!(bv.to_u64().unwrap(), 42);
 
     // Test zero
     let value = BigInt::zero();
-    let bv = BitVec::from_bigint(&value, 32);
+    let bv = BitVec::from((value, 32));
     assert_eq!(bv.len(), 32);
     assert_eq!(bv.to_u64().unwrap(), 0);
 
     // Test negative values (2's complement representation)
     // -1 in 8-bit 2's complement is 11111111 (all ones)
     let value = BigInt::from(-1i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 0xFF);
     assert!(bv.is_all_ones());
 
     // -42 in 8-bit 2's complement is 256 - 42 = 214 (0xD6)
     let value = BigInt::from(-42i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 0xD6);
 
     // -128 in 8-bit 2's complement is 10000000 (0x80)
     let value = BigInt::from(-128i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 0x80);
 
     // Test different bit widths
     let value = BigInt::from(-1i32);
-    let bv = BitVec::from_bigint(&value, 16);
+    let bv = BitVec::from((value, 16));
     assert_eq!(bv.len(), 16);
     assert_eq!(bv.to_u64().unwrap(), 0xFFFF);
 
     let value = BigInt::from(-1i32);
-    let bv = BitVec::from_bigint(&value, 32);
+    let bv = BitVec::from((value, 32));
     assert_eq!(bv.len(), 32);
     assert_eq!(bv.to_u64().unwrap(), 0xFFFFFFFF);
 
     // Test truncation with positive value
     let value = BigInt::from(256i32);
-    let result = BitVec::from_bigint(&value, 8);
+    let result = BitVec::from((value, 8));
     assert_eq!(result.to_u64().unwrap(), 0); // 256 & 0xFF = 0
 
     // Test truncation with negative value
     let value = BigInt::from(-129i32);
-    let result = BitVec::from_bigint(&value, 8);
+    let result = BitVec::from((value, 8));
     assert_eq!(result.to_u64().unwrap(), 127); // -129 mod 256 = 127 in two's complement
 
     Ok(())
@@ -115,57 +115,57 @@ fn test_from_bigint() -> Result<(), BitVecError> {
 fn test_from_bigint_truncation() {
     // Test positive values
     let value = BigInt::from(42i32);
-    let bv = BitVec::from_bigint(&value, 32);
+    let bv = BitVec::from((value, 32));
     assert_eq!(bv.len(), 32);
     assert_eq!(bv.to_u64().unwrap(), 42);
 
     // Test truncation of positive values
     let value = BigInt::from(0x12345678i32);
-    let bv = BitVec::from_bigint(&value, 16); // Truncate to 16 bits
+    let bv = BitVec::from((value, 16)); // Truncate to 16 bits
     assert_eq!(bv.len(), 16);
     assert_eq!(bv.to_u64().unwrap(), 0x5678); // Only lower 16 bits should remain
 
     // Test negative values (2's complement representation)
     // -1 in 8-bit 2's complement is 11111111 (all ones)
     let value = BigInt::from(-1i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 0xFF);
     assert!(bv.is_all_ones());
 
     // -42 in 8-bit 2's complement is 256 - 42 = 214 (0xD6)
     let value = BigInt::from(-42i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 0xD6);
 
     // Test truncation of negative values
     let value = BigInt::from(-0x12345678i32);
-    let bv = BitVec::from_bigint(&value, 16); // Truncate to 16 bits
+    let bv = BitVec::from((value, 16)); // Truncate to 16 bits
     assert_eq!(bv.len(), 16);
     // In 2's complement, -0x12345678 truncated to 16 bits should be the 2's complement of 0x5678
     assert_eq!(bv.to_u64().unwrap(), 0xA988); // 2's complement of 0x5678 in 16 bits
 
     // Test different bit widths
     let value = BigInt::from(-1i32);
-    let bv = BitVec::from_bigint(&value, 16);
+    let bv = BitVec::from((value, 16));
     assert_eq!(bv.len(), 16);
     assert_eq!(bv.to_u64().unwrap(), 0xFFFF);
 
     // Test zero
     let value = BigInt::zero();
-    let bv = BitVec::from_bigint(&value, 32);
+    let bv = BitVec::from((value, 32));
     assert_eq!(bv.len(), 32);
     assert_eq!(bv.to_u64().unwrap(), 0);
 
     // Test with values larger than the specified width
     let value = BigInt::from(256i32);
-    let bv = BitVec::from_bigint(&value, 8); // 256 doesn't fit in 8 bits
+    let bv = BitVec::from((value, 8)); // 256 doesn't fit in 8 bits
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 0); // Should be truncated to 0
 
     let value = BigInt::from(257i32);
-    let bv = BitVec::from_bigint(&value, 8); // 257 (0x101) truncated to 8 bits
+    let bv = BitVec::from((value, 8)); // 257 (0x101) truncated to 8 bits
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 1); // Should be truncated to 1
 }
@@ -174,42 +174,42 @@ fn test_from_bigint_truncation() {
 fn test_from_biguint_truncation() {
     // Test values within bit width
     let value = BigUint::from(42u32);
-    let bv = BitVec::from_biguint(&value, 32);
+    let bv = BitVec::from((value, 32));
     assert_eq!(bv.len(), 32);
     assert_eq!(bv.to_u64().unwrap(), 42);
 
     // Test truncation
     let value = BigUint::from(0x12345678u32);
-    let bv = BitVec::from_biguint(&value, 16); // Truncate to 16 bits
+    let bv = BitVec::from((value, 16)); // Truncate to 16 bits
     assert_eq!(bv.len(), 16);
     assert_eq!(bv.to_u64().unwrap(), 0x5678); // Only lower 16 bits should remain
 
     // Test different bit widths
     let value = BigUint::from(0xFFu32);
-    let bv = BitVec::from_biguint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 0xFF);
 
     // Test zero
     let value = BigUint::zero();
-    let bv = BitVec::from_biguint(&value, 32);
+    let bv = BitVec::from((value, 32));
     assert_eq!(bv.len(), 32);
     assert_eq!(bv.to_u64().unwrap(), 0);
 
     // Test with values larger than the specified width
     let value = BigUint::from(256u32);
-    let bv = BitVec::from_biguint(&value, 8); // 256 doesn't fit in 8 bits
+    let bv = BitVec::from((value, 8)); // 256 doesn't fit in 8 bits
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 0); // Should be truncated to 0
 
     let value = BigUint::from(257u32);
-    let bv = BitVec::from_biguint(&value, 8); // 257 (0x101) truncated to 8 bits
+    let bv = BitVec::from((value, 8)); // 257 (0x101) truncated to 8 bits
     assert_eq!(bv.len(), 8);
     assert_eq!(bv.to_u64().unwrap(), 1); // Should be truncated to 1
 
     // Test with large values
     let value = (BigUint::from(1u32) << 64) - BigUint::from(1u32); // 2^64 - 1
-    let bv = BitVec::from_biguint(&value, 32); // Truncate to 32 bits
+    let bv = BitVec::from((value, 32u32)); // Truncate to 32 bits
     assert_eq!(bv.len(), 32);
     assert_eq!(bv.to_u64().unwrap(), 0xFFFFFFFF); // Should be all ones in 32 bits
 }
@@ -220,22 +220,22 @@ fn test_bigint_biguint_conversion() -> Result<(), BitVecError> {
 
     // Positive values should be the same in both representations
     let value = BigInt::from(42i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.to_u64().unwrap(), 42);
 
     // -1 in 8-bit 2's complement is 11111111 (all ones, or 255 unsigned)
     let value = BigInt::from(-1i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.to_u64().unwrap(), 0xFF);
 
     // -42 in 8-bit 2's complement is 256 - 42 = 214 (0xD6)
     let value = BigInt::from(-42i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     assert_eq!(bv.to_u64().unwrap(), 0xD6);
 
     // Convert back to BigUint (should remain as 2's complement representation)
     let value = BigInt::from(-42i32);
-    let bv = BitVec::from_bigint(&value, 8);
+    let bv = BitVec::from((value, 8));
     let biguint: BigUint = bv.to_biguint();
     assert_eq!(biguint, BigUint::from(0xD6u32));
 
@@ -243,15 +243,15 @@ fn test_bigint_biguint_conversion() -> Result<(), BitVecError> {
     let value = BigInt::from(-42i32);
 
     // 8-bit: -42 = 214 (0xD6)
-    let bv8 = BitVec::from_bigint(&value, 8);
+    let bv8 = BitVec::from((value.clone(), 8));
     assert_eq!(bv8.to_u64().unwrap(), 0xD6);
 
     // 16-bit: -42 = 65494 (0xFFD6)
-    let bv16 = BitVec::from_bigint(&value, 16);
+    let bv16 = BitVec::from((value.clone(), 16));
     assert_eq!(bv16.to_u64().unwrap(), 0xFFD6);
 
     // 32-bit: -42 = 4294967254 (0xFFFFFFD6)
-    let bv32 = BitVec::from_bigint(&value, 32);
+    let bv32 = BitVec::from((value, 32));
     assert_eq!(bv32.to_u64().unwrap(), 0xFFFFFFD6);
 
     Ok(())
@@ -260,36 +260,33 @@ fn test_bigint_biguint_conversion() -> Result<(), BitVecError> {
 #[test]
 fn test_valid_bv_from_length() {
     // Basic valid creation
-    let bv = BitVec::from_prim_with_size(5u8, 8);
-    let bv = bv.unwrap();
+    let bv = BitVec::from((5u64, 8));
     assert_eq!(bv.length, 8);
     assert_eq!(bv.words[0], 5);
 
     // Creating a BitVec with a larger value and different size
-    let bv = BitVec::from_prim_with_size(255u8, 8);
-    let bv = bv.unwrap();
+    let bv = BitVec::from((255u64, 8));
     assert_eq!(bv.length, 8);
     assert_eq!(bv.words[0], 255);
 
     // Creating a 16-bit BitVec from a u16
-    let bv = BitVec::from_prim_with_size(1023u16, 16);
-    let bv = bv.unwrap();
+    let bv = BitVec::from((1023u64, 16));
     assert_eq!(bv.length, 16);
     assert_eq!(bv.words[0], 1023);
 
-    // Edge case - a zero value in a too-small size
-    let result = BitVec::from_prim_with_size(0u8, 0);
-    assert!(result.is_ok());
+    // Edge case - a zero value in a zero-width size
+    let result = BitVec::from((0u64, 0));
+    assert_eq!(result.len(), 0);
 }
 
 #[test]
 fn test_invalid_bv_from_length() {
     // Value larger than bit width is truncated
-    let bv = BitVec::from_prim_with_size(5u8, 1).unwrap();
+    let bv = BitVec::from((5u64, 1));
     assert_eq!(bv.to_u64().unwrap(), 1); // 5 & 1 = 1
 
     // Value truncated to fit within bit width
-    let bv = BitVec::from_prim_with_size(255u8, 4).unwrap();
+    let bv = BitVec::from((255u64, 4));
     assert_eq!(bv.to_u64().unwrap(), 15); // 255 & 0xF = 15
 }
 
@@ -300,16 +297,16 @@ fn test_is_zero() -> Result<(), BitVecError> {
     assert!(bv.is_zero());
 
     // Test false case (any bit one)
-    let bv = BitVec::from_prim_with_size(1u64, 64)?;
+    let bv = BitVec::from((1u64, 64));
     assert!(!bv.is_zero());
-    let bv = BitVec::from_prim_with_size(1u64 << 63, 64)?; // Test highest bi?t
+    let bv = BitVec::from((1u64 << 63, 64)); // Test highest bi?t
     assert!(!bv.is_zero());
 
     // Test different widths
     for width in [8, 16, 32] {
         let bv = BitVec::zeros(width);
         assert!(bv.is_zero());
-        let bv = BitVec::from_prim_with_size(1u64, width)?;
+        let bv = BitVec::from((1u64, width));
         assert!(!bv.is_zero());
     }
 
@@ -320,13 +317,13 @@ fn test_is_zero() -> Result<(), BitVecError> {
     // Test single-bit vector
     let bv = BitVec::zeros(1);
     assert!(bv.is_zero());
-    let bv = BitVec::from_prim_with_size(1u64, 1)?;
+    let bv = BitVec::from((1u64, 1));
     assert!(!bv.is_zero());
 
     // Test odd-sized vectors
     let bv = BitVec::zeros(3);
     assert!(bv.is_zero());
-    let bv = BitVec::from_prim_with_size(0b101u64, 3)?;
+    let bv = BitVec::from((0b101u64, 3));
     assert!(!bv.is_zero());
 
     // Test 72-bit vectors
@@ -346,20 +343,20 @@ fn test_is_zero() -> Result<(), BitVecError> {
 #[test]
 fn test_is_all_ones() -> Result<(), BitVecError> {
     // Test true case (all bits one)
-    let bv = BitVec::from_biguint(&((BigUint::from(1u8) << 64) - 1u8), 64);
+    let bv = BitVec::from(((BigUint::from(1u8) << 64) - 1u8, 64u32));
     assert!(bv.is_all_ones());
 
     // Test false case (any bit zero)
-    let bv = BitVec::from_biguint(&((BigUint::from(1u8) << 64) - 2u8), 64); // All ones except last bit
+    let bv = BitVec::from(((BigUint::from(1u8) << 64) - 2u8, 64u32)); // All ones except last bit
     assert!(!bv.is_all_ones());
-    let bv = BitVec::from_prim_with_size(0x7FFFFFFFFFFFFFFFu64, 64)?; // All ones except highest bit
+    let bv = BitVec::from((0x7FFFFFFFFFFFFFFFu64, 64)); // All ones except highest bit
     assert!(!bv.is_all_ones());
 
     // Test different widths
-    for width in [8, 16, 32] {
-        let bv = BitVec::from_biguint(&((BigUint::from(1u8) << width) - 1u8), width);
+    for width in [8u32, 16, 32] {
+        let bv = BitVec::from(((BigUint::from(1u8) << width) - 1u8, width));
         assert!(bv.is_all_ones());
-        let bv = BitVec::from_biguint(&((BigUint::from(1u8) << width) - 2u8), width);
+        let bv = BitVec::from(((BigUint::from(1u8) << width) - 2u8, width));
         assert!(!bv.is_all_ones());
     }
 
@@ -368,15 +365,15 @@ fn test_is_all_ones() -> Result<(), BitVecError> {
     assert!(bv.is_all_ones()); // Empty bitvector should return true as there are no zero bits
 
     // Test single-bit vector
-    let bv = BitVec::from_prim_with_size(1u64, 1)?;
+    let bv = BitVec::from((1u64, 1));
     assert!(bv.is_all_ones());
-    let bv = BitVec::from_prim_with_size(0u64, 1)?;
+    let bv = BitVec::from((0u64, 1));
     assert!(!bv.is_all_ones());
 
     // Test odd-sized vectors
-    let bv = BitVec::from_prim_with_size(0b111u64, 3)?;
+    let bv = BitVec::from((0b111u64, 3));
     assert!(bv.is_all_ones());
-    let bv = BitVec::from_prim_with_size(0b110u64, 3)?;
+    let bv = BitVec::from((0b110u64, 3));
     assert!(!bv.is_all_ones());
 
     // Test 72-bit vectors
@@ -396,22 +393,22 @@ fn test_is_all_ones() -> Result<(), BitVecError> {
 #[test]
 fn test_reverse_bytes() -> Result<(), BitVecError> {
     // Test single byte
-    let bv = BitVec::from_prim_with_size(0xA5u8, 8)?; // 10100101
+    let bv = BitVec::from((0xA5u64, 8)); // 10100101
     let reversed = bv.reverse_bytes()?;
     assert!(reversed.len() == 8);
     assert_eq!(reversed.to_u64().unwrap(), 0xA5); // Single byte should remain unchanged
 
     // Test multiple bytes
-    let bv = BitVec::from_prim_with_size(0x1234u16, 16)?; // 0x12 0x34
+    let bv = BitVec::from((0x1234u64, 16)); // 0x12 0x34
     let reversed = bv.reverse_bytes()?;
     assert_eq!(reversed.to_u64().unwrap(), 0x3412); // Should be 0x34 0x12
 
-    let bv = BitVec::from_prim_with_size(0x12345678u32, 32)?; // 0x12 0x34 0x56 0x78
+    let bv = BitVec::from((0x12345678u64, 32)); // 0x12 0x34 0x56 0x78
     let reversed = bv.reverse_bytes()?;
     assert_eq!(reversed.to_u64().unwrap(), 0x78563412); // Should be 0x78 0x56 0x34 0x12
 
     // Test with non-byte-aligned width
-    let bv = BitVec::from_prim_with_size(0b111100001111u16, 12)?; // Only use 12 bits
+    let bv = BitVec::from((0b111100001111u64, 12)); // Only use 12 bits
     assert!(bv.reverse_bytes().is_err()); // Should fail as width is not byte-aligned
 
     // Test zero-width vector
@@ -421,11 +418,11 @@ fn test_reverse_bytes() -> Result<(), BitVecError> {
     assert!(reversed.is_zero());
 
     // Test odd number of bits
-    let bv = BitVec::from_prim_with_size(0b10110u8, 5)?; // 5 bits
+    let bv = BitVec::from((0b10110u64, 5)); // 5 bits
     assert!(bv.reverse_bytes().is_err()); // Should fail as width is not byte-aligned
 
     // Test patterns that would expose endianness issues
-    let bv = BitVec::from_prim_with_size(0x0123456789ABCDEFu64, 64)?;
+    let bv = BitVec::from((0x0123456789ABCDEFu64, 64));
     let reversed = bv.reverse_bytes()?;
     assert_eq!(reversed.to_u64().unwrap(), 0xEFCDAB8967452301);
 
@@ -449,7 +446,7 @@ fn test_reverse_bytes() -> Result<(), BitVecError> {
 #[test]
 fn test_serde_roundtrip_recomputes_final_word_mask() -> Result<(), BitVecError> {
     // Test that final_word_mask is correctly recomputed after deserialization
-    let original = BitVec::from_prim_with_size(0xFFu8, 8)?;
+    let original = BitVec::from((0xFFu64, 8));
     assert!(original.is_all_ones());
 
     let json = serde_json::to_string(&original).unwrap();
@@ -478,10 +475,10 @@ fn test_serde_roundtrip_recomputes_final_word_mask() -> Result<(), BitVecError> 
     assert_eq!(bv, deserialized);
 
     // Test that arithmetic still works after deserialization
-    let a = BitVec::from_prim_with_size(42u8, 8)?;
+    let a = BitVec::from((42u64, 8));
     let json = serde_json::to_string(&a).unwrap();
     let a_deser: BitVec = serde_json::from_str(&json).unwrap();
-    let b = BitVec::from_prim_with_size(10u8, 8)?;
+    let b = BitVec::from((10u64, 8));
     let sum = (a_deser + b)?;
     assert_eq!(sum.to_u64(), Some(52));
 

--- a/crates/clarirs_num/src/bitvec/tests.rs
+++ b/crates/clarirs_num/src/bitvec/tests.rs
@@ -12,21 +12,21 @@ fn test_leading_zeros() -> Result<(), BitVecError> {
     assert_eq!(bv.leading_zeros(), 64);
 
     // Test all ones (no leading zeros)
-    let bv = BitVec::from((0xFFu64, 8));
+    let bv = BitVec::from((0xFF, 8));
     assert_eq!(bv.leading_zeros(), 0);
 
     // Test single one at different positions
-    let bv = BitVec::from((0b00000001u64, 8));
+    let bv = BitVec::from((0b00000001, 8));
     assert_eq!(bv.leading_zeros(), 7);
-    let bv = BitVec::from((0b00000100u64, 8));
+    let bv = BitVec::from((0b00000100, 8));
     assert_eq!(bv.leading_zeros(), 5);
-    let bv = BitVec::from((0b10000000u64, 8));
+    let bv = BitVec::from((0b10000000, 8));
     assert_eq!(bv.leading_zeros(), 0);
 
     // Test different widths
-    let bv = BitVec::from((0b00001111u64, 8));
+    let bv = BitVec::from((0b00001111, 8));
     assert_eq!(bv.leading_zeros(), 4);
-    let bv = BitVec::from((0b0000111100001111u64, 16));
+    let bv = BitVec::from((0b0000111100001111, 16));
     assert_eq!(bv.leading_zeros(), 4);
 
     // Test zero-width vector
@@ -34,7 +34,7 @@ fn test_leading_zeros() -> Result<(), BitVecError> {
     assert_eq!(bv.leading_zeros(), 0);
 
     // Test odd-sized vectors
-    let bv = BitVec::from((0b010u64, 3)); // Only 3 bits: 010
+    let bv = BitVec::from((0b010, 3)); // Only 3 bits: 010
     assert_eq!(bv.leading_zeros(), 1);
 
     // Test 72-bit vectors
@@ -260,33 +260,33 @@ fn test_bigint_biguint_conversion() -> Result<(), BitVecError> {
 #[test]
 fn test_valid_bv_from_length() {
     // Basic valid creation
-    let bv = BitVec::from((5u64, 8));
+    let bv = BitVec::from((5, 8));
     assert_eq!(bv.length, 8);
     assert_eq!(bv.words[0], 5);
 
     // Creating a BitVec with a larger value and different size
-    let bv = BitVec::from((255u64, 8));
+    let bv = BitVec::from((255, 8));
     assert_eq!(bv.length, 8);
     assert_eq!(bv.words[0], 255);
 
     // Creating a 16-bit BitVec from a u16
-    let bv = BitVec::from((1023u64, 16));
+    let bv = BitVec::from((1023, 16));
     assert_eq!(bv.length, 16);
     assert_eq!(bv.words[0], 1023);
 
     // Edge case - a zero value in a zero-width size
-    let result = BitVec::from((0u64, 0));
+    let result = BitVec::from((0, 0));
     assert_eq!(result.len(), 0);
 }
 
 #[test]
 fn test_invalid_bv_from_length() {
     // Value larger than bit width is truncated
-    let bv = BitVec::from((5u64, 1));
+    let bv = BitVec::from((5, 1));
     assert_eq!(bv.to_u64().unwrap(), 1); // 5 & 1 = 1
 
     // Value truncated to fit within bit width
-    let bv = BitVec::from((255u64, 4));
+    let bv = BitVec::from((255, 4));
     assert_eq!(bv.to_u64().unwrap(), 15); // 255 & 0xF = 15
 }
 
@@ -297,7 +297,7 @@ fn test_is_zero() -> Result<(), BitVecError> {
     assert!(bv.is_zero());
 
     // Test false case (any bit one)
-    let bv = BitVec::from((1u64, 64));
+    let bv = BitVec::from((1, 64));
     assert!(!bv.is_zero());
     let bv = BitVec::from((1u64 << 63, 64)); // Test highest bi?t
     assert!(!bv.is_zero());
@@ -306,7 +306,7 @@ fn test_is_zero() -> Result<(), BitVecError> {
     for width in [8, 16, 32] {
         let bv = BitVec::zeros(width);
         assert!(bv.is_zero());
-        let bv = BitVec::from((1u64, width));
+        let bv = BitVec::from((1, width));
         assert!(!bv.is_zero());
     }
 
@@ -317,13 +317,13 @@ fn test_is_zero() -> Result<(), BitVecError> {
     // Test single-bit vector
     let bv = BitVec::zeros(1);
     assert!(bv.is_zero());
-    let bv = BitVec::from((1u64, 1));
+    let bv = BitVec::from((1, 1));
     assert!(!bv.is_zero());
 
     // Test odd-sized vectors
     let bv = BitVec::zeros(3);
     assert!(bv.is_zero());
-    let bv = BitVec::from((0b101u64, 3));
+    let bv = BitVec::from((0b101, 3));
     assert!(!bv.is_zero());
 
     // Test 72-bit vectors
@@ -349,7 +349,7 @@ fn test_is_all_ones() -> Result<(), BitVecError> {
     // Test false case (any bit zero)
     let bv = BitVec::from(((BigUint::from(1u8) << 64) - 2u8, 64u32)); // All ones except last bit
     assert!(!bv.is_all_ones());
-    let bv = BitVec::from((0x7FFFFFFFFFFFFFFFu64, 64)); // All ones except highest bit
+    let bv = BitVec::from((0x7FFFFFFFFFFFFFFF, 64)); // All ones except highest bit
     assert!(!bv.is_all_ones());
 
     // Test different widths
@@ -365,15 +365,15 @@ fn test_is_all_ones() -> Result<(), BitVecError> {
     assert!(bv.is_all_ones()); // Empty bitvector should return true as there are no zero bits
 
     // Test single-bit vector
-    let bv = BitVec::from((1u64, 1));
+    let bv = BitVec::from((1, 1));
     assert!(bv.is_all_ones());
-    let bv = BitVec::from((0u64, 1));
+    let bv = BitVec::from((0, 1));
     assert!(!bv.is_all_ones());
 
     // Test odd-sized vectors
-    let bv = BitVec::from((0b111u64, 3));
+    let bv = BitVec::from((0b111, 3));
     assert!(bv.is_all_ones());
-    let bv = BitVec::from((0b110u64, 3));
+    let bv = BitVec::from((0b110, 3));
     assert!(!bv.is_all_ones());
 
     // Test 72-bit vectors
@@ -393,22 +393,22 @@ fn test_is_all_ones() -> Result<(), BitVecError> {
 #[test]
 fn test_reverse_bytes() -> Result<(), BitVecError> {
     // Test single byte
-    let bv = BitVec::from((0xA5u64, 8)); // 10100101
+    let bv = BitVec::from((0xA5, 8)); // 10100101
     let reversed = bv.reverse_bytes()?;
     assert!(reversed.len() == 8);
     assert_eq!(reversed.to_u64().unwrap(), 0xA5); // Single byte should remain unchanged
 
     // Test multiple bytes
-    let bv = BitVec::from((0x1234u64, 16)); // 0x12 0x34
+    let bv = BitVec::from((0x1234, 16)); // 0x12 0x34
     let reversed = bv.reverse_bytes()?;
     assert_eq!(reversed.to_u64().unwrap(), 0x3412); // Should be 0x34 0x12
 
-    let bv = BitVec::from((0x12345678u64, 32)); // 0x12 0x34 0x56 0x78
+    let bv = BitVec::from((0x12345678, 32)); // 0x12 0x34 0x56 0x78
     let reversed = bv.reverse_bytes()?;
     assert_eq!(reversed.to_u64().unwrap(), 0x78563412); // Should be 0x78 0x56 0x34 0x12
 
     // Test with non-byte-aligned width
-    let bv = BitVec::from((0b111100001111u64, 12)); // Only use 12 bits
+    let bv = BitVec::from((0b111100001111, 12)); // Only use 12 bits
     assert!(bv.reverse_bytes().is_err()); // Should fail as width is not byte-aligned
 
     // Test zero-width vector
@@ -418,11 +418,11 @@ fn test_reverse_bytes() -> Result<(), BitVecError> {
     assert!(reversed.is_zero());
 
     // Test odd number of bits
-    let bv = BitVec::from((0b10110u64, 5)); // 5 bits
+    let bv = BitVec::from((0b10110, 5)); // 5 bits
     assert!(bv.reverse_bytes().is_err()); // Should fail as width is not byte-aligned
 
     // Test patterns that would expose endianness issues
-    let bv = BitVec::from((0x0123456789ABCDEFu64, 64));
+    let bv = BitVec::from((0x0123456789ABCDEF, 64));
     let reversed = bv.reverse_bytes()?;
     assert_eq!(reversed.to_u64().unwrap(), 0xEFCDAB8967452301);
 
@@ -446,7 +446,7 @@ fn test_reverse_bytes() -> Result<(), BitVecError> {
 #[test]
 fn test_serde_roundtrip_recomputes_final_word_mask() -> Result<(), BitVecError> {
     // Test that final_word_mask is correctly recomputed after deserialization
-    let original = BitVec::from((0xFFu64, 8));
+    let original = BitVec::from((0xFF, 8));
     assert!(original.is_all_ones());
 
     let json = serde_json::to_string(&original).unwrap();
@@ -475,10 +475,10 @@ fn test_serde_roundtrip_recomputes_final_word_mask() -> Result<(), BitVecError> 
     assert_eq!(bv, deserialized);
 
     // Test that arithmetic still works after deserialization
-    let a = BitVec::from((42u64, 8));
+    let a = BitVec::from((42, 8));
     let json = serde_json::to_string(&a).unwrap();
     let a_deser: BitVec = serde_json::from_str(&json).unwrap();
-    let b = BitVec::from((10u64, 8));
+    let b = BitVec::from((10, 8));
     let sum = (a_deser + b)?;
     assert_eq!(sum.to_u64(), Some(52));
 

--- a/crates/clarirs_num/src/float.rs
+++ b/crates/clarirs_num/src/float.rs
@@ -122,11 +122,11 @@ impl Float {
         match self {
             Float::F32(f) => {
                 let (_, exp, _) = decompose_f32(*f);
-                BitVec::from_prim_with_size(exp, 8).unwrap()
+                BitVec::from((u64::from(exp), 8))
             }
             Float::F64(f) => {
                 let (_, exp, _) = decompose_f64(*f);
-                BitVec::from_prim_with_size(exp, 11).unwrap()
+                BitVec::from((u64::from(exp), 11))
             }
         }
     }
@@ -135,11 +135,11 @@ impl Float {
         match self {
             Float::F32(f) => {
                 let (_, _, mant) = decompose_f32(*f);
-                BitVec::from_prim_with_size(mant, 23).unwrap()
+                BitVec::from((u64::from(mant), 23))
             }
             Float::F64(f) => {
                 let (_, _, mant) = decompose_f64(*f);
-                BitVec::from_prim_with_size(mant, 52).unwrap()
+                BitVec::from((mant, 52))
             }
         }
     }

--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -73,8 +73,10 @@ impl BV {
     ) -> Result<Py<BV>, ClaripyError> {
         let inner = match op {
             "BVS" => GLOBAL_CONTEXT.bvs(args[0].extract::<String>(py)?, args[1].extract(py)?)?,
-            "BVV" => GLOBAL_CONTEXT
-                .bvv_from_biguint_with_size(&args[0].extract(py)?, args[1].extract(py)?)?,
+            "BVV" => GLOBAL_CONTEXT.bvv(BitVec::from((
+                args[0].extract::<BigUint>(py)?,
+                args[1].extract::<u32>(py)?,
+            )))?,
             "__and__" => GLOBAL_CONTEXT.and2(
                 &args[0].cast_bound::<BV>(py)?.get().inner,
                 &args[1].cast_bound::<BV>(py)?.get().inner,
@@ -859,7 +861,7 @@ impl BV {
         // Handle size = 0
         if size == 0 {
             let a = GLOBAL_CONTEXT
-                .bvv_from_biguint_with_size(&BigUint::from(0u32), 0)
+                .bvv(BitVec::from((BigUint::from(0u32), 0)))
                 .map_err(ClaripyError::from)?;
             return BV::new(py, &a);
         }
@@ -879,7 +881,7 @@ impl BV {
                 // Create a BVV with the concrete value
                 let result_size = extracted.get().size() as u32;
                 let a = GLOBAL_CONTEXT
-                    .bvv_from_biguint_with_size(&concrete_value, result_size)
+                    .bvv(BitVec::from((concrete_value, result_size)))
                     .map_err(ClaripyError::from)?;
                 return BV::new(py, &a);
             }
@@ -910,7 +912,7 @@ impl BV {
                 // Create a BVV with the concrete value
                 let result_size = extracted.get().size() as u32;
                 let a = GLOBAL_CONTEXT
-                    .bvv_from_biguint_with_size(&concrete_value, result_size)
+                    .bvv(BitVec::from((concrete_value, result_size)))
                     .map_err(ClaripyError::from)?;
                 return BV::new(py, &a);
             }
@@ -935,7 +937,7 @@ impl BV {
             // Create a BVV with the concrete value
             let result_size = final_size.get().size() as u32;
             let a = GLOBAL_CONTEXT
-                .bvv_from_biguint_with_size(&concrete_value, result_size)
+                .bvv(BitVec::from((concrete_value, result_size)))
                 .map_err(ClaripyError::from)?;
             return BV::new(py, &a);
         }
@@ -1067,7 +1069,7 @@ pub fn BVV<'py>(
     if let Ok(int_val) = value.extract::<BigUint>() {
         if let Some(size) = size {
             let a = GLOBAL_CONTEXT
-                .bvv_from_biguint_with_size(&int_val, size)
+                .bvv(BitVec::from((int_val, size)))
                 .map_err(ClaripyError::from)?;
             return Ok(BV::new(py, &a)?);
         } else {
@@ -1082,7 +1084,7 @@ pub fn BVV<'py>(
                     .expect("BigInt to BigUInt failed"),
             );
             let a = GLOBAL_CONTEXT
-                .bvv_from_biguint_with_size(&uint_value, size)
+                .bvv(BitVec::from((uint_value, size)))
                 .map_err(ClaripyError::from)?;
             return Ok(BV::new(py, &a)?);
         } else {
@@ -1099,7 +1101,7 @@ pub fn BVV<'py>(
         return Ok(BV::new(
             py,
             &GLOBAL_CONTEXT
-                .bvv_from_biguint_with_size(&int_val, bytes_val.len() as u32 * 8)
+                .bvv(BitVec::from((int_val, bytes_val.len() as u32 * 8)))
                 .map_err(ClaripyError::from)?,
         )?);
     }
@@ -1113,7 +1115,7 @@ pub fn BVV<'py>(
         return Ok(BV::new(
             py,
             &GLOBAL_CONTEXT
-                .bvv_from_biguint_with_size(&int_val, bytes_val.len() as u32 * 8)
+                .bvv(BitVec::from((int_val, bytes_val.len() as u32 * 8)))
                 .map_err(ClaripyError::from)?,
         )?);
     }

--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, str};
 
-use num_bigint::BigInt;
+use num_bigint::{BigInt, BigUint};
 use pyo3::types::{PyFloat, PyInt};
 
 use crate::prelude::*;
@@ -205,11 +205,13 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBV<'py> {
         } else if let Ok(bool_val) = val.cast::<Bool>() {
             Ok(CoerceBV::Bool(bool_val.to_owned()))
         } else if let Ok(bytes_val) = val.extract::<Vec<u8>>() {
+            // Interpret the raw bytes as a big-endian bitvector of len(bytes) * 8 bits.
+            let length = bytes_val.len() as u32 * 8;
+            let words = BigUint::from_bytes_be(&bytes_val).iter_u64_digits().collect();
+            let bv = BitVec::new(words, length).expect("BitVec::new is infallible");
             Ok(CoerceBV::BV(BV::new(
                 val.py(),
-                &GLOBAL_CONTEXT
-                    .bvv(BitVec::from_bytes_be(&bytes_val))
-                    .map_err(ClaripyError::from)?,
+                &GLOBAL_CONTEXT.bvv(bv).map_err(ClaripyError::from)?,
             )?))
         } else {
             Err(ClaripyError::InvalidArgumentType("Expected BV".to_string()).into())

--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -18,7 +18,7 @@ fn bv_to_bool(bv: &BV) -> Result<AstRef<'static>, ClaripyError> {
             GLOBAL_CONTEXT.true_()?
         });
     }
-    let zero = GLOBAL_CONTEXT.bvv(BitVec::from_prim_with_size(0u8, bv.size() as u32)?)?;
+    let zero = GLOBAL_CONTEXT.bvv(BitVec::from((0u64, bv.size() as u32)))?;
     Ok(GLOBAL_CONTEXT.neq(inner, &zero)?)
 }
 
@@ -84,13 +84,13 @@ impl<'py> CoerceBV<'py> {
                 }
             }
             CoerceBV::Int(int) => {
-                let bv = BitVec::from_bigint(int, size);
+                let bv = BitVec::from((int.clone(), size));
                 BV::new(py, &GLOBAL_CONTEXT.bvv(bv)?)
             }
             CoerceBV::Bool(bool_val) => {
                 // Convert Bool to BV of the requested size: If(bool, 1, 0).
-                let one = GLOBAL_CONTEXT.bvv(BitVec::from_prim_with_size(1u8, size)?)?;
-                let zero = GLOBAL_CONTEXT.bvv(BitVec::from_prim_with_size(0u8, size)?)?;
+                let one = GLOBAL_CONTEXT.bvv(BitVec::from((1u64, size)))?;
+                let zero = GLOBAL_CONTEXT.bvv(BitVec::from((0u64, size)))?;
                 let bv_ast = GLOBAL_CONTEXT.ite(&bool_val.get().inner, &one, &zero)?;
                 BV::new(py, &bv_ast)
             }
@@ -382,7 +382,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for CoerceBase<'py> {
         } else if let Ok(int_val) = val.cast::<PyInt>() {
             // Handle Python int literals by wrapping in BVV (64-bit default)
             let int: BigInt = int_val.extract()?;
-            let bv = BitVec::from_bigint(&int, 64);
+            let bv = BitVec::from((int, 64));
             let bv_ast = BV::new(
                 val.py(),
                 &GLOBAL_CONTEXT.bvv(bv).map_err(ClaripyError::from)?,

--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -18,7 +18,7 @@ fn bv_to_bool(bv: &BV) -> Result<AstRef<'static>, ClaripyError> {
             GLOBAL_CONTEXT.true_()?
         });
     }
-    let zero = GLOBAL_CONTEXT.bvv(BitVec::from((0u64, bv.size() as u32)))?;
+    let zero = GLOBAL_CONTEXT.bvv(BitVec::from((0, bv.size() as u32)))?;
     Ok(GLOBAL_CONTEXT.neq(inner, &zero)?)
 }
 
@@ -89,8 +89,8 @@ impl<'py> CoerceBV<'py> {
             }
             CoerceBV::Bool(bool_val) => {
                 // Convert Bool to BV of the requested size: If(bool, 1, 0).
-                let one = GLOBAL_CONTEXT.bvv(BitVec::from((1u64, size)))?;
-                let zero = GLOBAL_CONTEXT.bvv(BitVec::from((0u64, size)))?;
+                let one = GLOBAL_CONTEXT.bvv(BitVec::from((1, size)))?;
+                let zero = GLOBAL_CONTEXT.bvv(BitVec::from((0, size)))?;
                 let bv_ast = GLOBAL_CONTEXT.ite(&bool_val.get().inner, &one, &zero)?;
                 BV::new(py, &bv_ast)
             }

--- a/crates/clarirs_py/src/solver.rs
+++ b/crates/clarirs_py/src/solver.rs
@@ -570,7 +570,7 @@ impl PySolver {
                     // For symbolic BVs, check if it can be non-zero
                     let zero = solver
                         .context()
-                        .bvv_prim_with_size(0u64, bv_expr.get().inner.size())?;
+                        .bvv(BitVec::from((0u64, bv_expr.get().inner.size())))?;
                     let eq_zero = solver.context().eq_(&bv_expr.get().inner, &zero)?;
                     let is_zero = solver.is_true(&eq_zero)?;
                     Ok(!is_zero)
@@ -611,7 +611,7 @@ impl PySolver {
                     // For symbolic BVs, check if it must be zero
                     let zero = solver
                         .context()
-                        .bvv_prim_with_size(0u64, bv_expr.get().inner.size())?;
+                        .bvv(BitVec::from((0u64, bv_expr.get().inner.size())))?;
                     let eq_zero = solver.context().eq_(&bv_expr.get().inner, &zero)?;
                     Ok(solver.is_true(&eq_zero)?)
                 }

--- a/crates/clarirs_py/src/solver.rs
+++ b/crates/clarirs_py/src/solver.rs
@@ -570,7 +570,7 @@ impl PySolver {
                     // For symbolic BVs, check if it can be non-zero
                     let zero = solver
                         .context()
-                        .bvv(BitVec::from((0u64, bv_expr.get().inner.size())))?;
+                        .bvv(BitVec::from((0, bv_expr.get().inner.size())))?;
                     let eq_zero = solver.context().eq_(&bv_expr.get().inner, &zero)?;
                     let is_zero = solver.is_true(&eq_zero)?;
                     Ok(!is_zero)
@@ -611,7 +611,7 @@ impl PySolver {
                     // For symbolic BVs, check if it must be zero
                     let zero = solver
                         .context()
-                        .bvv(BitVec::from((0u64, bv_expr.get().inner.size())))?;
+                        .bvv(BitVec::from((0, bv_expr.get().inner.size())))?;
                     let eq_zero = solver.context().eq_(&bv_expr.get().inner, &zero)?;
                     Ok(solver.is_true(&eq_zero)?)
                 }

--- a/crates/clarirs_py/src/vsa.rs
+++ b/crates/clarirs_py/src/vsa.rs
@@ -46,7 +46,7 @@ pub fn reduce<'py>(
                 if lower_bound == upper_bound {
                     BV::new(
                         py,
-                        &GLOBAL_CONTEXT.bvv_from_biguint_with_size(&lower_bound, bits)?,
+                        &GLOBAL_CONTEXT.bvv(BitVec::from((lower_bound, bits)))?,
                     )?
                 } else {
                     BV::new(

--- a/crates/clarirs_z3/src/astext.rs
+++ b/crates/clarirs_z3/src/astext.rs
@@ -544,7 +544,7 @@ impl<'c> AstExtZ3<'c> for AstRef<'c> {
                             let numeral_string = z3::get_numeral_string(z3_ctx, *ast);
                             let numeral_str = CStr::from_ptr(numeral_string).to_str().unwrap();
                             let width = z3::get_bv_sort_size(z3_ctx, sort);
-                            ctx.bvv(BitVec::from_str(numeral_str, width).unwrap())
+                            ctx.bvv(BitVec::try_from((numeral_str.to_string(), width)).unwrap())
                         }
                         z3::SortKind::FloatingPoint => {
                             let fsort = FSort::new(
@@ -790,7 +790,7 @@ impl<'c> AstExtZ3<'c> for AstRef<'c> {
                                         CStr::from_ptr(numeral_string).to_str().unwrap();
                                     let s = z3::get_sort(z3_ctx, inner_int);
                                     let width = z3::get_bv_sort_size(z3_ctx, s);
-                                    ctx.bvv(BitVec::from_str(numeral_str, width).unwrap())
+                                    ctx.bvv(BitVec::try_from((numeral_str.to_string(), width)).unwrap())
                                 }
                                 z3::AstKind::App => {
                                     let inner_app = z3::to_app(z3_ctx, inner_int);

--- a/crates/clarirs_z3/src/astext/test_bv.rs
+++ b/crates/clarirs_z3/src/astext/test_bv.rs
@@ -29,7 +29,7 @@ mod to_z3 {
     #[test]
     fn value_8bit() {
         let ctx = Context::new();
-        let bv = ctx.bvv(BitVec::from((42u64, 8))).unwrap();
+        let bv = ctx.bvv(BitVec::from((42, 8))).unwrap();
         let z3_ast = bv.to_z3().unwrap();
         assert_eq!(z3_ast.decl_kind(), z3::DeclKind::Bnum);
     }
@@ -37,7 +37,7 @@ mod to_z3 {
     #[test]
     fn value_32bit() {
         let ctx = Context::new();
-        let bv = ctx.bvv(BitVec::from((0xDEADBEEFu64, 32))).unwrap();
+        let bv = ctx.bvv(BitVec::from((0xDEADBEEF, 32))).unwrap();
         let z3_ast = bv.to_z3().unwrap();
         assert_eq!(z3_ast.decl_kind(), z3::DeclKind::Bnum);
     }
@@ -45,7 +45,7 @@ mod to_z3 {
     #[test]
     fn value_64bit() {
         let ctx = Context::new();
-        let bv = ctx.bvv(BitVec::from((0x0123456789ABCDEFu64, 64))).unwrap();
+        let bv = ctx.bvv(BitVec::from((0x0123456789ABCDEF, 64))).unwrap();
         let z3_ast = bv.to_z3().unwrap();
         assert_eq!(z3_ast.decl_kind(), z3::DeclKind::Bnum);
     }
@@ -406,7 +406,7 @@ mod from_z3 {
         let ctx = Context::new();
         let z3_ast = RcAst::mk_bv_val("42", 8);
         let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
-        assert_eq!(result, ctx.bvv(BitVec::from((42u64, 8))).unwrap());
+        assert_eq!(result, ctx.bvv(BitVec::from((42, 8))).unwrap());
     }
 
     #[test]
@@ -414,7 +414,7 @@ mod from_z3 {
         let ctx = Context::new();
         let z3_ast = RcAst::mk_bv_val("3735928559", 32); // 0xDEADBEEF
         let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
-        assert_eq!(result, ctx.bvv(BitVec::from((0xDEADBEEFu64, 32))).unwrap());
+        assert_eq!(result, ctx.bvv(BitVec::from((0xDEADBEEF, 32))).unwrap());
     }
 
     #[test]
@@ -422,7 +422,7 @@ mod from_z3 {
         let ctx = Context::new();
         let z3_ast = RcAst::mk_bv_val("81985529216486895", 64); // 0x0123456789ABCDEF
         let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
-        assert_eq!(result, ctx.bvv(BitVec::from((0x0123456789ABCDEFu64, 64))).unwrap());
+        assert_eq!(result, ctx.bvv(BitVec::from((0x0123456789ABCDEF, 64))).unwrap());
     }
 
     // -- Unary ops --
@@ -798,21 +798,21 @@ mod roundtrip {
     #[test]
     fn value_8bit() {
         let ctx = Context::new();
-        let ast = ctx.bvv(BitVec::from((42u64, 8))).unwrap();
+        let ast = ctx.bvv(BitVec::from((42, 8))).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
 
     #[test]
     fn value_32bit() {
         let ctx = Context::new();
-        let ast = ctx.bvv(BitVec::from((0xDEADBEEFu64, 32))).unwrap();
+        let ast = ctx.bvv(BitVec::from((0xDEADBEEF, 32))).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
 
     #[test]
     fn value_64bit() {
         let ctx = Context::new();
-        let ast = ctx.bvv(BitVec::from((0x0123456789ABCDEFu64, 64))).unwrap();
+        let ast = ctx.bvv(BitVec::from((0x0123456789ABCDEF, 64))).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
 
@@ -1071,7 +1071,7 @@ mod roundtrip {
         let ctx = Context::new();
         let s = ctx.strings("s").unwrap();
         let t = ctx.strings("t").unwrap();
-        let offset = ctx.bvv(BitVec::from((0u64, 64))).unwrap();
+        let offset = ctx.bvv(BitVec::from((0, 64))).unwrap();
         let ast = ctx.str_index_of(s, t, offset).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -1081,7 +1081,7 @@ mod roundtrip {
         let ctx = Context::new();
         let s = ctx.stringv("hello world").unwrap();
         let t = ctx.stringv("world").unwrap();
-        let offset = ctx.bvv(BitVec::from((0u64, 64))).unwrap();
+        let offset = ctx.bvv(BitVec::from((0, 64))).unwrap();
         let ast = ctx.str_index_of(s, t, offset).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -1091,7 +1091,7 @@ mod roundtrip {
         let ctx = Context::new();
         let s = ctx.strings("s").unwrap();
         let t = ctx.strings("t").unwrap();
-        let offset = ctx.bvv(BitVec::from((5u64, 64))).unwrap();
+        let offset = ctx.bvv(BitVec::from((5, 64))).unwrap();
         let ast = ctx.str_index_of(s, t, offset).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }

--- a/crates/clarirs_z3/src/astext/test_bv.rs
+++ b/crates/clarirs_z3/src/astext/test_bv.rs
@@ -29,7 +29,7 @@ mod to_z3 {
     #[test]
     fn value_8bit() {
         let ctx = Context::new();
-        let bv = ctx.bvv_prim(42u8).unwrap();
+        let bv = ctx.bvv(BitVec::from((42u64, 8))).unwrap();
         let z3_ast = bv.to_z3().unwrap();
         assert_eq!(z3_ast.decl_kind(), z3::DeclKind::Bnum);
     }
@@ -37,7 +37,7 @@ mod to_z3 {
     #[test]
     fn value_32bit() {
         let ctx = Context::new();
-        let bv = ctx.bvv_prim(0xDEADBEEFu32).unwrap();
+        let bv = ctx.bvv(BitVec::from((0xDEADBEEFu64, 32))).unwrap();
         let z3_ast = bv.to_z3().unwrap();
         assert_eq!(z3_ast.decl_kind(), z3::DeclKind::Bnum);
     }
@@ -45,7 +45,7 @@ mod to_z3 {
     #[test]
     fn value_64bit() {
         let ctx = Context::new();
-        let bv = ctx.bvv_prim(0x0123456789ABCDEFu64).unwrap();
+        let bv = ctx.bvv(BitVec::from((0x0123456789ABCDEFu64, 64))).unwrap();
         let z3_ast = bv.to_z3().unwrap();
         assert_eq!(z3_ast.decl_kind(), z3::DeclKind::Bnum);
     }
@@ -406,7 +406,7 @@ mod from_z3 {
         let ctx = Context::new();
         let z3_ast = RcAst::mk_bv_val("42", 8);
         let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
-        assert_eq!(result, ctx.bvv_prim(42u8).unwrap());
+        assert_eq!(result, ctx.bvv(BitVec::from((42u64, 8))).unwrap());
     }
 
     #[test]
@@ -414,7 +414,7 @@ mod from_z3 {
         let ctx = Context::new();
         let z3_ast = RcAst::mk_bv_val("3735928559", 32); // 0xDEADBEEF
         let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
-        assert_eq!(result, ctx.bvv_prim(0xDEADBEEFu32).unwrap());
+        assert_eq!(result, ctx.bvv(BitVec::from((0xDEADBEEFu64, 32))).unwrap());
     }
 
     #[test]
@@ -422,7 +422,7 @@ mod from_z3 {
         let ctx = Context::new();
         let z3_ast = RcAst::mk_bv_val("81985529216486895", 64); // 0x0123456789ABCDEF
         let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
-        assert_eq!(result, ctx.bvv_prim(0x0123456789ABCDEFu64).unwrap());
+        assert_eq!(result, ctx.bvv(BitVec::from((0x0123456789ABCDEFu64, 64))).unwrap());
     }
 
     // -- Unary ops --
@@ -798,21 +798,21 @@ mod roundtrip {
     #[test]
     fn value_8bit() {
         let ctx = Context::new();
-        let ast = ctx.bvv_prim(42u8).unwrap();
+        let ast = ctx.bvv(BitVec::from((42u64, 8))).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
 
     #[test]
     fn value_32bit() {
         let ctx = Context::new();
-        let ast = ctx.bvv_prim(0xDEADBEEFu32).unwrap();
+        let ast = ctx.bvv(BitVec::from((0xDEADBEEFu64, 32))).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
 
     #[test]
     fn value_64bit() {
         let ctx = Context::new();
-        let ast = ctx.bvv_prim(0x0123456789ABCDEFu64).unwrap();
+        let ast = ctx.bvv(BitVec::from((0x0123456789ABCDEFu64, 64))).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
 
@@ -1071,7 +1071,7 @@ mod roundtrip {
         let ctx = Context::new();
         let s = ctx.strings("s").unwrap();
         let t = ctx.strings("t").unwrap();
-        let offset = ctx.bvv_prim(0u64).unwrap();
+        let offset = ctx.bvv(BitVec::from((0u64, 64))).unwrap();
         let ast = ctx.str_index_of(s, t, offset).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -1081,7 +1081,7 @@ mod roundtrip {
         let ctx = Context::new();
         let s = ctx.stringv("hello world").unwrap();
         let t = ctx.stringv("world").unwrap();
-        let offset = ctx.bvv_prim(0u64).unwrap();
+        let offset = ctx.bvv(BitVec::from((0u64, 64))).unwrap();
         let ast = ctx.str_index_of(s, t, offset).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -1091,7 +1091,7 @@ mod roundtrip {
         let ctx = Context::new();
         let s = ctx.strings("s").unwrap();
         let t = ctx.strings("t").unwrap();
-        let offset = ctx.bvv_prim(5u64).unwrap();
+        let offset = ctx.bvv(BitVec::from((5u64, 64))).unwrap();
         let ast = ctx.str_index_of(s, t, offset).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }

--- a/crates/clarirs_z3/src/astext/test_float.rs
+++ b/crates/clarirs_z3/src/astext/test_float.rs
@@ -239,7 +239,7 @@ mod to_z3 {
     #[test]
     fn fp_fp() {
         let ctx = Context::new();
-        let sign = ctx.bvv(BitVec::from((0u64, 8))).unwrap();
+        let sign = ctx.bvv(BitVec::from((0, 8))).unwrap();
         let sign = ctx.extract(sign, 0, 0).unwrap(); // 1-bit
         let exp = ctx.bvs("exp", 8).unwrap();
         let sig = ctx.bvs("sig", 23).unwrap();
@@ -711,7 +711,7 @@ mod roundtrip {
     #[test]
     fn fp_fp() {
         let ctx = Context::new();
-        let sign = ctx.bvv(BitVec::from((0u64, 8))).unwrap();
+        let sign = ctx.bvv(BitVec::from((0, 8))).unwrap();
         let sign = ctx.extract(sign, 0, 0).unwrap(); // 1-bit
         let exp = ctx.bvs("exp", 8).unwrap();
         let sig = ctx.bvs("sig", 23).unwrap();

--- a/crates/clarirs_z3/src/astext/test_float.rs
+++ b/crates/clarirs_z3/src/astext/test_float.rs
@@ -239,7 +239,7 @@ mod to_z3 {
     #[test]
     fn fp_fp() {
         let ctx = Context::new();
-        let sign = ctx.bvv_prim(0u8).unwrap();
+        let sign = ctx.bvv(BitVec::from((0u64, 8))).unwrap();
         let sign = ctx.extract(sign, 0, 0).unwrap(); // 1-bit
         let exp = ctx.bvs("exp", 8).unwrap();
         let sig = ctx.bvs("sig", 23).unwrap();
@@ -711,7 +711,7 @@ mod roundtrip {
     #[test]
     fn fp_fp() {
         let ctx = Context::new();
-        let sign = ctx.bvv_prim(0u8).unwrap();
+        let sign = ctx.bvv(BitVec::from((0u64, 8))).unwrap();
         let sign = ctx.extract(sign, 0, 0).unwrap(); // 1-bit
         let exp = ctx.bvs("exp", 8).unwrap();
         let sig = ctx.bvs("sig", 23).unwrap();

--- a/crates/clarirs_z3/src/astext/test_string.rs
+++ b/crates/clarirs_z3/src/astext/test_string.rs
@@ -107,8 +107,8 @@ mod to_z3 {
     fn substr() {
         let ctx = Context::new();
         let s = ctx.stringv("hello world").unwrap();
-        let start = ctx.bvv(BitVec::from((6u64, 32))).unwrap();
-        let length = ctx.bvv(BitVec::from((5u64, 32))).unwrap();
+        let start = ctx.bvv(BitVec::from((6, 32))).unwrap();
+        let length = ctx.bvv(BitVec::from((5, 32))).unwrap();
         let sub = ctx.str_substr(s, start, length).unwrap();
         let z3_ast = sub.to_z3().unwrap();
 
@@ -259,8 +259,8 @@ mod from_z3 {
         let expected = ctx
             .str_substr(
                 ctx.stringv("hello world").unwrap(),
-                ctx.bvv(BitVec::from((6u64, 64))).unwrap(),
-                ctx.bvv(BitVec::from((5u64, 64))).unwrap(),
+                ctx.bvv(BitVec::from((6, 64))).unwrap(),
+                ctx.bvv(BitVec::from((5, 64))).unwrap(),
             )
             .unwrap();
         assert_eq!(expected, result);
@@ -438,8 +438,8 @@ mod roundtrip {
     fn substr_value() {
         let ctx = Context::new();
         let s = ctx.stringv("hello world").unwrap();
-        let start = ctx.bvv(BitVec::from((6u64, 64))).unwrap();
-        let length = ctx.bvv(BitVec::from((5u64, 64))).unwrap();
+        let start = ctx.bvv(BitVec::from((6, 64))).unwrap();
+        let length = ctx.bvv(BitVec::from((5, 64))).unwrap();
         let ast = ctx.str_substr(s, start, length).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -448,8 +448,8 @@ mod roundtrip {
     fn substr_symbol() {
         let ctx = Context::new();
         let s = ctx.strings("s").unwrap();
-        let start = ctx.bvv(BitVec::from((0u64, 64))).unwrap();
-        let length = ctx.bvv(BitVec::from((3u64, 64))).unwrap();
+        let start = ctx.bvv(BitVec::from((0, 64))).unwrap();
+        let length = ctx.bvv(BitVec::from((3, 64))).unwrap();
         let ast = ctx.str_substr(s, start, length).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -458,8 +458,8 @@ mod roundtrip {
     fn substr_from_start() {
         let ctx = Context::new();
         let s = ctx.stringv("abcdef").unwrap();
-        let start = ctx.bvv(BitVec::from((0u64, 64))).unwrap();
-        let length = ctx.bvv(BitVec::from((3u64, 64))).unwrap();
+        let start = ctx.bvv(BitVec::from((0, 64))).unwrap();
+        let length = ctx.bvv(BitVec::from((3, 64))).unwrap();
         let ast = ctx.str_substr(s, start, length).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -541,7 +541,7 @@ mod roundtrip {
     #[test]
     fn bv_to_str_value() {
         let ctx = Context::new();
-        let bv = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
+        let bv = ctx.bvv(BitVec::from((42, 64))).unwrap();
         let ast = ctx.bv_to_str(bv).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }

--- a/crates/clarirs_z3/src/astext/test_string.rs
+++ b/crates/clarirs_z3/src/astext/test_string.rs
@@ -107,8 +107,8 @@ mod to_z3 {
     fn substr() {
         let ctx = Context::new();
         let s = ctx.stringv("hello world").unwrap();
-        let start = ctx.bvv_prim(6u32).unwrap();
-        let length = ctx.bvv_prim(5u32).unwrap();
+        let start = ctx.bvv(BitVec::from((6u64, 32))).unwrap();
+        let length = ctx.bvv(BitVec::from((5u64, 32))).unwrap();
         let sub = ctx.str_substr(s, start, length).unwrap();
         let z3_ast = sub.to_z3().unwrap();
 
@@ -259,8 +259,8 @@ mod from_z3 {
         let expected = ctx
             .str_substr(
                 ctx.stringv("hello world").unwrap(),
-                ctx.bvv_prim(6u64).unwrap(),
-                ctx.bvv_prim(5u64).unwrap(),
+                ctx.bvv(BitVec::from((6u64, 64))).unwrap(),
+                ctx.bvv(BitVec::from((5u64, 64))).unwrap(),
             )
             .unwrap();
         assert_eq!(expected, result);
@@ -438,8 +438,8 @@ mod roundtrip {
     fn substr_value() {
         let ctx = Context::new();
         let s = ctx.stringv("hello world").unwrap();
-        let start = ctx.bvv_prim(6u64).unwrap();
-        let length = ctx.bvv_prim(5u64).unwrap();
+        let start = ctx.bvv(BitVec::from((6u64, 64))).unwrap();
+        let length = ctx.bvv(BitVec::from((5u64, 64))).unwrap();
         let ast = ctx.str_substr(s, start, length).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -448,8 +448,8 @@ mod roundtrip {
     fn substr_symbol() {
         let ctx = Context::new();
         let s = ctx.strings("s").unwrap();
-        let start = ctx.bvv_prim(0u64).unwrap();
-        let length = ctx.bvv_prim(3u64).unwrap();
+        let start = ctx.bvv(BitVec::from((0u64, 64))).unwrap();
+        let length = ctx.bvv(BitVec::from((3u64, 64))).unwrap();
         let ast = ctx.str_substr(s, start, length).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -458,8 +458,8 @@ mod roundtrip {
     fn substr_from_start() {
         let ctx = Context::new();
         let s = ctx.stringv("abcdef").unwrap();
-        let start = ctx.bvv_prim(0u64).unwrap();
-        let length = ctx.bvv_prim(3u64).unwrap();
+        let start = ctx.bvv(BitVec::from((0u64, 64))).unwrap();
+        let length = ctx.bvv(BitVec::from((3u64, 64))).unwrap();
         let ast = ctx.str_substr(s, start, length).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }
@@ -541,7 +541,7 @@ mod roundtrip {
     #[test]
     fn bv_to_str_value() {
         let ctx = Context::new();
-        let bv = ctx.bvv_prim(42u64).unwrap();
+        let bv = ctx.bvv(BitVec::from((42u64, 64))).unwrap();
         let ast = ctx.bv_to_str(bv).unwrap();
         assert_eq!(ast, round_trip(&ctx, &ast).unwrap());
     }

--- a/crates/clarirs_z3/src/solver.rs
+++ b/crates/clarirs_z3/src/solver.rs
@@ -405,7 +405,7 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         // For signed minimization, the sign bit should be 1 (for negative numbers)
         // Extract the sign bit
         let sign_bit = self.ctx.extract(expr, size - 1, size - 1)?;
-        let one_bit = self.ctx.bvv(BitVec::from((1u64, 1)))?;
+        let one_bit = self.ctx.bvv(BitVec::from((1, 1)))?;
 
         // Create a target variable equal to the expression
         let target_name = format!("min_signed_target_{size}");
@@ -440,7 +440,7 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         // For signed maximization, the sign bit should be 0 (for positive numbers)
         // Extract the sign bit
         let sign_bit = self.ctx.extract(expr, size - 1, size - 1)?;
-        let zero_bit = self.ctx.bvv(BitVec::from((0u64, 1)))?;
+        let zero_bit = self.ctx.bvv(BitVec::from((0, 1)))?;
 
         // Create a target variable equal to the expression
         let target_name = format!("max_signed_target_{size}");
@@ -831,7 +831,7 @@ mod tests {
             let mut solver = Z3Solver::new(&ctx);
 
             // Using a concrete value should return the same value
-            let bv = ctx.bvv(BitVec::from((42u64, 64)))?;
+            let bv = ctx.bvv(BitVec::from((42, 64)))?;
             let result = solver.min_unsigned(&bv)?;
 
             assert_eq!(result, bv);
@@ -845,7 +845,7 @@ mod tests {
             let mut solver = Z3Solver::new(&ctx);
 
             // Using a concrete value should return the same value
-            let bv = ctx.bvv(BitVec::from((42u64, 64)))?;
+            let bv = ctx.bvv(BitVec::from((42, 64)))?;
             let result = solver.max_unsigned(&bv)?;
 
             assert_eq!(result, bv);
@@ -862,8 +862,8 @@ mod tests {
             let x = ctx.bvs("x", 64)?;
 
             // Add constraints: 10 <= x <= 20
-            let lower_bound = ctx.bvv(BitVec::from((10u64, 64)))?;
-            let upper_bound = ctx.bvv(BitVec::from((20u64, 64)))?;
+            let lower_bound = ctx.bvv(BitVec::from((10, 64)))?;
+            let upper_bound = ctx.bvv(BitVec::from((20, 64)))?;
 
             solver.add(&ctx.uge(&x, &lower_bound)?)?;
             solver.add(&ctx.ule(&x, &upper_bound)?)?;
@@ -884,8 +884,8 @@ mod tests {
             let x = ctx.bvs("x", 64)?;
 
             // Add constraints: 10 <= x <= 20
-            let lower_bound = ctx.bvv(BitVec::from((10u64, 64)))?;
-            let upper_bound = ctx.bvv(BitVec::from((20u64, 64)))?;
+            let lower_bound = ctx.bvv(BitVec::from((10, 64)))?;
+            let upper_bound = ctx.bvv(BitVec::from((20, 64)))?;
 
             solver.add(&ctx.uge(&x, &lower_bound)?)?;
             solver.add(&ctx.ule(&x, &upper_bound)?)?;
@@ -910,15 +910,15 @@ mod tests {
             // x must be greater than 5
             // y must be less than 10
             // x + y must be even (lowest bit is 0)
-            let five = ctx.bvv(BitVec::from((5u64, 8)))?;
-            let ten = ctx.bvv(BitVec::from((10u64, 8)))?;
+            let five = ctx.bvv(BitVec::from((5, 8)))?;
+            let ten = ctx.bvv(BitVec::from((10, 8)))?;
 
             solver.add(&ctx.ugt(&x, &five)?)?;
             solver.add(&ctx.ult(&y, &ten)?)?;
 
             // x + y must be even
             let sum = ctx.add(&x, &y)?;
-            let zero = ctx.bvv(BitVec::from((0u64, 1)))?;
+            let zero = ctx.bvv(BitVec::from((0, 1)))?;
             solver.add(&ctx.eq_(&ctx.extract(&sum, 0, 0)?, &zero)?)?;
 
             // Find min value of x
@@ -926,7 +926,7 @@ mod tests {
 
             // Min value should be 6
             // Because x > 5, and if x = 6 and y = 0, then 6+0=6 which is even
-            let six = ctx.bvv(BitVec::from((6u64, 8)))?;
+            let six = ctx.bvv(BitVec::from((6, 8)))?;
             assert_eq!(result, six);
 
             Ok(())
@@ -945,8 +945,8 @@ mod tests {
             // x must be less than 100
             // y must be greater than 20
             // x must be greater than y
-            let hundred = ctx.bvv(BitVec::from((100u64, 8)))?;
-            let twenty = ctx.bvv(BitVec::from((20u64, 8)))?;
+            let hundred = ctx.bvv(BitVec::from((100, 8)))?;
+            let twenty = ctx.bvv(BitVec::from((20, 8)))?;
 
             solver.add(&ctx.ult(&x, &hundred)?)?;
             solver.add(&ctx.ugt(&y, &twenty)?)?;
@@ -956,7 +956,7 @@ mod tests {
             let result = solver.max_unsigned(&x)?;
 
             // Max value should be 99 (since x < 100)
-            let ninety_nine = ctx.bvv(BitVec::from((99u64, 8)))?;
+            let ninety_nine = ctx.bvv(BitVec::from((99, 8)))?;
             assert_eq!(result, ninety_nine);
 
             Ok(())
@@ -970,7 +970,7 @@ mod tests {
             let mut solver = Z3Solver::new(&ctx);
 
             // Using a concrete value should return the same value
-            let bv = ctx.bvv(BitVec::from((42u64, 64)))?;
+            let bv = ctx.bvv(BitVec::from((42, 64)))?;
             let result = solver.min_signed(&bv)?;
 
             assert_eq!(result, bv);
@@ -984,7 +984,7 @@ mod tests {
             let mut solver = Z3Solver::new(&ctx);
 
             // Using a concrete value should return the same value
-            let bv = ctx.bvv(BitVec::from((42u64, 64)))?;
+            let bv = ctx.bvv(BitVec::from((42, 64)))?;
             let result = solver.max_signed(&bv)?;
 
             assert_eq!(result, bv);
@@ -1002,8 +1002,8 @@ mod tests {
 
             // Add constraints: -10 <= x <= 20 (in signed interpretation)
             // -10 in 64-bit two's complement is 0xfffffffffffffff6
-            let lower_bound = ctx.bvv(BitVec::from((0xfffffffffffffff6u64, 64)))?;
-            let upper_bound = ctx.bvv(BitVec::from((20u64, 64)))?;
+            let lower_bound = ctx.bvv(BitVec::from((0xfffffffffffffff6, 64)))?;
+            let upper_bound = ctx.bvv(BitVec::from((20, 64)))?;
 
             solver.add(&ctx.sge(&x, &lower_bound)?)?;
             solver.add(&ctx.sle(&x, &upper_bound)?)?;
@@ -1025,8 +1025,8 @@ mod tests {
 
             // Add constraints: -10 <= x <= 20 (in signed interpretation)
             // -10 in 64-bit two's complement is 0xfffffffffffffff6
-            let lower_bound = ctx.bvv(BitVec::from((0xfffffffffffffff6u64, 64)))?;
-            let upper_bound = ctx.bvv(BitVec::from((20u64, 64)))?;
+            let lower_bound = ctx.bvv(BitVec::from((0xfffffffffffffff6, 64)))?;
+            let upper_bound = ctx.bvv(BitVec::from((20, 64)))?;
 
             solver.add(&ctx.sge(&x, &lower_bound)?)?;
             solver.add(&ctx.sle(&x, &upper_bound)?)?;
@@ -1053,15 +1053,15 @@ mod tests {
             // x + y must be even (lowest bit is 0)
 
             // -5 in 8-bit two's complement is 0xfb (251 in unsigned)
-            let neg_five = ctx.bvv(BitVec::from((0xfbu64, 8)))?;
-            let ten = ctx.bvv(BitVec::from((10u64, 8)))?;
+            let neg_five = ctx.bvv(BitVec::from((0xfb, 8)))?;
+            let ten = ctx.bvv(BitVec::from((10, 8)))?;
 
             solver.add(&ctx.sgt(&x, &neg_five)?)?;
             solver.add(&ctx.slt(&y, &ten)?)?;
 
             // x + y must be even
             let sum = ctx.add(&x, &y)?;
-            let zero = ctx.bvv(BitVec::from((0u64, 1)))?;
+            let zero = ctx.bvv(BitVec::from((0, 1)))?;
             solver.add(&ctx.eq_(&ctx.extract(&sum, 0, 0)?, &zero)?)?;
 
             // Find min value of x
@@ -1069,7 +1069,7 @@ mod tests {
 
             // Min value should be -4 (0xfc in 8-bit two's complement)
             // Because x > -5, and if x = -4 and y = 0, then -4+0=-4 which is even
-            let neg_four = ctx.bvv(BitVec::from((0xfcu64, 8)))?;
+            let neg_four = ctx.bvv(BitVec::from((0xfc, 8)))?;
             assert_eq!(result, neg_four);
 
             Ok(())
@@ -1088,10 +1088,10 @@ mod tests {
             // x must be less than 100 (signed)
             // y must be greater than -20 (signed)
             // x must be greater than y (signed)
-            let hundred = ctx.bvv(BitVec::from((100u64, 8)))?;
+            let hundred = ctx.bvv(BitVec::from((100, 8)))?;
 
             // -20 in 8-bit two's complement is 0xec (236 in unsigned)
-            let neg_twenty = ctx.bvv(BitVec::from((0xecu64, 8)))?;
+            let neg_twenty = ctx.bvv(BitVec::from((0xec, 8)))?;
 
             solver.add(&ctx.slt(&x, &hundred)?)?;
             solver.add(&ctx.sgt(&y, &neg_twenty)?)?;
@@ -1101,7 +1101,7 @@ mod tests {
             let result = solver.max_signed(&x)?;
 
             // Max value should be 99 (since x < 100)
-            let ninety_nine = ctx.bvv(BitVec::from((99u64, 8)))?;
+            let ninety_nine = ctx.bvv(BitVec::from((99, 8)))?;
             assert_eq!(result, ninety_nine);
 
             Ok(())
@@ -1118,8 +1118,8 @@ mod tests {
             // Add constraints: -100 <= x <= -10 (in signed interpretation)
             // -100 in 8-bit two's complement is 0x9c (156 in unsigned)
             // -10 in 8-bit two's complement is 0xf6 (246 in unsigned)
-            let lower_bound = ctx.bvv(BitVec::from((0x9cu64, 8)))?;
-            let upper_bound = ctx.bvv(BitVec::from((0xf6u64, 8)))?;
+            let lower_bound = ctx.bvv(BitVec::from((0x9c, 8)))?;
+            let upper_bound = ctx.bvv(BitVec::from((0xf6, 8)))?;
 
             solver.add(&ctx.sge(&x, &lower_bound)?)?;
             solver.add(&ctx.sle(&x, &upper_bound)?)?;
@@ -1142,8 +1142,8 @@ mod tests {
             // Add constraints: -100 <= x <= -10 (in signed interpretation)
             // -100 in 8-bit two's complement is 0x9c (156 in unsigned)
             // -10 in 8-bit two's complement is 0xf6 (246 in unsigned)
-            let lower_bound = ctx.bvv(BitVec::from((0x9cu64, 8)))?;
-            let upper_bound = ctx.bvv(BitVec::from((0xf6u64, 8)))?;
+            let lower_bound = ctx.bvv(BitVec::from((0x9c, 8)))?;
+            let upper_bound = ctx.bvv(BitVec::from((0xf6, 8)))?;
 
             solver.add(&ctx.sge(&x, &lower_bound)?)?;
             solver.add(&ctx.sle(&x, &upper_bound)?)?;
@@ -1192,9 +1192,9 @@ mod tests {
         let x = ctx.bvs("x", 8)?;
 
         // Add constraints
-        let c0 = ctx.ugt(&x, &ctx.bvv(BitVec::from((10u64, 8)))?)?; // x > 10
-        let c1 = ctx.ult(&x, &ctx.bvv(BitVec::from((5u64, 8)))?)?; // x < 5 - contradicts c0
-        let c2 = ctx.ugt(&x, &ctx.bvv(BitVec::from((0u64, 8)))?)?; // x > 0 - doesn't contribute to unsat
+        let c0 = ctx.ugt(&x, &ctx.bvv(BitVec::from((10, 8)))?)?; // x > 10
+        let c1 = ctx.ult(&x, &ctx.bvv(BitVec::from((5, 8)))?)?; // x < 5 - contradicts c0
+        let c2 = ctx.ugt(&x, &ctx.bvv(BitVec::from((0, 8)))?)?; // x > 0 - doesn't contribute to unsat
 
         solver.add(&c0)?; // constraint 0
         solver.add(&c1)?; // constraint 1

--- a/crates/clarirs_z3/src/solver.rs
+++ b/crates/clarirs_z3/src/solver.rs
@@ -405,7 +405,7 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         // For signed minimization, the sign bit should be 1 (for negative numbers)
         // Extract the sign bit
         let sign_bit = self.ctx.extract(expr, size - 1, size - 1)?;
-        let one_bit = self.ctx.bvv_prim_with_size(1u64, 1)?;
+        let one_bit = self.ctx.bvv(BitVec::from((1u64, 1)))?;
 
         // Create a target variable equal to the expression
         let target_name = format!("min_signed_target_{size}");
@@ -440,7 +440,7 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         // For signed maximization, the sign bit should be 0 (for positive numbers)
         // Extract the sign bit
         let sign_bit = self.ctx.extract(expr, size - 1, size - 1)?;
-        let zero_bit = self.ctx.bvv_prim_with_size(0u64, 1)?;
+        let zero_bit = self.ctx.bvv(BitVec::from((0u64, 1)))?;
 
         // Create a target variable equal to the expression
         let target_name = format!("max_signed_target_{size}");
@@ -831,7 +831,7 @@ mod tests {
             let mut solver = Z3Solver::new(&ctx);
 
             // Using a concrete value should return the same value
-            let bv = ctx.bvv_prim(42u64)?;
+            let bv = ctx.bvv(BitVec::from((42u64, 64)))?;
             let result = solver.min_unsigned(&bv)?;
 
             assert_eq!(result, bv);
@@ -845,7 +845,7 @@ mod tests {
             let mut solver = Z3Solver::new(&ctx);
 
             // Using a concrete value should return the same value
-            let bv = ctx.bvv_prim(42u64)?;
+            let bv = ctx.bvv(BitVec::from((42u64, 64)))?;
             let result = solver.max_unsigned(&bv)?;
 
             assert_eq!(result, bv);
@@ -862,8 +862,8 @@ mod tests {
             let x = ctx.bvs("x", 64)?;
 
             // Add constraints: 10 <= x <= 20
-            let lower_bound = ctx.bvv_prim(10u64)?;
-            let upper_bound = ctx.bvv_prim(20u64)?;
+            let lower_bound = ctx.bvv(BitVec::from((10u64, 64)))?;
+            let upper_bound = ctx.bvv(BitVec::from((20u64, 64)))?;
 
             solver.add(&ctx.uge(&x, &lower_bound)?)?;
             solver.add(&ctx.ule(&x, &upper_bound)?)?;
@@ -884,8 +884,8 @@ mod tests {
             let x = ctx.bvs("x", 64)?;
 
             // Add constraints: 10 <= x <= 20
-            let lower_bound = ctx.bvv_prim(10u64)?;
-            let upper_bound = ctx.bvv_prim(20u64)?;
+            let lower_bound = ctx.bvv(BitVec::from((10u64, 64)))?;
+            let upper_bound = ctx.bvv(BitVec::from((20u64, 64)))?;
 
             solver.add(&ctx.uge(&x, &lower_bound)?)?;
             solver.add(&ctx.ule(&x, &upper_bound)?)?;
@@ -910,15 +910,15 @@ mod tests {
             // x must be greater than 5
             // y must be less than 10
             // x + y must be even (lowest bit is 0)
-            let five = ctx.bvv_prim(5u8)?;
-            let ten = ctx.bvv_prim(10u8)?;
+            let five = ctx.bvv(BitVec::from((5u64, 8)))?;
+            let ten = ctx.bvv(BitVec::from((10u64, 8)))?;
 
             solver.add(&ctx.ugt(&x, &five)?)?;
             solver.add(&ctx.ult(&y, &ten)?)?;
 
             // x + y must be even
             let sum = ctx.add(&x, &y)?;
-            let zero = ctx.bvv_prim_with_size(0u64, 1)?;
+            let zero = ctx.bvv(BitVec::from((0u64, 1)))?;
             solver.add(&ctx.eq_(&ctx.extract(&sum, 0, 0)?, &zero)?)?;
 
             // Find min value of x
@@ -926,7 +926,7 @@ mod tests {
 
             // Min value should be 6
             // Because x > 5, and if x = 6 and y = 0, then 6+0=6 which is even
-            let six = ctx.bvv_prim(6u8)?;
+            let six = ctx.bvv(BitVec::from((6u64, 8)))?;
             assert_eq!(result, six);
 
             Ok(())
@@ -945,8 +945,8 @@ mod tests {
             // x must be less than 100
             // y must be greater than 20
             // x must be greater than y
-            let hundred = ctx.bvv_prim(100u8)?;
-            let twenty = ctx.bvv_prim(20u8)?;
+            let hundred = ctx.bvv(BitVec::from((100u64, 8)))?;
+            let twenty = ctx.bvv(BitVec::from((20u64, 8)))?;
 
             solver.add(&ctx.ult(&x, &hundred)?)?;
             solver.add(&ctx.ugt(&y, &twenty)?)?;
@@ -956,7 +956,7 @@ mod tests {
             let result = solver.max_unsigned(&x)?;
 
             // Max value should be 99 (since x < 100)
-            let ninety_nine = ctx.bvv_prim(99u8)?;
+            let ninety_nine = ctx.bvv(BitVec::from((99u64, 8)))?;
             assert_eq!(result, ninety_nine);
 
             Ok(())
@@ -970,7 +970,7 @@ mod tests {
             let mut solver = Z3Solver::new(&ctx);
 
             // Using a concrete value should return the same value
-            let bv = ctx.bvv_prim(42u64)?;
+            let bv = ctx.bvv(BitVec::from((42u64, 64)))?;
             let result = solver.min_signed(&bv)?;
 
             assert_eq!(result, bv);
@@ -984,7 +984,7 @@ mod tests {
             let mut solver = Z3Solver::new(&ctx);
 
             // Using a concrete value should return the same value
-            let bv = ctx.bvv_prim(42u64)?;
+            let bv = ctx.bvv(BitVec::from((42u64, 64)))?;
             let result = solver.max_signed(&bv)?;
 
             assert_eq!(result, bv);
@@ -1002,8 +1002,8 @@ mod tests {
 
             // Add constraints: -10 <= x <= 20 (in signed interpretation)
             // -10 in 64-bit two's complement is 0xfffffffffffffff6
-            let lower_bound = ctx.bvv_prim(0xfffffffffffffff6u64)?;
-            let upper_bound = ctx.bvv_prim(20u64)?;
+            let lower_bound = ctx.bvv(BitVec::from((0xfffffffffffffff6u64, 64)))?;
+            let upper_bound = ctx.bvv(BitVec::from((20u64, 64)))?;
 
             solver.add(&ctx.sge(&x, &lower_bound)?)?;
             solver.add(&ctx.sle(&x, &upper_bound)?)?;
@@ -1025,8 +1025,8 @@ mod tests {
 
             // Add constraints: -10 <= x <= 20 (in signed interpretation)
             // -10 in 64-bit two's complement is 0xfffffffffffffff6
-            let lower_bound = ctx.bvv_prim(0xfffffffffffffff6u64)?;
-            let upper_bound = ctx.bvv_prim(20u64)?;
+            let lower_bound = ctx.bvv(BitVec::from((0xfffffffffffffff6u64, 64)))?;
+            let upper_bound = ctx.bvv(BitVec::from((20u64, 64)))?;
 
             solver.add(&ctx.sge(&x, &lower_bound)?)?;
             solver.add(&ctx.sle(&x, &upper_bound)?)?;
@@ -1053,15 +1053,15 @@ mod tests {
             // x + y must be even (lowest bit is 0)
 
             // -5 in 8-bit two's complement is 0xfb (251 in unsigned)
-            let neg_five = ctx.bvv_prim(0xfbu8)?;
-            let ten = ctx.bvv_prim(10u8)?;
+            let neg_five = ctx.bvv(BitVec::from((0xfbu64, 8)))?;
+            let ten = ctx.bvv(BitVec::from((10u64, 8)))?;
 
             solver.add(&ctx.sgt(&x, &neg_five)?)?;
             solver.add(&ctx.slt(&y, &ten)?)?;
 
             // x + y must be even
             let sum = ctx.add(&x, &y)?;
-            let zero = ctx.bvv_prim_with_size(0u64, 1)?;
+            let zero = ctx.bvv(BitVec::from((0u64, 1)))?;
             solver.add(&ctx.eq_(&ctx.extract(&sum, 0, 0)?, &zero)?)?;
 
             // Find min value of x
@@ -1069,7 +1069,7 @@ mod tests {
 
             // Min value should be -4 (0xfc in 8-bit two's complement)
             // Because x > -5, and if x = -4 and y = 0, then -4+0=-4 which is even
-            let neg_four = ctx.bvv_prim(0xfcu8)?;
+            let neg_four = ctx.bvv(BitVec::from((0xfcu64, 8)))?;
             assert_eq!(result, neg_four);
 
             Ok(())
@@ -1088,10 +1088,10 @@ mod tests {
             // x must be less than 100 (signed)
             // y must be greater than -20 (signed)
             // x must be greater than y (signed)
-            let hundred = ctx.bvv_prim(100u8)?;
+            let hundred = ctx.bvv(BitVec::from((100u64, 8)))?;
 
             // -20 in 8-bit two's complement is 0xec (236 in unsigned)
-            let neg_twenty = ctx.bvv_prim(0xecu8)?;
+            let neg_twenty = ctx.bvv(BitVec::from((0xecu64, 8)))?;
 
             solver.add(&ctx.slt(&x, &hundred)?)?;
             solver.add(&ctx.sgt(&y, &neg_twenty)?)?;
@@ -1101,7 +1101,7 @@ mod tests {
             let result = solver.max_signed(&x)?;
 
             // Max value should be 99 (since x < 100)
-            let ninety_nine = ctx.bvv_prim(99u8)?;
+            let ninety_nine = ctx.bvv(BitVec::from((99u64, 8)))?;
             assert_eq!(result, ninety_nine);
 
             Ok(())
@@ -1118,8 +1118,8 @@ mod tests {
             // Add constraints: -100 <= x <= -10 (in signed interpretation)
             // -100 in 8-bit two's complement is 0x9c (156 in unsigned)
             // -10 in 8-bit two's complement is 0xf6 (246 in unsigned)
-            let lower_bound = ctx.bvv_prim(0x9cu8)?;
-            let upper_bound = ctx.bvv_prim(0xf6u8)?;
+            let lower_bound = ctx.bvv(BitVec::from((0x9cu64, 8)))?;
+            let upper_bound = ctx.bvv(BitVec::from((0xf6u64, 8)))?;
 
             solver.add(&ctx.sge(&x, &lower_bound)?)?;
             solver.add(&ctx.sle(&x, &upper_bound)?)?;
@@ -1142,8 +1142,8 @@ mod tests {
             // Add constraints: -100 <= x <= -10 (in signed interpretation)
             // -100 in 8-bit two's complement is 0x9c (156 in unsigned)
             // -10 in 8-bit two's complement is 0xf6 (246 in unsigned)
-            let lower_bound = ctx.bvv_prim(0x9cu8)?;
-            let upper_bound = ctx.bvv_prim(0xf6u8)?;
+            let lower_bound = ctx.bvv(BitVec::from((0x9cu64, 8)))?;
+            let upper_bound = ctx.bvv(BitVec::from((0xf6u64, 8)))?;
 
             solver.add(&ctx.sge(&x, &lower_bound)?)?;
             solver.add(&ctx.sle(&x, &upper_bound)?)?;
@@ -1192,9 +1192,9 @@ mod tests {
         let x = ctx.bvs("x", 8)?;
 
         // Add constraints
-        let c0 = ctx.ugt(&x, &ctx.bvv_prim(10u8)?)?; // x > 10
-        let c1 = ctx.ult(&x, &ctx.bvv_prim(5u8)?)?; // x < 5 - contradicts c0
-        let c2 = ctx.ugt(&x, &ctx.bvv_prim(0u8)?)?; // x > 0 - doesn't contribute to unsat
+        let c0 = ctx.ugt(&x, &ctx.bvv(BitVec::from((10u64, 8)))?)?; // x > 10
+        let c1 = ctx.ult(&x, &ctx.bvv(BitVec::from((5u64, 8)))?)?; // x < 5 - contradicts c0
+        let c2 = ctx.ugt(&x, &ctx.bvv(BitVec::from((0u64, 8)))?)?; // x > 0 - doesn't contribute to unsat
 
         solver.add(&c0)?; // constraint 0
         solver.add(&c1)?; // constraint 1


### PR DESCRIPTION
## Summary
This PR refactors the BitVec conversion API to use Rust's standard `From` trait with tuple-based inputs instead of custom methods. This provides a more idiomatic and ergonomic interface for creating BitVec instances from various numeric types.

## Key Changes

- **Replaced custom conversion methods with `From` trait implementations:**
  - `BitVec::from_prim()` and `BitVec::from_prim_with_size()` → `BitVec::from((value, length))`
  - `BitVec::from_biguint()` → `BitVec::from((biguint, length))`
  - `BitVec::from_bigint()` → `BitVec::from((bigint, length))`
  - `BitVec::from_str()` → `TryFrom<(String, u32)>`

- **Implemented three new `From` trait implementations:**
  - `From<(u64, u32)>` for creating BitVec from unsigned 64-bit values with explicit length
  - `From<(BigUint, u32)>` for creating BitVec from arbitrary-precision unsigned integers
  - `From<(BigInt, u32)>` for creating BitVec from arbitrary-precision signed integers with two's complement handling

- **Added `TryFrom<(String, u32)>` implementation** for parsing base-10 strings into BitVec values

- **Updated all call sites** throughout the codebase to use the new tuple-based syntax:
  - Test files in `bitvec/tests.rs`, `bitvec/reference_tests.rs`, `bitvec/comparison.rs`
  - Arithmetic operations in `bitvec/arithmetic.rs`
  - Bitwise operations in `bitvec/bitwise.rs`
  - Extension operations in `bitvec/extension.rs`
  - Algorithm implementations in `simplify/bv.rs`, `simplify/test_bv.rs`, `simplify/test_bool.rs`
  - Solver implementations in Z3, VSA, and other solver modules
  - Python bindings and other integration points

## Implementation Details

- The new `From` implementations handle truncation of values to fit within the specified bit length
- Two's complement representation is properly handled for negative BigInt values
- All implementations are infallible (no `Result` return type) where possible, matching the original behavior
- The refactoring maintains backward compatibility in behavior while improving the API surface

https://claude.ai/code/session_01CMN7ZrX2Usd6TkN465NdK1