### PR TITLE
solver: CompositeSolver records unsat instead of raising from add

### DIFF
--- a/crates/clarirs_core/src/solver/composite.rs
+++ b/crates/clarirs_core/src/solver/composite.rs
@@ -18,6 +18,10 @@ pub struct CompositeSolver<'c, S: Solver<'c>> {
     children: HashMap<usize, S>,
     var_to_child: HashMap<InternedString, usize>,
     next_id: usize,
+    /// Set when a concretely-false constraint is added. claripy's
+    /// CompositeFrontend records the unsat state instead of raising from
+    /// add(); unsat is reported by satisfiable() and value queries.
+    unsat: bool,
 }
 
 impl<'c, S: Solver<'c>> HasContext<'c> for CompositeSolver<'c, S> {
@@ -34,6 +38,7 @@ impl<'c, S: Solver<'c>> CompositeSolver<'c, S> {
             children: HashMap::new(),
             var_to_child: HashMap::new(),
             next_id: 0,
+            unsat: false,
         }
     }
 
@@ -121,9 +126,10 @@ impl<'c, S: Solver<'c>> Solver<'c> for CompositeSolver<'c, S> {
         let vars: BTreeSet<InternedString> = constraint.variables().clone();
 
         if vars.is_empty() {
-            // Concrete constraint — reject immediately if false.
+            // Concrete constraint — record unsat if false. claripy does not
+            // raise from add(); the unsat state surfaces on later queries.
             if constraint.is_false() {
-                return Err(ClarirsError::Unsat);
+                self.unsat = true;
             }
             return Ok(());
         }
@@ -149,6 +155,7 @@ impl<'c, S: Solver<'c>> Solver<'c> for CompositeSolver<'c, S> {
     fn clear(&mut self) -> Result<(), ClarirsError> {
         self.children.clear();
         self.var_to_child.clear();
+        self.unsat = false;
         Ok(())
     }
 
@@ -168,6 +175,9 @@ impl<'c, S: Solver<'c>> Solver<'c> for CompositeSolver<'c, S> {
     }
 
     fn satisfiable(&mut self) -> Result<bool, ClarirsError> {
+        if self.unsat {
+            return Ok(false);
+        }
         for child in self.children.values_mut() {
             if !child.satisfiable()? {
                 return Ok(false);
@@ -265,26 +275,41 @@ impl<'c, S: Solver<'c>> Solver<'c> for CompositeSolver<'c, S> {
     }
 
     fn min_unsigned(&mut self, expr: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
+        if self.unsat {
+            return Err(ClarirsError::Unsat);
+        }
         let vars = expr.variables().clone();
         self.with_solver_for(&vars, |s| s.min_unsigned(expr))
     }
 
     fn max_unsigned(&mut self, expr: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
+        if self.unsat {
+            return Err(ClarirsError::Unsat);
+        }
         let vars = expr.variables().clone();
         self.with_solver_for(&vars, |s| s.max_unsigned(expr))
     }
 
     fn min_signed(&mut self, expr: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
+        if self.unsat {
+            return Err(ClarirsError::Unsat);
+        }
         let vars = expr.variables().clone();
         self.with_solver_for(&vars, |s| s.min_signed(expr))
     }
 
     fn max_signed(&mut self, expr: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
+        if self.unsat {
+            return Err(ClarirsError::Unsat);
+        }
         let vars = expr.variables().clone();
         self.with_solver_for(&vars, |s| s.max_signed(expr))
     }
 
     fn eval_n(&mut self, expr: &AstRef<'c>, n: u32) -> Result<Vec<AstRef<'c>>, ClarirsError> {
+        if self.unsat {
+            return Err(ClarirsError::Unsat);
+        }
         let vars = expr.variables().clone();
         self.with_solver_for(&vars, |s| s.eval_n(expr, n))
     }
@@ -315,9 +340,14 @@ mod tests {
         let template = ConcreteSolver::new(&ctx);
         let mut solver = CompositeSolver::new(&ctx, template);
 
-        // Adding false should return Unsat
-        let result = solver.add(&ctx.false_().unwrap());
-        assert!(result.is_err());
+        // Adding false succeeds (claripy does not raise from add); the unsat
+        // state is reported by satisfiable().
+        solver.add(&ctx.false_().unwrap()).unwrap();
+        assert!(!solver.satisfiable().unwrap());
+
+        // clear() resets the unsat state.
+        solver.clear().unwrap();
+        assert!(solver.satisfiable().unwrap());
     }
 
     #[test]

--- a/crates/clarirs_py/tests/test_composite_unsat.py
+++ b/crates/clarirs_py/tests/test_composite_unsat.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import unittest
+
+import claripy
+
+
+class TestCompositeUnsat(unittest.TestCase):
+    def test_add_false_does_not_raise(self):
+        # claripy's CompositeFrontend records the unsat state instead of
+        # raising from add(); it surfaces through satisfiable().
+        solver = claripy.SolverComposite()
+        solver.add(claripy.BoolV(False))
+        self.assertFalse(solver.satisfiable())
+
+    def test_contradictory_concrete_constraints(self):
+        solver = claripy.SolverComposite()
+        x = claripy.BVS("x", 32)
+        solver.add(x == 1)
+        solver.add(x == 2)
+        self.assertFalse(solver.satisfiable())
+
+    def test_satisfiable_when_consistent(self):
+        solver = claripy.SolverComposite()
+        x = claripy.BVS("x", 32)
+        solver.add(x == 5)
+        self.assertTrue(solver.satisfiable())
+        self.assertEqual(tuple(solver.eval(x, 1)), (5,))
+
+    def test_false_makes_otherwise_sat_solver_unsat(self):
+        solver = claripy.SolverComposite()
+        x = claripy.BVS("x", 32)
+        solver.add(x == 5)
+        self.assertTrue(solver.satisfiable())
+        solver.add(claripy.BoolV(False))
+        self.assertFalse(solver.satisfiable())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`CompositeSolver::add` returned `Err(Unsat)` immediately when a concretely-false constraint was added. claripy's `CompositeFrontend` instead **records** the unsat state and lets it surface through `satisfiable()` and value queries — `add()` itself does not raise.

This change matches that: a concretely-false constraint sets an `unsat` flag (reset by `clear()`), and `satisfiable()` / `min_*` / `max_*` / `eval_n` report it, rather than erroring at `add()` time.

## Why

Consumers add a `false` constraint to mark a path/state infeasible and expect the infeasibility to surface on the next `satisfiable()` check, not to raise at `add()`. For example angr's `state.add_constraints(false)` marks the state unsat and the executor prunes it; raising from `add()` turns that into a crash.

## Tests

- Rust: `test_composite_solver_unsat_concrete` (updated) — `add(false)` succeeds, `satisfiable()` is `false`.
- Python: new `test_composite_unsat.py` — `add(false)` does not raise; unsat after false/contradictory constraints; still-satisfiable case unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)