### PR TITLE
Remove unused `paste` dependency from clarirs_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,6 @@ dependencies = [
  "clarirs_num",
  "num-bigint",
  "num-traits",
- "paste",
  "serde",
  "smallvec",
  "thiserror",
@@ -353,12 +352,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "portable-atomic"

--- a/crates/clarirs_core/Cargo.toml
+++ b/crates/clarirs_core/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = { workspace = true }
 clarirs_num = { path = "../clarirs_num" }
 num-bigint = { version = "0.4.6", features = ["serde"] }
 num-traits = "0.2"
-paste = "1.0.15"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 smallvec = { version = "1.15.1", features = ["serde"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Summary
Removed the unused `paste` crate dependency from the `clarirs_core` package.

## Changes
- Removed `paste = "1.0.15"` from `clarirs_core/Cargo.toml` dependencies

## Details
The `paste` crate was not being utilized in the codebase and has been removed to reduce unnecessary dependencies and improve build times.

https://claude.ai/code/session_011SMsdRDaPcaL1YLak31BvL