### PR TITLE
test: un-mark VSA test_solving_with_constraints as expected failure

### DIFF
--- a/crates/clarirs_py/tests/test_vsa_simplify_solving.py
+++ b/crates/clarirs_py/tests/test_vsa_simplify_solving.py
@@ -243,7 +243,6 @@ class TestVSASimplificationAndSolving(unittest.TestCase):
         self.assertTrue(self.solver.solution(expr, 10))
         self.assertFalse(self.solver.solution(expr, 5))
 
-    @unittest.expectedFailure
     def test_solving_with_constraints(self):
         """Test solving with added constraints."""
         # Note: VSA solver might not handle constraints in the same way as the Z3 solver


### PR DESCRIPTION
## Summary

Removes the `@unittest.expectedFailure` annotation from
`test_vsa_simplify_solving.py::TestVSASimplificationAndSolving::test_solving_with_constraints`.

The test now passes, so the annotation caused unittest/pytest to report an
**"Unexpected success"**, which fails the suite.

## Why the test passes

The VSA backend's solver (`crates/clarirs-vsa/src/solver.rs`):
- `add()` is a no-op
- `satisfiable()` returns `true` unconditionally

The test's only hard assertion is `assertTrue(s.satisfiable())` (after
`s.add(BVV(10,32) > 5)`), which gets `True` and passes. The second block,
which checks an unsatisfiable case, is wrapped in `try/except AssertionError:
pass`, so it never fails the test regardless of VSA behavior. With the test
body succeeding, `@unittest.expectedFailure` turns it into an unexpected
success.

## Verification

Built the `claripy` extension with `maturin develop` and ran the file:

- **Before** (annotation present): `test_solving_with_constraints` → `FAILED` ("Unexpected success")
- **After** (annotation removed): all 12 tests in the file pass, including `test_solving_with_constraints`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWkmmZyKK4sH2oFZ4SiVW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWkmmZyKK4sH2oFZ4SiVW6)_