### PR TITLE
solver: composite solver unsat_core

### DIFF
--- a/crates/clarirs_core/src/solver/composite.rs
+++ b/crates/clarirs_core/src/solver/composite.rs
@@ -42,6 +42,11 @@ impl<'c, S: Solver<'c>> CompositeSolver<'c, S> {
         }
     }
 
+    /// Iterate over the child solvers (one per independent constraint set).
+    pub fn children_mut(&mut self) -> impl Iterator<Item = &mut S> {
+        self.children.values_mut()
+    }
+
     /// Return the child IDs that own any of the given variables (deduplicated).
     fn child_ids_for_vars(&self, vars: &BTreeSet<InternedString>) -> Vec<usize> {
         let set: HashSet<usize> = vars

--- a/crates/clarirs_py/src/dynsolver.rs
+++ b/crates/clarirs_py/src/dynsolver.rs
@@ -72,6 +72,18 @@ impl DynSolver {
                 let z3_solver = hybrid.exact_mut().inner_mut().inner_mut().inner_mut();
                 z3_solver.unsat_core()
             }
+            DynSolver::Composite(composite) => {
+                // The composite's core is the core of whichever independent
+                // child is unsat (claripy's CompositeFrontend does the same).
+                for child in composite.children_mut() {
+                    if !child.satisfiable()? {
+                        // SimplificationMixin -> ConcreteEarlyResolutionMixin -> ModelCacheMixin -> Z3Solver
+                        let z3_solver = child.inner_mut().inner_mut().inner_mut();
+                        return z3_solver.unsat_core();
+                    }
+                }
+                Ok(vec![])
+            }
             _ => Err(ClarirsError::UnsupportedOperation(
                 "unsat_core is only supported for Z3 and Hybrid solvers".to_string(),
             )),

--- a/crates/clarirs_py/tests/test_unsat_core.py
+++ b/crates/clarirs_py/tests/test_unsat_core.py
@@ -103,10 +103,46 @@ def test_unsat_core_complex():
     assert 2 in core
 
 
+def test_unsat_core_composite():
+    """SolverComposite returns the core of whichever independent child is unsat."""
+    s = claripy.SolverComposite(track=True)
+
+    x = claripy.BVS("x", 8)
+    y = claripy.BVS("y", 8)
+
+    # Contradictory group on x (constraints 0, 1) plus an independent,
+    # satisfiable group on y (constraint 2).
+    s.add(x > 10)
+    s.add(x < 5)
+    s.add(y == 3)
+
+    assert not s.satisfiable()
+
+    core = s.unsat_core()
+    assert len(core) > 0
+    assert 0 in core
+    assert 1 in core
+    # The independent, satisfiable constraint is not part of the core.
+    assert 2 not in core
+
+
+def test_unsat_core_composite_on_sat():
+    """A satisfiable composite solver has an empty unsat core."""
+    s = claripy.SolverComposite(track=True)
+    x = claripy.BVS("x", 8)
+    y = claripy.BVS("y", 8)
+    s.add(x > 1)
+    s.add(y < 10)
+    assert s.satisfiable()
+    assert s.unsat_core() == []
+
+
 if __name__ == "__main__":
     test_unsat_core_simple()
     test_unsat_core_bool()
     test_unsat_core_not_enabled()
     test_unsat_core_on_sat()
     test_unsat_core_complex()
+    test_unsat_core_composite()
+    test_unsat_core_composite_on_sat()
     print("All tests passed!")


### PR DESCRIPTION
## Summary

`SolverComposite` (the composite frontend) did not support `unsat_core`. This returns the unsat core of whichever independent child constraint group is unsatisfiable, matching claripy's `CompositeFrontend`.

- Adds a `children_mut()` accessor on the core `CompositeSolver` to iterate the per-group child solvers.
- The Python binding's `unsat_core` now handles the `Composite` case: it finds the unsatisfiable child and returns its core (reaching the Z3 backend through the `ModelCacheMixin` stack).

## Tests

Adds composite cases to `test_unsat_core.py`: the core comes from the unsat group (an independent satisfiable constraint is excluded), and a satisfiable composite solver returns an empty core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)