### PR TITLE
Preserve Python identity for all annotations across AST round-trips

### DIFF
--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -13,13 +13,14 @@ use crate::prelude::*;
 static ORIGINAL_ANNOTATIONS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
 fn original_annotations(py: Python<'_>) -> Result<Bound<'_, PyAny>, ClaripyError> {
-    let cache = ORIGINAL_ANNOTATIONS.get_or_try_init(py, || -> Result<Py<PyAny>, ClaripyError> {
-        Ok(py
-            .import("weakref")?
-            .getattr("WeakValueDictionary")?
-            .call0()?
-            .unbind())
-    })?;
+    let cache =
+        ORIGINAL_ANNOTATIONS.get_or_try_init(py, || -> Result<Py<PyAny>, ClaripyError> {
+            Ok(py
+                .import("weakref")?
+                .getattr("WeakValueDictionary")?
+                .call0()?
+                .unbind())
+        })?;
     Ok(cache.bind(py).clone())
 }
 

--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -1,7 +1,27 @@
 use num_bigint::BigUint;
-use pyo3::types::{PyDict, PyTuple, PyType};
+use pyo3::sync::PyOnceLock;
+use pyo3::types::{PyBytes, PyDict, PyTuple, PyType};
 
 use crate::prelude::*;
+
+/// Process-global cache of the original Python objects for user-defined
+/// (Unknown) annotations, keyed by their pickled bytes. It lets retrieval
+/// return the very object that was attached — while it is still alive —
+/// instead of an unpickled copy, so `is` and `==` hold for callers that
+/// round-trip an annotation through an AST. It is a `WeakValueDictionary`, so
+/// entries evict once the original annotation is garbage-collected.
+static ORIGINAL_ANNOTATIONS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
+fn original_annotations(py: Python<'_>) -> Result<Bound<'_, PyAny>, ClaripyError> {
+    let cache = ORIGINAL_ANNOTATIONS.get_or_try_init(py, || -> Result<Py<PyAny>, ClaripyError> {
+        Ok(py
+            .import("weakref")?
+            .getattr("WeakValueDictionary")?
+            .call0()?
+            .unbind())
+    })?;
+    Ok(cache.bind(py).clone())
+}
 
 /// `claripy.annotation.Annotation`
 ///
@@ -88,11 +108,20 @@ impl PyAnnotation {
                 .getattr("__class__")?
                 .getattr("__name__")?
                 .extract::<String>()?;
-            let pickle_dumps = slf.py().import("pickle")?.getattr("dumps")?;
+            let py = slf.py();
+            let pickle_dumps = py.import("pickle")?.getattr("dumps")?;
+            let pickled = pickle_dumps.call1((slf,))?.extract::<Vec<u8>>()?;
+            // Remember the original object, keyed by its pickled bytes, so
+            // retrieval can return it verbatim while it is still alive,
+            // preserving Python identity. Best-effort: objects that are not
+            // weak-referenceable are simply not cached.
+            if let Ok(cache) = original_annotations(py) {
+                let _ = cache.set_item(PyBytes::new(py, &pickled), slf);
+            }
             Ok(Annotation::new(
                 AnnotationType::Unknown {
                     name: format!("{module_name}:{class_name}"),
-                    value: pickle_dumps.call1((slf,))?.extract::<Vec<u8>>()?,
+                    value: pickled,
                 },
                 eliminatable,
                 relocatable,
@@ -107,8 +136,20 @@ impl PyAnnotation {
     ) -> Result<Bound<'py, PyAnnotation>, ClaripyError> {
         match annotation.type_() {
             AnnotationType::Unknown { value, .. } => {
-                let pickle_loads = py.import("pickle")?.getattr("loads")?;
-                Ok(pickle_loads.call1((value,))?.cast_into::<PyAnnotation>()?)
+                // Return the original Python object if it is still cached and
+                // alive (preserving identity); otherwise reconstruct it by
+                // unpickling the stored bytes.
+                let cached = original_annotations(py)
+                    .ok()
+                    .and_then(|cache| cache.call_method1("get", (PyBytes::new(py, value),)).ok())
+                    .filter(|obj| !obj.is_none());
+                match cached {
+                    Some(obj) => Ok(obj.cast_into::<PyAnnotation>()?),
+                    None => {
+                        let pickle_loads = py.import("pickle")?.getattr("loads")?;
+                        Ok(pickle_loads.call1((value,))?.cast_into::<PyAnnotation>()?)
+                    }
+                }
             }
             AnnotationType::SimplificationAvoidance => upcast(Bound::new(
                 py,

--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -1,15 +1,17 @@
 use num_bigint::BigUint;
 use pyo3::sync::PyOnceLock;
-use pyo3::types::{PyBytes, PyDict, PyTuple, PyType};
+use pyo3::types::{PyDict, PyString, PyTuple, PyType};
 
 use crate::prelude::*;
 
-/// Process-global cache of the original Python objects for user-defined
-/// (Unknown) annotations, keyed by their pickled bytes. It lets retrieval
-/// return the very object that was attached — while it is still alive —
-/// instead of an unpickled copy, so `is` and `==` hold for callers that
-/// round-trip an annotation through an AST. It is a `WeakValueDictionary`, so
-/// entries evict once the original annotation is garbage-collected.
+/// Process-global cache of the original Python objects for annotations, keyed
+/// by their core [`Annotation`] value. It lets retrieval return the very object
+/// that was attached — while it is still alive — instead of a freshly
+/// constructed copy, so `is` and `==` hold for callers that round-trip an
+/// annotation through an AST. This applies to every annotation, built-in or
+/// user-defined. It is a `WeakValueDictionary`, so entries evict once the
+/// original annotation is garbage-collected, at which point retrieval falls
+/// back to reconstructing the annotation from the core value.
 static ORIGINAL_ANNOTATIONS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
 fn original_annotations(py: Python<'_>) -> Result<Bound<'_, PyAny>, ClaripyError> {
@@ -24,11 +26,55 @@ fn original_annotations(py: Python<'_>) -> Result<Bound<'_, PyAny>, ClaripyError
     Ok(cache.bind(py).clone())
 }
 
+/// A process-local key identifying an annotation by its content, used to store
+/// and look up the original Python object in [`ORIGINAL_ANNOTATIONS`].
+///
+/// The `Debug` representation is injective over distinct [`Annotation`] values,
+/// and the cache it keys is never persisted (it lives only for the lifetime of
+/// the process), so `Debug` is a sound key here even though it is not a stable
+/// serialization format.
+fn cache_key<'py>(py: Python<'py>, annotation: &Annotation) -> Bound<'py, PyString> {
+    PyString::new(py, &format!("{annotation:?}"))
+}
+
+/// Remember `obj` as the original Python object for `annotation`, so a later
+/// retrieval can hand it back verbatim while it is still alive. Best-effort:
+/// objects that cannot be weakly referenced are simply not cached.
+fn remember_original(annotation: &Annotation, obj: &Bound<'_, PyAnnotation>) {
+    let py = obj.py();
+    if let Ok(cache) = original_annotations(py) {
+        let _ = cache.set_item(cache_key(py, annotation), obj);
+    }
+}
+
+/// Return the original Python object that produced `annotation` if it is still
+/// cached and alive, preserving Python identity across an attach/read
+/// round-trip.
+fn cached_annotation<'py>(
+    py: Python<'py>,
+    annotation: &Annotation,
+) -> Option<Bound<'py, PyAnnotation>> {
+    let cache = original_annotations(py).ok()?;
+    let obj = cache
+        .call_method1("get", (cache_key(py, annotation),))
+        .ok()?;
+    if obj.is_none() {
+        return None;
+    }
+    obj.cast_into::<PyAnnotation>().ok()
+}
+
 /// `claripy.annotation.Annotation`
 ///
 /// The base class for every annotation. User code can subclass it, and the
 /// built-in annotations below are genuine subclasses.
-#[pyclass(name = "Annotation", subclass, frozen, module = "claripy.annotation")]
+#[pyclass(
+    name = "Annotation",
+    subclass,
+    frozen,
+    weakref,
+    module = "claripy.annotation"
+)]
 pub struct PyAnnotation;
 
 #[pymethods]
@@ -58,15 +104,11 @@ impl PyAnnotation {
     /// its subclasses) into the core [`Annotation`] consumed by the solver.
     pub fn to_annotation(slf: &Bound<'_, PyAnnotation>) -> Result<Annotation, ClaripyError> {
         let any = slf.as_any();
-        if any.cast::<SimplificationAvoidanceAnnotation>().is_ok() {
-            Ok(Annotation::new(
-                AnnotationType::SimplificationAvoidance,
-                false,
-                false,
-            ))
+        let annotation = if any.cast::<SimplificationAvoidanceAnnotation>().is_ok() {
+            Annotation::new(AnnotationType::SimplificationAvoidance, false, false)
         } else if let Ok(si) = any.cast::<StridedIntervalAnnotation>() {
             let si = si.get();
-            Ok(Annotation::new(
+            Annotation::new(
                 AnnotationType::StridedInterval {
                     stride: si.stride.clone(),
                     lower_bound: si.lower_bound.clone(),
@@ -74,25 +116,21 @@ impl PyAnnotation {
                 },
                 false,
                 false,
-            ))
+            )
         } else if any.cast::<EmptyStridedIntervalAnnotation>().is_ok() {
-            Ok(Annotation::new(
-                AnnotationType::EmptyStridedInterval,
-                false,
-                false,
-            ))
+            Annotation::new(AnnotationType::EmptyStridedInterval, false, false)
         } else if let Ok(region) = any.cast::<RegionAnnotation>() {
             let region = region.get();
-            Ok(Annotation::new(
+            Annotation::new(
                 AnnotationType::Region {
                     region_id: region.region_id.clone(),
                     region_base_addr: region.region_base_addr.clone(),
                 },
                 false,
                 false,
-            ))
+            )
         } else if any.cast::<UninitializedAnnotation>().is_ok() {
-            Ok(Annotation::new(AnnotationType::Uninitialized, false, true))
+            Annotation::new(AnnotationType::Uninitialized, false, true)
         } else {
             // Unknown, user-defined annotation: preserve it losslessly by
             // pickling the Python object so it can be reconstructed later.
@@ -109,25 +147,25 @@ impl PyAnnotation {
                 .getattr("__class__")?
                 .getattr("__name__")?
                 .extract::<String>()?;
-            let py = slf.py();
-            let pickle_dumps = py.import("pickle")?.getattr("dumps")?;
+            let pickle_dumps = slf.py().import("pickle")?.getattr("dumps")?;
             let pickled = pickle_dumps.call1((slf,))?.extract::<Vec<u8>>()?;
-            // Remember the original object, keyed by its pickled bytes, so
-            // retrieval can return it verbatim while it is still alive,
-            // preserving Python identity. Best-effort: objects that are not
-            // weak-referenceable are simply not cached.
-            if let Ok(cache) = original_annotations(py) {
-                let _ = cache.set_item(PyBytes::new(py, &pickled), slf);
-            }
-            Ok(Annotation::new(
+            Annotation::new(
                 AnnotationType::Unknown {
                     name: format!("{module_name}:{class_name}"),
                     value: pickled,
                 },
                 eliminatable,
                 relocatable,
-            ))
-        }
+            )
+        };
+
+        // Remember the original object, keyed by the core annotation it
+        // produced, so retrieval can return it verbatim while it is still alive,
+        // preserving Python identity (`is`/`==`) across an attach/read
+        // round-trip — for built-in and user-defined annotations alike.
+        remember_original(&annotation, slf);
+
+        Ok(annotation)
     }
 
     /// Build a Python annotation object from a core [`Annotation`].
@@ -135,22 +173,17 @@ impl PyAnnotation {
         py: Python<'py>,
         annotation: &Annotation,
     ) -> Result<Bound<'py, PyAnnotation>, ClaripyError> {
+        // Return the original Python object if it is still cached and alive,
+        // preserving identity; otherwise reconstruct it from the core value
+        // below. This covers every annotation type, not just user-defined ones.
+        if let Some(obj) = cached_annotation(py, annotation) {
+            return Ok(obj);
+        }
+
         match annotation.type_() {
             AnnotationType::Unknown { value, .. } => {
-                // Return the original Python object if it is still cached and
-                // alive (preserving identity); otherwise reconstruct it by
-                // unpickling the stored bytes.
-                let cached = original_annotations(py)
-                    .ok()
-                    .and_then(|cache| cache.call_method1("get", (PyBytes::new(py, value),)).ok())
-                    .filter(|obj| !obj.is_none());
-                match cached {
-                    Some(obj) => Ok(obj.cast_into::<PyAnnotation>()?),
-                    None => {
-                        let pickle_loads = py.import("pickle")?.getattr("loads")?;
-                        Ok(pickle_loads.call1((value,))?.cast_into::<PyAnnotation>()?)
-                    }
-                }
+                let pickle_loads = py.import("pickle")?.getattr("loads")?;
+                Ok(pickle_loads.call1((value,))?.cast_into::<PyAnnotation>()?)
             }
             AnnotationType::SimplificationAvoidance => upcast(Bound::new(
                 py,
@@ -201,7 +234,7 @@ fn upcast<'py, T>(bound: Bound<'py, T>) -> Result<Bound<'py, PyAnnotation>, Clar
 }
 
 /// `claripy.annotation.SimplificationAvoidanceAnnotation`
-#[pyclass(extends = PyAnnotation, subclass, frozen, module = "claripy.annotation")]
+#[pyclass(extends = PyAnnotation, subclass, frozen, weakref, module = "claripy.annotation")]
 pub struct SimplificationAvoidanceAnnotation;
 
 #[pymethods]
@@ -231,7 +264,7 @@ impl SimplificationAvoidanceAnnotation {
 }
 
 /// `claripy.annotation.StridedIntervalAnnotation`
-#[pyclass(extends = PyAnnotation, subclass, frozen, module = "claripy.annotation")]
+#[pyclass(extends = PyAnnotation, subclass, frozen, weakref, module = "claripy.annotation")]
 pub struct StridedIntervalAnnotation {
     #[pyo3(get)]
     stride: BigUint,
@@ -286,7 +319,7 @@ impl StridedIntervalAnnotation {
 }
 
 /// `claripy.annotation.EmptyStridedIntervalAnnotation`
-#[pyclass(extends = PyAnnotation, subclass, frozen, module = "claripy.annotation")]
+#[pyclass(extends = PyAnnotation, subclass, frozen, weakref, module = "claripy.annotation")]
 pub struct EmptyStridedIntervalAnnotation;
 
 #[pymethods]
@@ -316,7 +349,7 @@ impl EmptyStridedIntervalAnnotation {
 }
 
 /// `claripy.annotation.RegionAnnotation`
-#[pyclass(extends = PyAnnotation, subclass, frozen, module = "claripy.annotation")]
+#[pyclass(extends = PyAnnotation, subclass, frozen, weakref, module = "claripy.annotation")]
 pub struct RegionAnnotation {
     #[pyo3(get)]
     region_id: String,
@@ -360,7 +393,7 @@ impl RegionAnnotation {
 }
 
 /// `claripy.annotation.UninitializedAnnotation`
-#[pyclass(extends = PyAnnotation, subclass, frozen, module = "claripy.annotation")]
+#[pyclass(extends = PyAnnotation, subclass, frozen, weakref, module = "claripy.annotation")]
 pub struct UninitializedAnnotation;
 
 #[pymethods]

--- a/crates/clarirs_py/tests/test_annotations.py
+++ b/crates/clarirs_py/tests/test_annotations.py
@@ -137,6 +137,25 @@ class TestAnnotationRoundtrip(unittest.TestCase):
         self.assertIsInstance(roundtripped, CustomRelocatableAnnotation)
         self.assertEqual(roundtripped.tag, "t")
 
+    def test_user_annotation_identity_preserved(self):
+        # While the original Python object is alive, retrieval returns it
+        # verbatim rather than an unpickled copy, so `is` holds.
+        anno = CustomRelocatableAnnotation("t")
+        bv = claripy.BVS("x", 32).annotate(anno)
+        self.assertIs(bv.annotations[0], anno)
+        self.assertIs(bv.annotations[0], bv.annotations[0])
+
+    def test_user_annotation_reconstructed_after_original_gc(self):
+        # Once the original is gone, retrieval falls back to unpickling a fresh
+        # equal copy (the cache holds only a weak reference).
+        import gc
+
+        bv = claripy.BVS("x", 32).annotate(CustomRelocatableAnnotation("t"))
+        gc.collect()
+        roundtripped = bv.annotations[0]
+        self.assertIsInstance(roundtripped, CustomRelocatableAnnotation)
+        self.assertEqual(roundtripped.tag, "t")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/crates/clarirs_py/tests/test_annotations.py
+++ b/crates/clarirs_py/tests/test_annotations.py
@@ -156,6 +156,34 @@ class TestAnnotationRoundtrip(unittest.TestCase):
         self.assertIsInstance(roundtripped, CustomRelocatableAnnotation)
         self.assertEqual(roundtripped.tag, "t")
 
+    def test_builtin_annotation_identity_preserved(self):
+        # Identity preservation is not limited to user-defined annotations: a
+        # built-in annotation that is still alive is also handed back verbatim,
+        # so `is` holds both against the original and across repeated reads.
+        for anno in (
+            claripy.SimplificationAvoidanceAnnotation(),
+            claripy.StridedIntervalAnnotation(3, 0, 9),
+            EmptyStridedIntervalAnnotation(),
+            claripy.RegionAnnotation("heap", 0x20),
+            claripy.UninitializedAnnotation(),
+        ):
+            with self.subTest(annotation=anno):
+                bv = claripy.BVS("x", 32).annotate(anno)
+                self.assertIs(bv.annotations[0], anno)
+                self.assertIs(bv.annotations[0], bv.annotations[0])
+
+    def test_builtin_annotation_reconstructed_after_original_gc(self):
+        # Once the original built-in annotation is gone, retrieval falls back to
+        # reconstructing a fresh equal copy from the stored core value.
+        import gc
+
+        bv = claripy.BVS("x", 32).annotate(claripy.RegionAnnotation("heap", 0x20))
+        gc.collect()
+        roundtripped = bv.annotations[0]
+        self.assertIsInstance(roundtripped, claripy.RegionAnnotation)
+        self.assertEqual(roundtripped.region_id, "heap")
+        self.assertEqual(roundtripped.region_base_addr, 0x20)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

When an annotation is attached to an AST and read back, the binding now hands
back the *same* Python object that was attached (while it is still alive),
rather than a freshly constructed copy. This makes `ast.annotations[0] is
original` hold — and, for the built-in annotations (which derive `==` from
identity), `==` hold too — for **every** annotation type, built-in and
user-defined alike.

Previously, retrieval always rebuilt the Python object from the core
`Annotation`: built-in annotations were reconstructed from their typed fields
and user-defined ones were unpickled, so identity never survived a round-trip
through an AST.

## How it works

A process-global `weakref.WeakValueDictionary` remembers the original Python
object for each annotation:

- **Keyed by the core `Annotation` value**, so the one mechanism covers built-in
  and user-defined annotations uniformly. (The key is derived from the
  annotation's `Debug` form; the cache is process-local and never persisted, so
  it only needs to be injective within a run, which `Debug` is over these
  derived types.)
- `to_annotation` records the original object for all types; `from_annotation`
  returns it verbatim while it is alive and otherwise falls back to
  reconstructing from the core value.
- Because the dictionary holds only weak references, entries evict once the
  original annotation is garbage-collected — at which point retrieval cleanly
  falls back to reconstruction.
- The built-in annotation pyclasses are made `weakref`-able (matching the
  existing `Base`/`Bits`/`BV` hierarchy); without this the cache could not hold
  them and would silently drop them.

## Testing

- `cargo build`, `cargo clippy` (no warnings on `clarirs_py`), and `cargo fmt
  --check` all pass.
- New Python tests cover identity preservation and post-GC reconstruction for
  the built-in annotations, alongside the existing user-defined coverage; the
  full `test_annotations.py` suite passes (15 tests + 5 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsHzcXVt5Te11sujA7CH6v

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsHzcXVt5Te11sujA7CH6v)_