### PR TITLE
Bump minimum Python version requirement to 3.12

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -149,5 +149,5 @@ Requires: CMake, Ninja, Clang (for faster builds). On CI, sccache caches compila
 
 - **Rust Edition**: 2024 (stable)
 - **Toolchain**: Rust 1.88 (see `rust-toolchain.toml`)
-- **Python**: 3.10+ (PyO3 0.27+)
+- **Python**: 3.12+ (PyO3 0.27+)
 - **Package Manager**: uv for Python dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
         include:
           - os: ubuntu-latest
             python-version: "3.14"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo build
 cargo test
 ```
 
-To build and test the python bindings, Python 3.10 or later is required. A venv
+To build and test the python bindings, Python 3.12 or later is required. A venv
 is reccomended. To build and install the python bindings, install with pip:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "clarirs"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dynamic = ["version"]
 
 [tool.maturin]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 [[package]]
 name = "clarirs"


### PR DESCRIPTION
## Summary
This PR updates the minimum supported Python version from 3.10 to 3.12 across the project configuration and documentation.

## Key Changes
- Updated `pyproject.toml` to require Python 3.12+ (`requires-python = ">=3.12"`)
- Updated CI workflow to test against Python 3.12 as the default version
- Updated documentation in `README.md` to reflect the new minimum Python version requirement
- Updated Copilot instructions to document the new Python version requirement

## Details
This change standardizes the project on Python 3.12 as the minimum supported version, ensuring compatibility with PyO3 0.27+ and allowing the use of newer Python language features. The CI matrix has been updated to test against Python 3.12 by default, with Python 3.14 included in the test matrix for forward compatibility.

https://claude.ai/code/session_01U3JzqYCbrg2YBbXSUCyuEN