### PR TITLE
solver: add Solver.split()

### DIFF
--- a/crates/clarirs_py/src/solver.rs
+++ b/crates/clarirs_py/src/solver.rs
@@ -163,6 +163,51 @@ impl PySolver {
             .collect())
     }
 
+    /// Split into one solver per independent (variable-connected) constraint
+    /// group, like claripy's `constrained_frontend.split()`. Each returned
+    /// solver is a blank copy of this one holding one group's constraints.
+    fn split<'py>(&mut self, py: Python<'py>) -> Result<Vec<Bound<'py, PySolver>>, ClaripyError> {
+        let constraints = self.inner.constraints()?;
+
+        // Group constraints by shared variables (transitively).
+        let mut groups: Vec<(BTreeSet<InternedString>, Vec<AstRef<'static>>)> = Vec::new();
+        for constraint in constraints {
+            let vars = constraint.variables().clone();
+            let (mut merged_vars, mut merged_constraints) = (vars, vec![constraint]);
+            let mut remaining = Vec::with_capacity(groups.len());
+            for (group_vars, group_constraints) in groups {
+                if group_vars.intersection(&merged_vars).next().is_some() {
+                    merged_vars.extend(group_vars);
+                    merged_constraints.extend(group_constraints);
+                } else {
+                    remaining.push((group_vars, group_constraints));
+                }
+            }
+            remaining.push((merged_vars, merged_constraints));
+            groups = remaining;
+        }
+
+        groups
+            .into_iter()
+            .map(|(_, group_constraints)| {
+                let mut solver = self.inner.clone();
+                solver.clear()?;
+                for constraint in &group_constraints {
+                    solver.add(constraint)?;
+                }
+                Bound::new(
+                    py,
+                    PySolver {
+                        inner: solver,
+                        timeout: self.timeout,
+                        unsat_core: self.unsat_core,
+                    },
+                )
+                .map_err(ClaripyError::from)
+            })
+            .collect()
+    }
+
     fn branch<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PySolver>, ClaripyError> {
         match &self.inner {
             DynSolver::Concrete(concrete_solver) => Ok(Bound::new(

--- a/crates/clarirs_py/tests/test_solver_split.py
+++ b/crates/clarirs_py/tests/test_solver_split.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import unittest
+
+import claripy
+
+
+class TestSolverSplit(unittest.TestCase):
+    """Solver.split() partitions constraints into independent (variable-connected)
+    groups, returning one blank-copy solver per group (like claripy's
+    constrained_frontend.split())."""
+
+    def test_independent_groups(self):
+        x = claripy.BVS("x", 32, explicit_name=True)
+        y = claripy.BVS("y", 32, explicit_name=True)
+        z = claripy.BVS("z", 32, explicit_name=True)
+        s = claripy.Solver()
+        s.add(x > 1)
+        s.add(x < 10)
+        s.add(y == z)
+        groups = s.split()
+        self.assertEqual(len(groups), 2)
+        var_sets = sorted(sorted(g.variables) for g in groups)
+        self.assertEqual(var_sets, [["x"], ["y", "z"]])
+
+    def test_transitively_connected_constraints_stay_together(self):
+        a = claripy.BVS("a", 32, explicit_name=True)
+        b = claripy.BVS("b", 32, explicit_name=True)
+        c = claripy.BVS("c", 32, explicit_name=True)
+        s = claripy.Solver()
+        s.add(a == b)
+        s.add(b == c)
+        groups = s.split()
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(sorted(groups[0].variables), ["a", "b", "c"])
+
+    def test_group_solvers_carry_their_constraints(self):
+        x = claripy.BVS("x", 32, explicit_name=True)
+        y = claripy.BVS("y", 32, explicit_name=True)
+        s = claripy.Solver()
+        s.add(x == 7)
+        s.add(y == 9)
+        groups = {tuple(sorted(g.variables)): g for g in s.split()}
+        self.assertEqual(tuple(groups[("x",)].eval(x, 1)), (7,))
+        self.assertEqual(tuple(groups[("y",)].eval(y, 1)), (9,))
+
+    def test_empty_and_single_group(self):
+        x = claripy.BVS("x", 32, explicit_name=True)
+        self.assertEqual(claripy.Solver().split(), [])
+        s = claripy.Solver()
+        s.add(x > 0)
+        s.add(x < 5)
+        self.assertEqual(len(s.split()), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `Solver.split()`, which partitions the constraint set into independent (variable-connected) groups and returns one solver per group — each a blank copy of the original holding that group's constraints.

This mirrors claripy's `constrained_frontend.split()`. Constraints are grouped transitively by shared variables, so constraints that share no variables (directly or indirectly) end up in separate groups.

## Why

angr's preconstrainer (`reconstrain`) calls `solver.split()` to process independent constraint groups separately.

## Tests

New `test_solver_split.py`: independent groups split apart; transitively-connected constraints stay together; each group solver carries its own constraints (and solves them); and the empty / single-group cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)