### PR TITLE
fix: simplify chop/Concat/coercion results bound before wrapping (regression from #606)

### DIFF
--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -1058,7 +1058,7 @@ impl BV {
     ) -> Result<Vec<Bound<'py, BV>>, ClaripyError> {
         self_.get().inner.chop(bits).map(|r| {
             r.into_iter()
-                .map(|r| BV::new(py, &r))
+                .map(|r| BV::new(py, &r.simplify_ext(true, true)?))
                 .collect::<Result<Vec<_>, _>>()
         })?
     }
@@ -1271,7 +1271,7 @@ pub fn Concat<'py>(
     }
     let inner_args: Vec<_> = unpacked.iter().map(|b| b.get().inner.clone()).collect();
     let result = GLOBAL_CONTEXT.concat(inner_args)?;
-    BV::new(py, &result)
+    BV::new(py, &result.simplify_ext(true, true)?)
 }
 
 #[pyfunction]

--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -92,7 +92,7 @@ impl<'py> CoerceBV<'py> {
                 let one = GLOBAL_CONTEXT.bvv(BitVec::from((1, size)))?;
                 let zero = GLOBAL_CONTEXT.bvv(BitVec::from((0, size)))?;
                 let bv_ast = GLOBAL_CONTEXT.ite(&bool_val.get().inner, &one, &zero)?;
-                BV::new(py, &bv_ast)
+                BV::new(py, &bv_ast.simplify_ext(true, true)?)
             }
         }
     }

--- a/crates/clarirs_py/tests/test_simplify_construction.py
+++ b/crates/clarirs_py/tests/test_simplify_construction.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+
+import claripy
+
+
+class TestSimplifyConstruction(unittest.TestCase):
+    """AST-building entry points that bind their operation result before
+    wrapping it (`chop`, `Concat`) simplify it, so a concrete result is folded
+    and interned rather than returned as a raw `Extract`/`Concat`."""
+
+    def test_concat_of_concrete_folds(self):
+        c = claripy.Concat(claripy.BVV(0, 32), claripy.BVV(0x1337, 32))
+        self.assertEqual(c.op, "BVV")
+        self.assertEqual(c.concrete_value, 0x1337)
+        # interned: equal to the directly-built constant
+        self.assertIs(c, claripy.BVV(0x1337, 64))
+
+    def test_chop_of_concrete_folds(self):
+        bytes_ = claripy.BVV(0x41424344, 32).chop(8)
+        self.assertEqual([b.op for b in bytes_], ["BVV"] * 4)
+        self.assertEqual([b.concrete_value for b in bytes_], [0x41, 0x42, 0x43, 0x44])
+
+    def test_chop_isolates_concrete_from_symbolic(self):
+        # The concrete high half must come back concrete even when concatenated
+        # with a symbolic low half (the chopped pieces are simplified).
+        v = claripy.Concat(claripy.BVV(0xAABBCCDD, 32), claripy.BVS("s", 32))
+        hi = v.chop(8)[0]
+        self.assertFalse(hi.symbolic)
+        self.assertEqual(hi.concrete_value, 0xAA)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#606 made the Python AST constructors raw and added simplification only at the operators and the *inline* `&GLOBAL_CONTEXT.op(...)` factory calls. Producers that **bind** the operation result before wrapping it — `BV::new(py, &result)` — were missed, so they returned unsimplified nodes:

- **`chop()`** returned `Extract` pieces — a concrete byte chopped out of a value reported `symbolic == True`.
- **`Concat`** returned a raw `Concat` of concrete inputs instead of a folded, interned constant.
- the **`CoerceBV` Bool→BV** `If(bool, 1, 0)` coercion (same pattern).

Each now simplifies its result.

This surfaced downstream (in angr): memory loads that join byte/page pieces with `Concat`, and `hex_dump`/`chop`-based reads, returned unsimplified values that failed `is`-identity and concreteness checks.

Added `crates/clarirs_py/tests/test_simplify_construction.py` covering the observable cases (`Concat` of concrete folds and interns; `chop` of concrete folds; `chop` isolates a concrete half from a symbolic one). The Bool→BV coercion is the same one-line pattern; its result is always consumed by a simplifying operator, so it has no independent test but is fixed for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)