### PR TITLE
clarirs_py: accept claripy's canonicalize(var_map=, counter=) kwargs

### DIFF
--- a/crates/clarirs_py/src/ast/base.rs
+++ b/crates/clarirs_py/src/ast/base.rs
@@ -1,7 +1,7 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
-use clarirs_core::algorithms::{canonicalize, structurally_match};
-use pyo3::types::{PyFrozenSet, PySet, PyType};
+use clarirs_core::algorithms::{collect_vars::collect_vars, structurally_match};
+use pyo3::types::{PyDict, PyFrozenSet, PySet, PyType};
 
 use crate::prelude::*;
 
@@ -136,21 +136,80 @@ impl Base {
         self.inner.to_smtlib_shallow(max_depth)
     }
 
+    /// Canonicalize variable names to v0, v1, ... like claripy's
+    /// `canonicalize(var_map=None, counter=None)`.
+    ///
+    /// `var_map` (hash -> canonical variable) is mutated in place when
+    /// provided, so a mapping can be shared across several expressions.
+    /// `counter` may be an int (the value clarirs returns) or any iterator of
+    /// ints such as `itertools.count` (which claripy returns); when an
+    /// iterator is passed it is advanced in place and returned as-is.
     #[allow(clippy::type_complexity)]
+    #[allow(clippy::mutable_key_type)]
+    #[pyo3(signature = (var_map = None, counter = None))]
     pub fn canonicalize<'py>(
         &self,
         py: Python<'py>,
-    ) -> Result<(HashMap<u64, Bound<'py, PyAny>>, usize, Bound<'py, Base>), ClaripyError> {
-        let (replacement_map, counter, canonical) = canonicalize(&self.inner.clone())?;
-        let canonical_py = Base::from_ast(py, canonical)?;
+        var_map: Option<Bound<'py, PyDict>>,
+        counter: Option<Bound<'py, PyAny>>,
+    ) -> Result<(Bound<'py, PyDict>, Bound<'py, PyAny>, Bound<'py, Base>), ClaripyError> {
+        let dict = var_map.unwrap_or_else(|| PyDict::new(py));
+        let counter_is_iter = matches!(&counter, Some(c) if c.hasattr("__next__").unwrap_or(false));
+        let mut int_counter: usize = match &counter {
+            Some(c) if !counter_is_iter => c.extract::<usize>()?,
+            _ => 0,
+        };
 
-        let mut py_map = HashMap::new();
-        for (hash, ast) in replacement_map {
-            let py_ast = Base::from_ast(py, ast)?;
-            py_map.insert(hash, py_ast.into_any());
+        let vars = collect_vars(&self.inner)?;
+        let mut sorted_vars: Vec<_> = vars.into_iter().collect();
+        sorted_vars.sort_by_key(|v| v.variables().iter().next().cloned());
+
+        let ctx = self.inner.context();
+        let mut replacements: Vec<(AstRef<'static>, AstRef<'static>)> = Vec::new();
+        for var in sorted_vars {
+            let key = var.hash();
+            let canonical_ast = match dict.get_item(key)? {
+                Some(existing) => Base::to_ast(existing.cast_into::<Base>()?)?,
+                None => {
+                    let idx = if counter_is_iter {
+                        counter
+                            .as_ref()
+                            .expect("counter_is_iter implies counter")
+                            .call_method0("__next__")?
+                            .extract::<usize>()?
+                    } else {
+                        let idx = int_counter;
+                        int_counter += 1;
+                        idx
+                    };
+                    let name = format!("v{idx}");
+                    let canonical = match var.ast_type() {
+                        AstType::Bool => ctx.bools(name.as_str())?,
+                        AstType::BitVec(size) => ctx.bvs(name.as_str(), size)?,
+                        AstType::Float(sort) => ctx.fps(name.as_str(), sort)?,
+                        AstType::String => ctx.strings(name.as_str())?,
+                    };
+                    dict.set_item(key, Base::from_ast(py, canonical.clone())?)?;
+                    canonical
+                }
+            };
+            replacements.push((var, canonical_ast));
         }
 
-        Ok((py_map, counter, canonical_py))
+        let mut result = self.inner.clone();
+        for (from, to) in &replacements {
+            result = result.replace(from, to)?;
+        }
+
+        let counter_ret: Bound<'py, PyAny> = match counter {
+            Some(c) if counter_is_iter => c,
+            _ => int_counter
+                .into_pyobject(py)
+                .map_err(PyErr::from)?
+                .into_any(),
+        };
+
+        Ok((dict, counter_ret, Base::from_ast(py, result)?))
     }
 
     pub fn identical(&self, other: Bound<'_, Base>) -> Result<bool, ClaripyError> {

--- a/crates/clarirs_py/tests/test_canonicalize.py
+++ b/crates/clarirs_py/tests/test_canonicalize.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import itertools
+import unittest
+
+import claripy
+
+
+class TestCanonicalize(unittest.TestCase):
+    def test_no_args_renames_to_canonical(self):
+        x = claripy.BVS("x", 32)
+        canon = (x + 1).canonicalize()[-1]
+        # The lone variable becomes v0.
+        self.assertIn("v0", str(canon))
+        self.assertNotIn("x", str(canon))
+
+    def test_structurally_equal_exprs_canonicalize_equal(self):
+        x = claripy.BVS("x", 32)
+        y = claripy.BVS("y", 32)
+        a = (x + 1) * x
+        b = (y + 1) * y
+        self.assertTrue(a.canonicalize()[-1].identical(b.canonicalize()[-1]))
+
+    def test_distinct_exprs_stay_distinct(self):
+        x = claripy.BVS("x", 32)
+        self.assertFalse((x + 1).canonicalize()[-1].identical((x + 2).canonicalize()[-1]))
+
+    def test_shared_var_map_and_counter(self):
+        # Canonicalize a constraint, then values under the same mapping so the
+        # same variable keeps the same canonical name across expressions.
+        x = claripy.BVS("x", 32)
+        y = claripy.BVS("y", 32)
+
+        nmap, ncounter, _ = (x > 5).canonicalize()
+        n_val = (x + 7).canonicalize(var_map=nmap, counter=ncounter)[-1]
+
+        umap, ucounter, _ = (y > 5).canonicalize()
+        u_val = (y + 7).canonicalize(var_map=umap, counter=ucounter)[-1]
+
+        self.assertTrue(n_val.identical(u_val))
+
+    def test_var_map_is_mutated_in_place(self):
+        x = claripy.BVS("x", 32)
+        var_map = {}
+        returned, _, _ = (x + 1).canonicalize(var_map=var_map)
+        self.assertIs(returned, var_map)
+        self.assertEqual(len(var_map), 1)
+
+    def test_counter_accepts_int(self):
+        x = claripy.BVS("x", 32)
+        # clarirs returns an int counter; it must also accept one back.
+        _, counter, _ = (x + 1).canonicalize(counter=0)
+        self.assertEqual(counter, 1)
+
+    def test_counter_accepts_iterator(self):
+        x = claripy.BVS("x", 32)
+        y = claripy.BVS("y", 32)
+        # claripy passes an itertools.count; it is advanced in place and
+        # returned as-is.
+        counter = itertools.count(0)
+        _, returned, canon = (x + y).canonicalize(counter=counter)
+        self.assertIs(returned, counter)
+        # Two distinct variables consumed v0 and v1; next value is 2.
+        self.assertEqual(next(counter), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`Base.canonicalize` currently takes no arguments and only returns a fresh `(var_map, counter, ast)`. claripy's `canonicalize(var_map=None, counter=None)` instead accepts a mapping and counter so that several expressions can be canonicalized against **one shared naming**. This brings the binding in line with claripy.

- `var_map` (hash → canonical variable) is mutated in place when provided and returned, so a caller can thread it across calls.
- `counter` may be an `int` (the value clarirs already returns) or any iterator of ints such as `itertools.count` (what claripy passes); it is advanced and returned in the same form it was given.
- With no arguments the behavior is unchanged: a fresh map and a `v0, v1, …` renaming.

The renaming is built from `collect_vars` + `replace` in the binding, sorted by variable name for determinism, rather than calling the core `canonicalize` (which takes no inputs).

## Motivation

angr's `CongruencyCheck` canonicalizes a constraint set and then evaluates several values under that same mapping, e.g.:

```python
nmap, ncounter, _ = claripy.And(*constraints).canonicalize()
flags = state.regs.eflags.canonicalize(var_map=nmap, counter=ncounter)[-1]
```

This requires the shared-`var_map`/`counter` form.

## Tests

Adds `crates/clarirs_py/tests/test_canonicalize.py`: renaming to `v0…`, structural equality of two renamed-equal expressions, distinct expressions staying distinct, a shared `var_map`/`counter` across expressions, in-place `var_map` mutation, and both `int` and `itertools.count` counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)