### PR TITLE
Fix incorrect expectations in test_fp_ops::test_div

### DIFF
--- a/crates/clarirs_py/tests/test_fp_ops.py
+++ b/crates/clarirs_py/tests/test_fp_ops.py
@@ -142,7 +142,7 @@ class TestFPOperations(unittest.TestCase):
         self._check_equal(result, 0.6)
 
         result = self.fp2 / self.fp1
-        self._check_equal(result, 1.6666665077, check_bits=True)
+        self._check_equal(result, 1.6666666269302368, check_bits=True)
 
         result = self.fp3 / self.fp4
         self._check_equal(result, 2.0)
@@ -152,11 +152,11 @@ class TestFPOperations(unittest.TestCase):
 
         # Test infinity division -> NaN
         result = self.fp_inf / self.fp_inf
-        self._check_equal(result, float("nan"), check_bits=True)
+        self.assertTrue(claripy.fpIsNaN(result).is_true())
 
         # 0/0 → NaN
         result = self.fp_zero / self.fp_zero
-        self._check_equal(result, float("nan"), check_bits=True)
+        self.assertTrue(claripy.fpIsNaN(result).is_true())
 
         # zero numerator → zero
         result = self.fp_zero / self.fp1


### PR DESCRIPTION
## Summary

Fixes `crates/clarirs_py/tests/test_fp_ops.py::TestFPOperations::test_div`, which fails for two independent reasons — both incorrect expectations in the test, not bugs in clarirs.

Rebased onto current `main` (includes #617 and #619).

### 1. Off-by-one-ULP division constant

```python
result = self.fp2 / self.fp1            # 2.5 / 1.5, single precision
self._check_equal(result, 1.6666665077, check_bits=True)
```

| | value | bits |
|---|---|---|
| clarirs result | `1.6666666269302368` | `0x3fd55555` |
| old expected (`1.6666665077`) | `1.6666665077209473` | `0x3fd55554` |
| Python `float32(2.5 / 1.5)` | `1.6666666269302368` | `0x3fd55555` |

clarirs produces the correctly-rounded IEEE-754 result; the test literal was one ULP too low. Corrected to the exact float32 value.

### 2. NaN compared by raw bits

The `inf/inf` and `0/0` cases checked NaN via `_check_equal(..., float("nan"), check_bits=True)`, i.e. a raw bit-vector comparison. clarirs yields a NaN with the sign bit set (`0xffc00000`) while `FPV(nan)` is `0x7fc00000`, and IEEE-754 leaves a NaN's sign bit and payload unspecified. These now assert NaN-ness with `claripy.fpIsNaN(result).is_true()`, matching the idiom introduced for `test_sqrt` in #619.

## Testing

```
$ pytest crates/clarirs_py/tests/test_fp_ops.py
18 passed, 1 skipped
```

Test-only change, scoped entirely to `test_div`; no library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)