### PR TITLE
annotation: set annotation tuples verbatim

### DIFF
--- a/crates/clarirs_core/src/ast/factory.rs
+++ b/crates/clarirs_core/src/ast/factory.rs
@@ -11,14 +11,30 @@ pub trait AstFactory<'c>: Sized {
     fn intern_string(&self, s: impl AsRef<str>) -> InternedString;
 
     /// The single node constructor. All other `make_*` helpers delegate here;
-    /// the node's type is inferred from the operation.
-    fn make_ast_annotated(
+    /// the node's type is inferred from the operation. The node gets exactly
+    /// `annotations`; relocatable annotations of children are NOT collected.
+    fn make_ast_exact(
         &'c self,
         op: AstOp<'c>,
         annotations: BTreeSet<Annotation>,
     ) -> Result<AstRef<'c>, ClarirsError>;
 
     // Provided methods
+
+    /// Construct a node with `annotations` plus the relocatable annotations of
+    /// the op's children, mirroring how operations propagate annotations.
+    fn make_ast_annotated(
+        &'c self,
+        op: AstOp<'c>,
+        mut annotations: BTreeSet<Annotation>,
+    ) -> Result<AstRef<'c>, ClarirsError> {
+        annotations.extend(
+            op.child_iter()
+                .flat_map(|c| c.annotations().clone())
+                .filter(|a| a.relocatable()),
+        );
+        self.make_ast_exact(op, annotations)
+    }
 
     fn make_ast(&'c self, op: AstOp<'c>) -> Result<AstRef<'c>, ClarirsError> {
         self.make_ast_annotated(op, BTreeSet::new())

--- a/crates/clarirs_core/src/context.rs
+++ b/crates/clarirs_core/src/context.rs
@@ -141,20 +141,14 @@ impl<'c> AstFactory<'c> for Context<'c> {
         self.intern_string(s)
     }
 
-    fn make_ast_annotated(
+    fn make_ast_exact(
         &'c self,
         op: AstOp<'c>,
-        mut annotations: BTreeSet<Annotation>,
+        annotations: BTreeSet<Annotation>,
     ) -> Result<AstRef<'c>, ClarirsError> {
         // Every construction funnels through here, so checking the op's child
         // types in this one place gives the whole API runtime type checking.
         op.validate()?;
-
-        annotations.extend(
-            op.child_iter()
-                .flat_map(|c| c.annotations().clone())
-                .filter(|a| a.relocatable()),
-        );
 
         // The node's type is inferred from the op and its children's cached
         // types; this also provides domain separation in the hash so that

--- a/crates/clarirs_py/src/ast/base.rs
+++ b/crates/clarirs_py/src/ast/base.rs
@@ -38,6 +38,8 @@ impl Base {
         Ok(self_.get().inner.clone())
     }
 
+    /// Wrap an existing [`AstRef`] without simplifying it, keeping its
+    /// annotation set exactly as given.
     pub fn from_ast<'py>(
         py: Python<'py>,
         ast: AstRef<'static>,
@@ -243,7 +245,8 @@ impl Base {
     ) -> Result<Bound<'py, Base>, ClaripyError> {
         let from_ast = Base::to_ast(from)?;
         let to_ast = Base::to_ast(to)?;
-        Base::from_ast(py, self.inner.replace(&from_ast, &to_ast)?)
+        // `replace` builds a new AST, so simplify the result before wrapping it.
+        Base::from_ast(py, self.inner.replace(&from_ast, &to_ast)?.simplify()?)
     }
 
     pub fn has_annotation_type(
@@ -345,7 +348,7 @@ impl Base {
         let inner = self
             .inner
             .context()
-            .make_ast_annotated(self.inner.op().clone(), new_annotations)?;
+            .make_ast_exact(self.inner.op().clone(), new_annotations)?;
         Base::from_ast(py, inner)
     }
 
@@ -367,7 +370,7 @@ impl Base {
         py: Python<'py>,
         annotations: Vec<Bound<'py, PyAnnotation>>,
     ) -> Result<Bound<'py, Base>, ClaripyError> {
-        let inner = self.inner.context().make_ast_annotated(
+        let inner = self.inner.context().make_ast_exact(
             self.inner.op().clone(),
             annotations
                 .iter()
@@ -383,7 +386,7 @@ impl Base {
     ) -> Result<Bound<'py, Base>, ClaripyError> {
         let py = annotation.py();
         let annotation = PyAnnotation::to_annotation(&annotation)?;
-        let inner = self.inner.context().make_ast_annotated(
+        let inner = self.inner.context().make_ast_exact(
             self.inner.op().clone(),
             self.inner
                 .annotations()
@@ -404,7 +407,7 @@ impl Base {
             .iter()
             .map(PyAnnotation::to_annotation)
             .collect::<Result<_, _>>()?;
-        let inner = self.inner.context().make_ast_annotated(
+        let inner = self.inner.context().make_ast_exact(
             self.inner.op().clone(),
             self.inner
                 .annotations()
@@ -423,7 +426,7 @@ impl Base {
         let inner = self
             .inner
             .context()
-            .make_ast_annotated(self.inner.op().clone(), Default::default())?;
+            .make_ast_exact(self.inner.op().clone(), Default::default())?;
         Base::from_ast(py, inner)
     }
 
@@ -441,7 +444,7 @@ impl Base {
         let inner = self
             .inner
             .context()
-            .make_ast_annotated(self.inner.op().clone(), kept)?;
+            .make_ast_exact(self.inner.op().clone(), kept)?;
         Base::from_ast(py, inner)
     }
 }

--- a/crates/clarirs_py/src/ast/bool.rs
+++ b/crates/clarirs_py/src/ast/bool.rs
@@ -33,12 +33,13 @@ impl Bool {
         Self::new_with_name(py, inner, None)
     }
 
+    /// Wrap an AST without simplifying it, keeping its annotation set exactly as
+    /// given.
     pub fn new_with_name<'py>(
         py: Python<'py>,
         inner: &AstRef<'static>,
         name: Option<String>,
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
-        let inner = &inner.simplify()?;
         if let Some(cache_hit) = PY_BOOL_CACHE.get(&inner.hash()).and_then(|cache_hit| {
             cache_hit
                 .bind(py)
@@ -214,6 +215,8 @@ impl Bool {
             inner
         };
 
+        // `__new__` reconstructs a node from (op, args, annotations) verbatim,
+        // without simplifying (e.g. when unpickling).
         Ok(Bool::new(py, &inner_with_annotations)?.unbind())
     }
 
@@ -242,7 +245,7 @@ impl Bool {
     }
 
     pub fn __invert__<'py>(&self, py: Python<'py>) -> Result<Bound<'py, Bool>, ClaripyError> {
-        Bool::new(py, &GLOBAL_CONTEXT.not(&self.inner)?)
+        Bool::new(py, &GLOBAL_CONTEXT.not(&self.inner)?.simplify()?)
     }
 
     pub fn __and__<'py>(
@@ -252,7 +255,9 @@ impl Bool {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.and2(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?,
+            &GLOBAL_CONTEXT
+                .and2(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?
+                .simplify()?,
         )
     }
 
@@ -263,7 +268,9 @@ impl Bool {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.or2(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?,
+            &GLOBAL_CONTEXT
+                .or2(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?
+                .simplify()?,
         )
     }
 
@@ -274,7 +281,9 @@ impl Bool {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.xor2(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?,
+            &GLOBAL_CONTEXT
+                .xor2(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?
+                .simplify()?,
         )
     }
 
@@ -285,7 +294,9 @@ impl Bool {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.eq_(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?,
+            &GLOBAL_CONTEXT
+                .eq_(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?
+                .simplify()?,
         )
     }
 
@@ -296,7 +307,9 @@ impl Bool {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.neq(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?,
+            &GLOBAL_CONTEXT
+                .neq(&self.inner, <CoerceBool as Into<AstRef>>::into(other))?
+                .simplify()?,
         )
     }
 
@@ -369,7 +382,12 @@ pub fn Eq_<'py>(
     a: Bound<Bool>,
     b: Bound<Bool>,
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
-    Bool::new(py, &GLOBAL_CONTEXT.eq_(&a.get().inner, &b.get().inner)?)
+    Bool::new(
+        py,
+        &GLOBAL_CONTEXT
+            .eq_(&a.get().inner, &b.get().inner)?
+            .simplify()?,
+    )
 }
 
 #[pyfunction]
@@ -378,7 +396,12 @@ pub fn Neq<'py>(
     a: Bound<Bool>,
     b: Bound<Bool>,
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
-    Bool::new(py, &GLOBAL_CONTEXT.neq(&a.get().inner, &b.get().inner)?)
+    Bool::new(
+        py,
+        &GLOBAL_CONTEXT
+            .neq(&a.get().inner, &b.get().inner)?
+            .simplify()?,
+    )
 }
 
 #[pyfunction(name = "true")]

--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -31,12 +31,13 @@ impl BV {
         Self::new_with_name(py, inner, None)
     }
 
+    /// Wrap an AST without simplifying it, keeping its annotation set exactly as
+    /// given.
     pub fn new_with_name<'py>(
         py: Python<'py>,
         inner: &AstRef<'static>,
         name: Option<String>,
     ) -> Result<Bound<'py, BV>, ClaripyError> {
-        let inner = &inner.simplify_ext(true, true)?;
         if let Some(cache_hit) = PY_BV_CACHE.get(&inner.hash()).and_then(|cache_hit| {
             cache_hit
                 .bind(py)
@@ -197,6 +198,8 @@ impl BV {
             inner
         };
 
+        // `__new__` reconstructs a node from (op, args, annotations) verbatim,
+        // without simplifying (e.g. when unpickling).
         Ok(BV::new(py, &inner_with_annotations)?.unbind())
     }
 
@@ -354,12 +357,16 @@ impl BV {
         if signed {
             FP::new(
                 self_.py(),
-                &GLOBAL_CONTEXT.bv_to_fp_signed(&self_.get().inner, sort, rm)?,
+                &GLOBAL_CONTEXT
+                    .bv_to_fp_signed(&self_.get().inner, sort, rm)?
+                    .simplify()?,
             )
         } else {
             FP::new(
                 self_.py(),
-                &GLOBAL_CONTEXT.bv_to_fp_unsigned(&self_.get().inner, sort, rm)?,
+                &GLOBAL_CONTEXT
+                    .bv_to_fp_unsigned(&self_.get().inner, sort, rm)?
+                    .simplify()?,
             )
         }
     }
@@ -371,7 +378,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.add(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .add(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -390,7 +399,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.sub(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .sub(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -401,7 +412,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.sub(&other.unpack_like(py, self)?.get().inner, &self.inner)?,
+            &GLOBAL_CONTEXT
+                .sub(&other.unpack_like(py, self)?.get().inner, &self.inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -412,7 +425,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.mul(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .mul(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -431,7 +446,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.udiv(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .udiv(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -442,7 +459,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.udiv(&other.unpack_like(py, self)?.get().inner, &self.inner)?,
+            &GLOBAL_CONTEXT
+                .udiv(&other.unpack_like(py, self)?.get().inner, &self.inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -453,7 +472,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.udiv(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .udiv(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -464,7 +485,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.udiv(&other.unpack_like(py, self)?.get().inner, &self.inner)?,
+            &GLOBAL_CONTEXT
+                .udiv(&other.unpack_like(py, self)?.get().inner, &self.inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -475,7 +498,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.urem(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .urem(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -486,7 +511,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.urem(&other.unpack_like(py, self)?.get().inner, &self.inner)?,
+            &GLOBAL_CONTEXT
+                .urem(&other.unpack_like(py, self)?.get().inner, &self.inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -497,7 +524,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.sdiv(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .sdiv(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -508,7 +537,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.srem(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .srem(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -519,7 +550,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.and2(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .and2(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -538,7 +571,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.or2(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .or2(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -557,7 +592,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.xor2(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .xor2(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -576,7 +613,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.shl(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .shl(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -587,7 +626,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.shl(&other.unpack_like(py, self)?.get().inner, &self.inner)?,
+            &GLOBAL_CONTEXT
+                .shl(&other.unpack_like(py, self)?.get().inner, &self.inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -598,7 +639,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.ashr(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .ashr(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -609,7 +652,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.ashr(&other.unpack_like(py, self)?.get().inner, &self.inner)?,
+            &GLOBAL_CONTEXT
+                .ashr(&other.unpack_like(py, self)?.get().inner, &self.inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -620,16 +665,24 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.lshr(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .lshr(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
     pub fn __neg__<'py>(&self, py: Python<'py>) -> Result<Bound<'py, BV>, ClaripyError> {
-        BV::new(py, &GLOBAL_CONTEXT.neg(&self.inner)?)
+        BV::new(
+            py,
+            &GLOBAL_CONTEXT.neg(&self.inner)?.simplify_ext(true, true)?,
+        )
     }
 
     pub fn __invert__<'py>(&self, py: Python<'py>) -> Result<Bound<'py, BV>, ClaripyError> {
-        BV::new(py, &GLOBAL_CONTEXT.not(&self.inner)?)
+        BV::new(
+            py,
+            &GLOBAL_CONTEXT.not(&self.inner)?.simplify_ext(true, true)?,
+        )
     }
 
     pub fn __pos__(self_: Bound<BV>) -> Result<Bound<BV>, ClaripyError> {
@@ -643,7 +696,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.eq_(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .eq_(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -654,7 +709,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.neq(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .neq(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -671,7 +728,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.ult(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .ult(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -682,7 +741,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.ule(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .ule(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -693,7 +754,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.ugt(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .ugt(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -704,7 +767,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.uge(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .uge(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -715,7 +780,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.ult(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .ult(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -726,7 +793,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.ule(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .ule(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -737,7 +806,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.ugt(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .ugt(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -748,7 +819,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.uge(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .uge(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -759,7 +832,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.slt(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .slt(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -770,7 +845,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.sle(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .sle(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -781,7 +858,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.sgt(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .sgt(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -792,7 +871,9 @@ impl BV {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.sge(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .sge(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -804,7 +885,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.extract(&self.inner, upper_bound, lower_bound)?,
+            &GLOBAL_CONTEXT
+                .extract(&self.inner, upper_bound, lower_bound)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -822,7 +905,12 @@ impl BV {
         py: Python<'py>,
         amount: u32,
     ) -> Result<Bound<'py, BV>, ClaripyError> {
-        BV::new(py, &GLOBAL_CONTEXT.zero_ext(&self.inner, amount)?)
+        BV::new(
+            py,
+            &GLOBAL_CONTEXT
+                .zero_ext(&self.inner, amount)?
+                .simplify_ext(true, true)?,
+        )
     }
 
     pub fn sign_extend<'py>(
@@ -830,12 +918,22 @@ impl BV {
         py: Python<'py>,
         amount: u32,
     ) -> Result<Bound<'py, BV>, ClaripyError> {
-        BV::new(py, &GLOBAL_CONTEXT.sign_ext(&self.inner, amount)?)
+        BV::new(
+            py,
+            &GLOBAL_CONTEXT
+                .sign_ext(&self.inner, amount)?
+                .simplify_ext(true, true)?,
+        )
     }
 
     #[getter]
     pub fn reversed<'py>(&self, py: Python<'py>) -> Result<Bound<'py, BV>, ClaripyError> {
-        BV::new(py, &GLOBAL_CONTEXT.byte_reverse(&self.inner)?)
+        BV::new(
+            py,
+            &GLOBAL_CONTEXT
+                .byte_reverse(&self.inner)?
+                .simplify_ext(true, true)?,
+        )
     }
 
     pub fn get_bytes<'py>(
@@ -974,7 +1072,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.union(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .union(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -985,7 +1085,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.intersection(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .intersection(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -996,7 +1098,9 @@ impl BV {
     ) -> Result<Bound<'py, BV>, ClaripyError> {
         BV::new(
             py,
-            &GLOBAL_CONTEXT.widen(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .widen(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -1135,7 +1239,9 @@ macro_rules! binop {
             let (elhs, erhs) = CoerceBV::unpack_pair(py, &lhs, &rhs)?;
             <$ret>::new(
                 py,
-                &GLOBAL_CONTEXT.$context_method(&elhs.get().inner, &erhs.get().inner)?,
+                &GLOBAL_CONTEXT
+                    .$context_method(&elhs.get().inner, &erhs.get().inner)?
+                    .simplify_ext(true, true)?,
             )
         }
     };
@@ -1191,7 +1297,9 @@ pub fn Extract<'py>(
 
     BV::new(
         py,
-        &GLOBAL_CONTEXT.extract(&base.get().inner, upper, lower)?,
+        &GLOBAL_CONTEXT
+            .extract(&base.get().inner, upper, lower)?
+            .simplify_ext(true, true)?,
     )
 }
 
@@ -1201,7 +1309,12 @@ pub fn ZeroExt<'py>(
     amount: u32,
     base: Bound<'py, BV>,
 ) -> Result<Bound<'py, BV>, ClaripyError> {
-    BV::new(py, &GLOBAL_CONTEXT.zero_ext(&base.get().inner, amount)?)
+    BV::new(
+        py,
+        &GLOBAL_CONTEXT
+            .zero_ext(&base.get().inner, amount)?
+            .simplify_ext(true, true)?,
+    )
 }
 
 #[pyfunction]
@@ -1210,12 +1323,22 @@ pub fn SignExt<'py>(
     amount: u32,
     base: Bound<'py, BV>,
 ) -> Result<Bound<'py, BV>, ClaripyError> {
-    BV::new(py, &GLOBAL_CONTEXT.sign_ext(&base.get().inner, amount)?)
+    BV::new(
+        py,
+        &GLOBAL_CONTEXT
+            .sign_ext(&base.get().inner, amount)?
+            .simplify_ext(true, true)?,
+    )
 }
 
 #[pyfunction]
 pub fn Reverse<'py>(py: Python<'py>, base: Bound<'py, BV>) -> Result<Bound<'py, BV>, ClaripyError> {
-    BV::new(py, &GLOBAL_CONTEXT.byte_reverse(&base.get().inner)?)
+    BV::new(
+        py,
+        &GLOBAL_CONTEXT
+            .byte_reverse(&base.get().inner)?
+            .simplify_ext(true, true)?,
+    )
 }
 
 binop!(ULT, ult, Bool);
@@ -1259,7 +1382,9 @@ pub fn SI(
 
     BV::new(
         py,
-        &GLOBAL_CONTEXT.si(bits, stride, lower_bound, upper_bound)?,
+        &GLOBAL_CONTEXT
+            .si(bits, stride, lower_bound, upper_bound)?
+            .simplify_ext(true, true)?,
     )
 }
 
@@ -1279,17 +1404,19 @@ pub fn VS<'py>(
     let value = value.unpack(py, bits, false)?;
     BV::new(
         py,
-        &GLOBAL_CONTEXT.annotate(
-            &value.get().inner,
-            [Annotation::new(
-                AnnotationType::Region {
-                    region_id,
-                    region_base_addr,
-                },
-                false,
-                false,
-            )],
-        )?,
+        &GLOBAL_CONTEXT
+            .annotate(
+                &value.get().inner,
+                [Annotation::new(
+                    AnnotationType::Region {
+                        region_id,
+                        region_base_addr,
+                    },
+                    false,
+                    false,
+                )],
+            )?
+            .simplify_ext(true, true)?,
     )
 }
 
@@ -1302,7 +1429,9 @@ pub fn union<'py>(
     let (elhs, erhs) = CoerceBV::unpack_pair(py, &lhs, &rhs)?;
     BV::new(
         py,
-        &GLOBAL_CONTEXT.union(&elhs.get().inner, &erhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .union(&elhs.get().inner, &erhs.get().inner)?
+            .simplify_ext(true, true)?,
     )
 }
 
@@ -1315,7 +1444,9 @@ pub fn intersection<'py>(
     let (elhs, erhs) = CoerceBV::unpack_pair(py, &lhs, &rhs)?;
     BV::new(
         py,
-        &GLOBAL_CONTEXT.intersection(&elhs.get().inner, &erhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .intersection(&elhs.get().inner, &erhs.get().inner)?
+            .simplify_ext(true, true)?,
     )
 }
 
@@ -1328,7 +1459,9 @@ pub fn widen<'py>(
     let (elhs, erhs) = CoerceBV::unpack_pair(py, &lhs, &rhs)?;
     BV::new(
         py,
-        &GLOBAL_CONTEXT.widen(&elhs.get().inner, &erhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .widen(&elhs.get().inner, &erhs.get().inner)?
+            .simplify_ext(true, true)?,
     )
 }
 

--- a/crates/clarirs_py/src/ast/fp.rs
+++ b/crates/clarirs_py/src/ast/fp.rs
@@ -166,12 +166,13 @@ impl FP {
         Self::new_with_name(py, inner, None)
     }
 
+    /// Wrap an AST without simplifying it, keeping its annotation set exactly as
+    /// given.
     pub fn new_with_name<'py>(
         py: Python<'py>,
         inner: &AstRef<'static>,
         name: Option<String>,
     ) -> Result<Bound<'py, FP>, ClaripyError> {
-        let inner = &inner.simplify()?;
         if let Some(cache_hit) = PY_FP_CACHE.get(&inner.hash()).and_then(|cache_hit| {
             cache_hit
                 .bind(py)
@@ -299,6 +300,8 @@ impl FP {
             inner
         };
 
+        // `__new__` reconstructs a node from (op, args, annotations) verbatim,
+        // without simplifying (e.g. when unpickling).
         Ok(FP::new(py, &inner_with_annotations)?.unbind())
     }
 
@@ -341,7 +344,9 @@ impl FP {
     pub fn raw_to_bv(self_: Bound<'_, FP>) -> Result<Bound<'_, BV>, ClaripyError> {
         BV::new(
             self_.py(),
-            &GLOBAL_CONTEXT.fp_to_ieeebv(&self_.get().inner)?,
+            &GLOBAL_CONTEXT
+                .fp_to_ieeebv(&self_.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -352,7 +357,9 @@ impl FP {
     pub fn to_bv(self_: Bound<'_, FP>) -> Result<Bound<'_, BV>, ClaripyError> {
         BV::new(
             self_.py(),
-            &GLOBAL_CONTEXT.fp_to_ieeebv(&self_.get().inner)?,
+            &GLOBAL_CONTEXT
+                .fp_to_ieeebv(&self_.get().inner)?
+                .simplify_ext(true, true)?,
         )
     }
 
@@ -364,7 +371,9 @@ impl FP {
     ) -> Result<Bound<'py, FP>, ClaripyError> {
         FP::new(
             self_.py(),
-            &GLOBAL_CONTEXT.fp_to_fp(&self_.get().inner, sort, rm.unwrap_or_default())?,
+            &GLOBAL_CONTEXT
+                .fp_to_fp(&self_.get().inner, sort, rm.unwrap_or_default())?
+                .simplify()?,
         )
     }
 
@@ -375,7 +384,9 @@ impl FP {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.fp_eq(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .fp_eq(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -386,7 +397,9 @@ impl FP {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.fp_neq(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .fp_neq(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -403,7 +416,9 @@ impl FP {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.fp_lt(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .fp_lt(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -414,7 +429,9 @@ impl FP {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.fp_leq(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .fp_leq(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -425,7 +442,9 @@ impl FP {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.fp_gt(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .fp_gt(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -436,16 +455,18 @@ impl FP {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.fp_geq(&self.inner, &other.unpack_like(py, self)?.get().inner)?,
+            &GLOBAL_CONTEXT
+                .fp_geq(&self.inner, &other.unpack_like(py, self)?.get().inner)?
+                .simplify()?,
         )
     }
 
     pub fn __abs__<'py>(&self, py: Python<'py>) -> Result<Bound<'py, FP>, ClaripyError> {
-        FP::new(py, &GLOBAL_CONTEXT.fp_abs(&self.inner)?)
+        FP::new(py, &GLOBAL_CONTEXT.fp_abs(&self.inner)?.simplify()?)
     }
 
     pub fn __neg__<'py>(&self, py: Python<'py>) -> Result<Bound<'py, FP>, ClaripyError> {
-        FP::new(py, &GLOBAL_CONTEXT.fp_neg(&self.inner)?)
+        FP::new(py, &GLOBAL_CONTEXT.fp_neg(&self.inner)?.simplify()?)
     }
 
     pub fn __add__<'py>(
@@ -455,11 +476,13 @@ impl FP {
     ) -> Result<Bound<'py, FP>, ClaripyError> {
         FP::new(
             py,
-            &GLOBAL_CONTEXT.fp_add(
-                &self.inner,
-                &other.unpack_like(py, self)?.get().inner,
-                PyRM::default(),
-            )?,
+            &GLOBAL_CONTEXT
+                .fp_add(
+                    &self.inner,
+                    &other.unpack_like(py, self)?.get().inner,
+                    PyRM::default(),
+                )?
+                .simplify()?,
         )
     }
 
@@ -470,11 +493,13 @@ impl FP {
     ) -> Result<Bound<'py, FP>, ClaripyError> {
         FP::new(
             py,
-            &GLOBAL_CONTEXT.fp_sub(
-                &self.inner,
-                &other.unpack_like(py, self)?.get().inner,
-                PyRM::default(),
-            )?,
+            &GLOBAL_CONTEXT
+                .fp_sub(
+                    &self.inner,
+                    &other.unpack_like(py, self)?.get().inner,
+                    PyRM::default(),
+                )?
+                .simplify()?,
         )
     }
 
@@ -485,11 +510,13 @@ impl FP {
     ) -> Result<Bound<'py, FP>, ClaripyError> {
         FP::new(
             py,
-            &GLOBAL_CONTEXT.fp_mul(
-                &self.inner,
-                &other.unpack_like(py, self)?.get().inner,
-                PyRM::default(),
-            )?,
+            &GLOBAL_CONTEXT
+                .fp_mul(
+                    &self.inner,
+                    &other.unpack_like(py, self)?.get().inner,
+                    PyRM::default(),
+                )?
+                .simplify()?,
         )
     }
 
@@ -500,11 +527,13 @@ impl FP {
     ) -> Result<Bound<'py, FP>, ClaripyError> {
         FP::new(
             py,
-            &GLOBAL_CONTEXT.fp_div(
-                &self.inner,
-                &other.unpack_like(py, self)?.get().inner,
-                PyRM::default(),
-            )?,
+            &GLOBAL_CONTEXT
+                .fp_div(
+                    &self.inner,
+                    &other.unpack_like(py, self)?.get().inner,
+                    PyRM::default(),
+                )?
+                .simplify()?,
         )
     }
 
@@ -555,12 +584,16 @@ impl FP {
         if signed {
             BV::new(
                 self_.py(),
-                &GLOBAL_CONTEXT.fp_to_sbv(&self_.get().inner, size, rm.unwrap_or_default())?,
+                &GLOBAL_CONTEXT
+                    .fp_to_sbv(&self_.get().inner, size, rm.unwrap_or_default())?
+                    .simplify_ext(true, true)?,
             )
         } else {
             BV::new(
                 self_.py(),
-                &GLOBAL_CONTEXT.fp_to_ubv(&self_.get().inner, size, rm.unwrap_or_default())?,
+                &GLOBAL_CONTEXT
+                    .fp_to_ubv(&self_.get().inner, size, rm.unwrap_or_default())?
+                    .simplify_ext(true, true)?,
             )
         }
     }
@@ -574,7 +607,9 @@ impl FP {
     ) -> Result<Bound<'py, FP>, ClaripyError> {
         FP::new(
             py,
-            &GLOBAL_CONTEXT.fp_sqrt(&lhs.get().inner, rm.unwrap_or_default())?,
+            &GLOBAL_CONTEXT
+                .fp_sqrt(&lhs.get().inner, rm.unwrap_or_default())?
+                .simplify()?,
         )
     }
 }
@@ -600,7 +635,9 @@ pub fn FPV(py: Python<'_>, value: f64, sort: PyFSort) -> Result<Bound<'_, FP>, C
     let float_value = Float::from(value);
     FP::new(
         py,
-        &GLOBAL_CONTEXT.fpv(float_value.to_fsort(sort.into(), FPRM::default())?)?,
+        &GLOBAL_CONTEXT
+            .fpv(float_value.to_fsort(sort.into(), FPRM::default())?)?
+            .simplify()?,
     )
 }
 
@@ -613,11 +650,13 @@ pub fn fpFP<'py>(
 ) -> Result<Bound<'py, FP>, ClaripyError> {
     FP::new(
         py,
-        &GLOBAL_CONTEXT.fp_fp(
-            &sign.get().inner,
-            &exponent.get().inner,
-            &significand.get().inner,
-        )?,
+        &GLOBAL_CONTEXT
+            .fp_fp(
+                &sign.get().inner,
+                &exponent.get().inner,
+                &significand.get().inner,
+            )?
+            .simplify()?,
     )
 }
 
@@ -633,14 +672,22 @@ pub fn FpToFP<'py>(
         let bv_item = args.get_item(0)?;
         let bv = bv_item.cast::<BV>()?;
         let sort: PyFSort = args.get_item(1)?.extract()?;
-        FP::new(py, &GLOBAL_CONTEXT.bv_to_fp(&bv.get().inner, sort)?)
+        FP::new(
+            py,
+            &GLOBAL_CONTEXT.bv_to_fp(&bv.get().inner, sort)?.simplify()?,
+        )
     } else if args.len() == 3 {
         // (RM, FP, FSort) case
         let rm: PyRM = args.get_item(0)?.extract()?;
         let fp_item = args.get_item(1)?;
         let fp = fp_item.cast::<FP>()?;
         let sort: PyFSort = args.get_item(2)?.extract()?;
-        FP::new(py, &GLOBAL_CONTEXT.fp_to_fp(&fp.get().inner, sort, rm)?)
+        FP::new(
+            py,
+            &GLOBAL_CONTEXT
+                .fp_to_fp(&fp.get().inner, sort, rm)?
+                .simplify()?,
+        )
     } else {
         Err(ClaripyError::InvalidOperation(
             "fpToFP requires 2 or 3 arguments".to_string(),
@@ -657,7 +704,9 @@ pub fn BvToFpUnsigned<'py>(
 ) -> Result<Bound<'py, FP>, ClaripyError> {
     FP::new(
         py,
-        &GLOBAL_CONTEXT.bv_to_fp_unsigned(&bv.get().inner, sort, rm)?,
+        &GLOBAL_CONTEXT
+            .bv_to_fp_unsigned(&bv.get().inner, sort, rm)?
+            .simplify()?,
     )
 }
 
@@ -666,7 +715,12 @@ pub fn fpToIEEEBV<'py>(
     py: Python<'py>,
     fp: Bound<'py, FP>,
 ) -> Result<Bound<'py, BV>, ClaripyError> {
-    BV::new(py, &GLOBAL_CONTEXT.fp_to_ieeebv(&fp.get().inner)?)
+    BV::new(
+        py,
+        &GLOBAL_CONTEXT
+            .fp_to_ieeebv(&fp.get().inner)?
+            .simplify_ext(true, true)?,
+    )
 }
 
 #[pyfunction(name = "fpToUBV", signature = (rm, fp, len))]
@@ -676,7 +730,12 @@ pub fn FpToUbv<'py>(
     fp: Bound<'py, FP>,
     len: u32,
 ) -> Result<Bound<'py, BV>, ClaripyError> {
-    BV::new(py, &GLOBAL_CONTEXT.fp_to_ubv(&fp.get().inner, len, rm)?)
+    BV::new(
+        py,
+        &GLOBAL_CONTEXT
+            .fp_to_ubv(&fp.get().inner, len, rm)?
+            .simplify_ext(true, true)?,
+    )
 }
 
 #[pyfunction(name = "fpToSBV", signature = (rm, fp, len))]
@@ -686,17 +745,22 @@ pub fn FpToBv<'py>(
     fp: Bound<'py, FP>,
     len: u32,
 ) -> Result<Bound<'py, BV>, ClaripyError> {
-    BV::new(py, &GLOBAL_CONTEXT.fp_to_sbv(&fp.get().inner, len, rm)?)
+    BV::new(
+        py,
+        &GLOBAL_CONTEXT
+            .fp_to_sbv(&fp.get().inner, len, rm)?
+            .simplify_ext(true, true)?,
+    )
 }
 
 #[pyfunction(name = "fpNeg", signature = (lhs))]
 pub fn FpNeg<'py>(py: Python<'py>, lhs: Bound<'py, FP>) -> Result<Bound<'py, FP>, ClaripyError> {
-    FP::new(py, &GLOBAL_CONTEXT.fp_neg(&lhs.get().inner)?)
+    FP::new(py, &GLOBAL_CONTEXT.fp_neg(&lhs.get().inner)?.simplify()?)
 }
 
 #[pyfunction(name = "fpAbs", signature = (lhs))]
 pub fn FpAbs<'py>(py: Python<'py>, lhs: Bound<'py, FP>) -> Result<Bound<'py, FP>, ClaripyError> {
-    FP::new(py, &GLOBAL_CONTEXT.fp_abs(&lhs.get().inner)?)
+    FP::new(py, &GLOBAL_CONTEXT.fp_abs(&lhs.get().inner)?.simplify()?)
 }
 
 #[pyfunction(name = "fpAdd", signature = (rm, lhs, rhs))]
@@ -708,7 +772,9 @@ pub fn FpAdd<'py>(
 ) -> Result<Bound<'py, FP>, ClaripyError> {
     FP::new(
         py,
-        &GLOBAL_CONTEXT.fp_add(&lhs.get().inner, &rhs.get().inner, rm)?,
+        &GLOBAL_CONTEXT
+            .fp_add(&lhs.get().inner, &rhs.get().inner, rm)?
+            .simplify()?,
     )
 }
 
@@ -721,7 +787,9 @@ pub fn FpSub<'py>(
 ) -> Result<Bound<'py, FP>, ClaripyError> {
     FP::new(
         py,
-        &GLOBAL_CONTEXT.fp_sub(&lhs.get().inner, &rhs.get().inner, rm)?,
+        &GLOBAL_CONTEXT
+            .fp_sub(&lhs.get().inner, &rhs.get().inner, rm)?
+            .simplify()?,
     )
 }
 
@@ -734,7 +802,9 @@ pub fn FpMul<'py>(
 ) -> Result<Bound<'py, FP>, ClaripyError> {
     FP::new(
         py,
-        &GLOBAL_CONTEXT.fp_mul(&lhs.get().inner, &rhs.get().inner, rm)?,
+        &GLOBAL_CONTEXT
+            .fp_mul(&lhs.get().inner, &rhs.get().inner, rm)?
+            .simplify()?,
     )
 }
 
@@ -747,7 +817,9 @@ pub fn FpDiv<'py>(
 ) -> Result<Bound<'py, FP>, ClaripyError> {
     FP::new(
         py,
-        &GLOBAL_CONTEXT.fp_div(&lhs.get().inner, &rhs.get().inner, rm)?,
+        &GLOBAL_CONTEXT
+            .fp_div(&lhs.get().inner, &rhs.get().inner, rm)?
+            .simplify()?,
     )
 }
 
@@ -781,7 +853,9 @@ pub fn FpSqrt<'py>(
 
     FP::new(
         py,
-        &GLOBAL_CONTEXT.fp_sqrt(&lhs.get().inner, rm.unwrap_or_default())?,
+        &GLOBAL_CONTEXT
+            .fp_sqrt(&lhs.get().inner, rm.unwrap_or_default())?
+            .simplify()?,
     )
 }
 
@@ -793,7 +867,9 @@ pub fn FpEq<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.fp_eq(&lhs.get().inner, &rhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .fp_eq(&lhs.get().inner, &rhs.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -805,7 +881,9 @@ pub fn FpNEQ<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.fp_neq(&lhs.get().inner, &rhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .fp_neq(&lhs.get().inner, &rhs.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -817,7 +895,9 @@ pub fn FpLt<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.fp_lt(&lhs.get().inner, &rhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .fp_lt(&lhs.get().inner, &rhs.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -829,7 +909,9 @@ pub fn FpLeq<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.fp_leq(&lhs.get().inner, &rhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .fp_leq(&lhs.get().inner, &rhs.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -841,7 +923,9 @@ pub fn FpGt<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.fp_gt(&lhs.get().inner, &rhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .fp_gt(&lhs.get().inner, &rhs.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -853,18 +937,20 @@ pub fn FpGeq<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.fp_geq(&lhs.get().inner, &rhs.get().inner)?,
+        &GLOBAL_CONTEXT
+            .fp_geq(&lhs.get().inner, &rhs.get().inner)?
+            .simplify()?,
     )
 }
 
 #[pyfunction(name = "fpIsNaN", signature = (fp))]
 pub fn FpIsNan<'py>(py: Python<'py>, fp: Bound<'py, FP>) -> Result<Bound<'py, Bool>, ClaripyError> {
-    Bool::new(py, &GLOBAL_CONTEXT.fp_is_nan(&fp.get().inner)?)
+    Bool::new(py, &GLOBAL_CONTEXT.fp_is_nan(&fp.get().inner)?.simplify()?)
 }
 
 #[pyfunction(name = "fpIsInf", signature = (fp))]
 pub fn FpIsInf<'py>(py: Python<'py>, fp: Bound<'py, FP>) -> Result<Bound<'py, Bool>, ClaripyError> {
-    Bool::new(py, &GLOBAL_CONTEXT.fp_is_inf(&fp.get().inner)?)
+    Bool::new(py, &GLOBAL_CONTEXT.fp_is_inf(&fp.get().inner)?.simplify()?)
 }
 
 pub(crate) fn import(_: Python, m: &Bound<PyModule>) -> PyResult<()> {

--- a/crates/clarirs_py/src/ast/mod.rs
+++ b/crates/clarirs_py/src/ast/mod.rs
@@ -19,11 +19,16 @@ pub static GLOBAL_CONTEXT: LazyLock<Context<'static>> = LazyLock::new(Context::n
 #[pyfunction(name = "Not")]
 pub fn not<'py>(py: Python<'py>, b: Bound<'py, Base>) -> Result<Bound<'py, Base>, ClaripyError> {
     if let Ok(b_bool) = b.clone().into_any().cast::<Bool>() {
-        return Bool::new(py, &GLOBAL_CONTEXT.not(&b_bool.get().inner)?)
+        return Bool::new(py, &GLOBAL_CONTEXT.not(&b_bool.get().inner)?.simplify()?)
             .map(|b| b.into_any().cast::<Base>().unwrap().clone());
     } else if let Ok(b_bv) = b.clone().into_any().cast::<BV>() {
-        return BV::new(py, &GLOBAL_CONTEXT.not(&b_bv.get().inner)?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+        return BV::new(
+            py,
+            &GLOBAL_CONTEXT
+                .not(&b_bv.get().inner)?
+                .simplify_ext(true, true)?,
+        )
+        .map(|b| b.into_any().cast::<Base>().unwrap().clone());
     } else {
         panic!("unsupported type")
     }
@@ -54,7 +59,7 @@ pub fn and<'py>(
                     .map_err(|_| ClaripyError::TypeError("And arguments must be Bool".to_string()))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        return Bool::new(py, &GLOBAL_CONTEXT.and(bool_args)?)
+        return Bool::new(py, &GLOBAL_CONTEXT.and(bool_args)?.simplify()?)
             .map(|b| b.into_any().cast::<Base>().unwrap().clone());
     }
     if args.len() == 2
@@ -64,7 +69,9 @@ pub fn and<'py>(
         let (lhs, rhs) = CoerceBV::unpack_pair(py, &lhs, &rhs)?;
         return BV::new(
             py,
-            &GLOBAL_CONTEXT.and2(&lhs.get().inner, &rhs.get().inner)?,
+            &GLOBAL_CONTEXT
+                .and2(&lhs.get().inner, &rhs.get().inner)?
+                .simplify_ext(true, true)?,
         )
         .map(|b| b.into_any().cast::<Base>().unwrap().clone());
     }
@@ -96,7 +103,7 @@ pub fn or<'py>(
                     .map_err(|_| ClaripyError::TypeError("Or arguments must be Bool".to_string()))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        return Bool::new(py, &GLOBAL_CONTEXT.or(bool_args)?)
+        return Bool::new(py, &GLOBAL_CONTEXT.or(bool_args)?.simplify()?)
             .map(|b| b.into_any().cast::<Base>().unwrap().clone());
     }
     if args.len() == 2
@@ -104,8 +111,13 @@ pub fn or<'py>(
         && let Some(rhs) = args[1].extract::<CoerceBV>().ok()
     {
         let (lhs, rhs) = CoerceBV::unpack_pair(py, &lhs, &rhs)?;
-        return BV::new(py, &GLOBAL_CONTEXT.or2(&lhs.get().inner, &rhs.get().inner)?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+        return BV::new(
+            py,
+            &GLOBAL_CONTEXT
+                .or2(&lhs.get().inner, &rhs.get().inner)?
+                .simplify_ext(true, true)?,
+        )
+        .map(|b| b.into_any().cast::<Base>().unwrap().clone());
     }
     Err(ClaripyError::TypeError(
         "Or: expected Bools or exactly two BVs".to_string(),
@@ -123,7 +135,9 @@ pub fn xor<'py>(
         if let Ok(b_bool) = b.clone().into_any().cast::<Bool>() {
             return Bool::new(
                 py,
-                &GLOBAL_CONTEXT.xor2(&a_bool.get().inner, &b_bool.get().inner)?,
+                &GLOBAL_CONTEXT
+                    .xor2(&a_bool.get().inner, &b_bool.get().inner)?
+                    .simplify()?,
             )
             .map(|b| b.into_any().cast::<Base>().unwrap().clone());
         } else {
@@ -134,7 +148,9 @@ pub fn xor<'py>(
             let (a_bv, b_bv) = CoerceBV::unpack_pair(py, &a_bv, &b_bv)?;
             return BV::new(
                 py,
-                &GLOBAL_CONTEXT.xor2(&a_bv.get().inner, &b_bv.get().inner)?,
+                &GLOBAL_CONTEXT
+                    .xor2(&a_bv.get().inner, &b_bv.get().inner)?
+                    .simplify_ext(true, true)?,
             )
             .map(|b| b.into_any().cast::<Base>().unwrap().clone());
         } else {
@@ -157,11 +173,13 @@ pub fn r#if<'py>(
             let (then_bv, else_bv) = CoerceBV::unpack_pair(py, &then_bv, &else_bv)?;
             BV::new(
                 py,
-                &GLOBAL_CONTEXT.ite(
-                    &cond.0.get().inner,
-                    &then_bv.get().inner,
-                    &else_bv.get().inner,
-                )?,
+                &GLOBAL_CONTEXT
+                    .ite(
+                        &cond.0.get().inner,
+                        &then_bv.get().inner,
+                        &else_bv.get().inner,
+                    )?
+                    .simplify_ext(true, true)?,
             )
             .map(|b| b.into_any().cast::<Base>().unwrap().clone())
         } else {
@@ -175,7 +193,9 @@ pub fn r#if<'py>(
             let else_bv = else_bv.0.get().inner.clone();
             Bool::new(
                 py,
-                &GLOBAL_CONTEXT.ite(&cond.0.get().inner, &then_bv, &else_bv)?,
+                &GLOBAL_CONTEXT
+                    .ite(&cond.0.get().inner, &then_bv, &else_bv)?
+                    .simplify()?,
             )
             .map(|b| b.into_any().cast::<Base>().unwrap().clone())
         } else {
@@ -188,11 +208,13 @@ pub fn r#if<'py>(
             let (then_fp, else_fp) = CoerceFP::unpack_pair(py, &then_fp, &else_fp)?;
             FP::new(
                 py,
-                &GLOBAL_CONTEXT.ite(
-                    &cond.0.get().inner,
-                    &then_fp.get().inner,
-                    &else_fp.get().inner,
-                )?,
+                &GLOBAL_CONTEXT
+                    .ite(
+                        &cond.0.get().inner,
+                        &then_fp.get().inner,
+                        &else_fp.get().inner,
+                    )?
+                    .simplify()?,
             )
             .map(|b| b.into_any().cast::<Base>().unwrap().clone())
         } else {
@@ -206,7 +228,9 @@ pub fn r#if<'py>(
             let else_bv = else_string.0.get().inner.clone();
             PyAstString::new(
                 py,
-                &GLOBAL_CONTEXT.ite(&cond.0.get().inner, &then_bv, &else_bv)?,
+                &GLOBAL_CONTEXT
+                    .ite(&cond.0.get().inner, &then_bv, &else_bv)?
+                    .simplify()?,
             )
             .map(|b| b.into_any().cast::<Base>().unwrap().clone())
         } else {

--- a/crates/clarirs_py/src/ast/string.rs
+++ b/crates/clarirs_py/src/ast/string.rs
@@ -27,12 +27,13 @@ impl PyAstString {
         Self::new_with_name(py, inner, None)
     }
 
+    /// Wrap an AST without simplifying it, keeping its annotation set exactly as
+    /// given.
     pub fn new_with_name<'py>(
         py: Python<'py>,
         inner: &AstRef<'static>,
         name: Option<String>,
     ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
-        let inner = &inner.simplify()?;
         if let Some(cache_hit) = PY_STRING_CACHE.get(&inner.hash()).and_then(|cache_hit| {
             cache_hit
                 .bind(py)
@@ -103,6 +104,8 @@ impl PyAstString {
             inner
         };
 
+        // `__new__` reconstructs a node from (op, args, annotations) verbatim,
+        // without simplifying (e.g. when unpickling).
         Ok(PyAstString::new(py, &inner_with_annotations)?.unbind())
     }
 
@@ -121,7 +124,9 @@ impl PyAstString {
     ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
         PyAstString::new(
             py,
-            &GLOBAL_CONTEXT.str_concat(&self.inner, &other.get().inner)?,
+            &GLOBAL_CONTEXT
+                .str_concat(&self.inner, &other.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -130,7 +135,12 @@ impl PyAstString {
         py: Python<'py>,
         other: Bound<'py, PyAstString>,
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
-        Bool::new(py, &GLOBAL_CONTEXT.str_eq(&self.inner, &other.get().inner)?)
+        Bool::new(
+            py,
+            &GLOBAL_CONTEXT
+                .str_eq(&self.inner, &other.get().inner)?
+                .simplify()?,
+        )
     }
 
     pub fn __ne__<'py>(
@@ -140,7 +150,9 @@ impl PyAstString {
     ) -> Result<Bound<'py, Bool>, ClaripyError> {
         Bool::new(
             py,
-            &GLOBAL_CONTEXT.str_neq(&self.inner, &other.get().inner)?,
+            &GLOBAL_CONTEXT
+                .str_neq(&self.inner, &other.get().inner)?
+                .simplify()?,
         )
     }
 
@@ -203,7 +215,12 @@ pub fn StrLen<'py>(
     py: Python<'py>,
     s: Bound<'py, PyAstString>,
 ) -> Result<Bound<'py, BV>, ClaripyError> {
-    BV::new(py, &GLOBAL_CONTEXT.str_len(&s.get().inner)?)
+    BV::new(
+        py,
+        &GLOBAL_CONTEXT
+            .str_len(&s.get().inner)?
+            .simplify_ext(true, true)?,
+    )
 }
 
 #[pyfunction]
@@ -214,7 +231,9 @@ pub fn StrConcat<'py>(
 ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
     PyAstString::new(
         py,
-        &GLOBAL_CONTEXT.str_concat(&s1.get().inner, &s2.get().inner)?,
+        &GLOBAL_CONTEXT
+            .str_concat(&s1.get().inner, &s2.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -227,11 +246,13 @@ pub fn StrSubstr<'py>(
 ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
     PyAstString::new(
         py,
-        &GLOBAL_CONTEXT.str_substr(
-            &base.get().inner,
-            &start.unpack(py, 64, false)?.get().inner,
-            &size.unpack(py, 64, false)?.get().inner,
-        )?,
+        &GLOBAL_CONTEXT
+            .str_substr(
+                &base.get().inner,
+                &start.unpack(py, 64, false)?.get().inner,
+                &size.unpack(py, 64, false)?.get().inner,
+            )?
+            .simplify()?,
     )
 }
 
@@ -243,7 +264,9 @@ pub fn StrContains<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.str_contains(&haystack.get().inner, &needle.get().inner)?,
+        &GLOBAL_CONTEXT
+            .str_contains(&haystack.get().inner, &needle.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -256,11 +279,13 @@ pub fn StrIndexOf<'py>(
 ) -> Result<Bound<'py, BV>, ClaripyError> {
     BV::new(
         py,
-        &GLOBAL_CONTEXT.str_index_of(
-            &haystack.get().inner,
-            &needle.get().inner,
-            &start.unpack(py, 64, false)?.get().inner,
-        )?,
+        &GLOBAL_CONTEXT
+            .str_index_of(
+                &haystack.get().inner,
+                &needle.get().inner,
+                &start.unpack(py, 64, false)?.get().inner,
+            )?
+            .simplify_ext(true, true)?,
     )
 }
 
@@ -273,11 +298,13 @@ pub fn StrReplace<'py>(
 ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
     PyAstString::new(
         py,
-        &GLOBAL_CONTEXT.str_replace(
-            &haystack.get().inner,
-            &needle.get().inner,
-            &replacement.get().inner,
-        )?,
+        &GLOBAL_CONTEXT
+            .str_replace(
+                &haystack.get().inner,
+                &needle.get().inner,
+                &replacement.get().inner,
+            )?
+            .simplify()?,
     )
 }
 
@@ -289,7 +316,9 @@ pub fn StrPrefixOf<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.str_prefix_of(&needle.get().inner, &haystack.get().inner)?,
+        &GLOBAL_CONTEXT
+            .str_prefix_of(&needle.get().inner, &haystack.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -301,7 +330,9 @@ pub fn StrSuffixOf<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.str_suffix_of(&needle.get().inner, &haystack.get().inner)?,
+        &GLOBAL_CONTEXT
+            .str_suffix_of(&needle.get().inner, &haystack.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -310,7 +341,12 @@ pub fn StrToInt<'py>(
     py: Python<'py>,
     s: Bound<'py, PyAstString>,
 ) -> Result<Bound<'py, BV>, ClaripyError> {
-    BV::new(py, &GLOBAL_CONTEXT.str_to_bv(&s.get().inner)?)
+    BV::new(
+        py,
+        &GLOBAL_CONTEXT
+            .str_to_bv(&s.get().inner)?
+            .simplify_ext(true, true)?,
+    )
 }
 
 #[pyfunction]
@@ -318,7 +354,7 @@ pub fn IntToStr<'py>(
     py: Python<'py>,
     bv: Bound<'py, BV>,
 ) -> Result<Bound<'py, PyAstString>, ClaripyError> {
-    PyAstString::new(py, &GLOBAL_CONTEXT.bv_to_str(&bv.get().inner)?)
+    PyAstString::new(py, &GLOBAL_CONTEXT.bv_to_str(&bv.get().inner)?.simplify()?)
 }
 
 #[pyfunction]
@@ -326,7 +362,10 @@ pub fn StrIsDigit<'py>(
     py: Python<'py>,
     s: Bound<'py, PyAstString>,
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
-    Bool::new(py, &GLOBAL_CONTEXT.str_is_digit(&s.get().inner)?)
+    Bool::new(
+        py,
+        &GLOBAL_CONTEXT.str_is_digit(&s.get().inner)?.simplify()?,
+    )
 }
 
 #[pyfunction]
@@ -337,7 +376,9 @@ pub fn StrEq<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.str_eq(&s1.get().inner, &s2.get().inner)?,
+        &GLOBAL_CONTEXT
+            .str_eq(&s1.get().inner, &s2.get().inner)?
+            .simplify()?,
     )
 }
 
@@ -349,7 +390,9 @@ pub fn StrNeq<'py>(
 ) -> Result<Bound<'py, Bool>, ClaripyError> {
     Bool::new(
         py,
-        &GLOBAL_CONTEXT.str_neq(&s1.get().inner, &s2.get().inner)?,
+        &GLOBAL_CONTEXT
+            .str_neq(&s1.get().inner, &s2.get().inner)?
+            .simplify()?,
     )
 }
 

--- a/crates/clarirs_py/src/lib.rs
+++ b/crates/clarirs_py/src/lib.rs
@@ -94,7 +94,9 @@ fn py_replace<'py>(
 
     Base::from_ast(
         expr.py(),
-        Base::to_ast(expr)?.replace(&old_dyn, &new_coerced)?,
+        Base::to_ast(expr)?
+            .replace(&old_dyn, &new_coerced)?
+            .simplify()?,
     )
 }
 
@@ -103,7 +105,7 @@ fn py_excavate_ite<'py>(
     py: Python<'py>,
     expr: Bound<'py, Base>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
-    Base::from_ast(py, Base::to_ast(expr)?.excavate_ite()?)
+    Base::from_ast(py, Base::to_ast(expr)?.excavate_ite()?.simplify()?)
 }
 
 #[pyfunction]

--- a/crates/clarirs_py/src/vsa.rs
+++ b/crates/clarirs_py/src/vsa.rs
@@ -44,11 +44,18 @@ pub fn reduce<'py>(
                 upper_bound,
             } => {
                 if lower_bound == upper_bound {
-                    BV::new(py, &GLOBAL_CONTEXT.bvv(BitVec::from((lower_bound, bits)))?)?
+                    BV::new(
+                        py,
+                        &GLOBAL_CONTEXT
+                            .bvv(BitVec::from((lower_bound, bits)))?
+                            .simplify_ext(true, true)?,
+                    )?
                 } else {
                     BV::new(
                         py,
-                        &GLOBAL_CONTEXT.si(bits, stride, lower_bound, upper_bound)?,
+                        &GLOBAL_CONTEXT
+                            .si(bits, stride, lower_bound, upper_bound)?
+                            .simplify_ext(true, true)?,
                     )?
                 }
             }

--- a/crates/clarirs_py/tests/test_verbatim_annotations.py
+++ b/crates/clarirs_py/tests/test_verbatim_annotations.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import unittest
+
+import claripy
+
+
+class RelocAnnotation(claripy.Annotation):
+    """A relocatable annotation: it propagates from a child to the nodes built
+    on top of it."""
+
+    relocatable = True
+    eliminatable = False
+
+    def __init__(self, tag):
+        self.tag = tag
+
+    def __hash__(self):
+        return hash(("RelocAnnotation", self.tag))
+
+    def __eq__(self, other):
+        return isinstance(other, RelocAnnotation) and other.tag == self.tag
+
+
+class OtherAnnotation(claripy.Annotation):
+    def __init__(self, tag):
+        self.tag = tag
+
+    def __hash__(self):
+        return hash(("OtherAnnotation", self.tag))
+
+    def __eq__(self, other):
+        return isinstance(other, OtherAnnotation) and other.tag == self.tag
+
+
+class TestVerbatimAnnotations(unittest.TestCase):
+    """The annotation-management methods set a node's annotation tuple
+    verbatim (matching claripy), so an explicit replace/remove/clear can drop
+    an annotation that a child also carries. Building new nodes still
+    propagates children's relocatable annotations."""
+
+    def setUp(self):
+        # A child carrying a relocatable annotation, and a parent that inherits
+        # it through ordinary construction.
+        self.child = claripy.BVS("x", 32, explicit_name=True).annotate(RelocAnnotation("a"))
+        self.parent = self.child + 1
+
+    def test_operations_propagate_child_relocatable_annotations(self):
+        # The propagating wrapper is preserved: a freshly built node still picks
+        # up its children's relocatable annotations.
+        self.assertTrue(any(isinstance(a, RelocAnnotation) for a in self.parent.annotations))
+        self.assertTrue(any(isinstance(a, RelocAnnotation) for a in (self.child * 2).annotations))
+
+    def test_clear_annotations_is_verbatim(self):
+        # Clearing empties the set even though the child still carries the
+        # relocatable annotation (it is not re-collected).
+        cleared = self.parent.clear_annotations()
+        self.assertEqual(cleared.annotations, [])
+
+    def test_remove_annotation_drops_inherited_annotation(self):
+        inherited = next(a for a in self.parent.annotations if isinstance(a, RelocAnnotation))
+        removed = self.parent.remove_annotation(inherited)
+        self.assertFalse(any(isinstance(a, RelocAnnotation) for a in removed.annotations))
+
+    def test_replace_annotations_is_verbatim(self):
+        # The result carries exactly the given annotations, not the union with
+        # the child's relocatable annotation.
+        replaced = self.parent.replace_annotations((OtherAnnotation("z"),))
+        self.assertEqual(
+            sorted(type(a).__name__ for a in replaced.annotations),
+            ["OtherAnnotation"],
+        )
+
+
+class TestVerbatimConstruction(unittest.TestCase):
+    """Simplification is the job of the paths that *create* ASTs (operators and
+    factory functions). The paths that merely wrap an existing op keep it
+    verbatim: the `__new__` constructor (used e.g. when unpickling) faithfully
+    reconstructs a node without re-simplifying."""
+
+    def test_operators_simplify(self):
+        x = claripy.BVS("x", 64, explicit_name=True)
+        self.assertEqual((x + claripy.BVV(0, 64)).op, "BVS")
+
+    def test_factory_functions_simplify(self):
+        x = claripy.BVS("x", 64, explicit_name=True)
+        self.assertEqual(claripy.ast.bv.Add(x, claripy.BVV(0, 64)).op, "BVS")
+
+    def test_new_constructor_is_verbatim(self):
+        x = claripy.BVS("x", 64, explicit_name=True)
+        raw = claripy.ast.bv.BV("__add__", [x, claripy.BVV(0, 64)])
+        self.assertEqual(raw.op, "__add__")
+
+    def test_pickle_round_trip_preserves_op(self):
+        import pickle
+
+        x = claripy.BVS("x", 64, explicit_name=True)
+        expr = x + claripy.BVV(5, 64)
+        self.assertEqual(pickle.loads(pickle.dumps(expr)).op, expr.op)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Split `make_ast_annotated` into `make_ast_exact` (a node gets exactly the given annotations) and a wrapper that also collects children's relocatable annotations. The annotation-management methods (`annotate`, `replace_annotations`, `remove_annotation(s)`, `clear_annotations`, `clear_annotation_type`) use the exact variant: claripy sets a node's annotation tuple verbatim, so an explicit replace/remove/clear must be able to drop an annotation that a child also carries.

The same verbatim principle now governs construction. Simplification is the job of the paths that *create* ASTs — operators and factory functions go through `new` (which simplifies), and `replace`/`excavate_ite` simplify their results. The paths that merely *wrap* an existing op keep it verbatim: `from_ast` is now a single non-simplifying wrap (the separate `from_ast_unsimplified` is removed), and the `__new__` constructor wraps the op as given so it faithfully reconstructs a node (e.g. when unpickling) without re-simplifying or re-collecting child annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)