### PR TITLE
Fix overly strict NaN comparison in test_sqrt

### DIFF
--- a/crates/clarirs_py/tests/test_fp_ops.py
+++ b/crates/clarirs_py/tests/test_fp_ops.py
@@ -614,13 +614,15 @@ class TestFPOperations(unittest.TestCase):
         result = claripy.fpSqrt(self.fp_neg_zero)
         self._check_equal(result, -0.0, check_bits=True)
 
-        # Square root of negative float - NaN
+        # Square root of negative float - NaN. Any NaN bit pattern is valid
+        # here (e.g. sqrt sets the sign bit), so only assert NaN-ness rather
+        # than comparing against a specific NaN encoding.
         result = claripy.fpSqrt(self.fp_neg)
-        self._check_equal(result, float("nan"), check_bits=True)
+        self.assertTrue(claripy.fpIsNaN(result).is_true())
 
         # Square root of negative infinity - NaN
         result = claripy.fpSqrt(self.fp_neg_inf)
-        self._check_equal(result, float("nan"), check_bits=True)
+        self.assertTrue(claripy.fpIsNaN(result).is_true())
 
         # Positive infinity
         result = claripy.fpSqrt(self.fp_inf)


### PR DESCRIPTION
## Summary

`TestFPOperations::test_sqrt` checks the square root of a negative float and of negative infinity by comparing the **raw IEEE bit pattern** of the result against `claripy.FPV(float("nan"), FSORT_FLOAT)` (via `_check_equal(..., check_bits=True)`). This is too strict.

`fpSqrt` delegates to Rust's native `f32::sqrt()`, which for a negative operand returns a NaN with the **sign bit set** (`0xFFC00000`), whereas `claripy.FPV(float("nan"))` encodes the canonical quiet NaN (`0x7FC00000`):

```
sqrt(-1.5) raw bits:    0xFFC00000
sqrt(-inf) raw bits:    0xFFC00000
canonical NaN raw bits: 0x7FC00000
```

Both are perfectly valid NaN encodings — IEEE 754 does not pin down a single NaN bit pattern (the sign bit is irrelevant to NaN-ness, and payloads may differ) — so requiring exact bit equality is incorrect and the assertion fails.

## Fix

Assert that the square-root results are NaN via `claripy.fpIsNaN(result).is_true()` instead of comparing against one specific NaN encoding. This matches the approach already used elsewhere in the same file (`test_special_values`, `test_conversions`).

```python
# Square root of negative float - NaN
result = claripy.fpSqrt(self.fp_neg)
self.assertTrue(claripy.fpIsNaN(result).is_true())

# Square root of negative infinity - NaN
result = claripy.fpSqrt(self.fp_neg_inf)
self.assertTrue(claripy.fpIsNaN(result).is_true())
```

The non-NaN cases (finite values, ±0, +inf) keep their existing bit-level checks, since those have a single well-defined encoding.

## Testing

Built the Python bindings with `maturin develop` and ran the test:

```
crates/clarirs_py/tests/test_fp_ops.py::TestFPOperations::test_sqrt PASSED
```

Verified the change is meaningful: on the original code the bit-equality check returns `False` (test fails), and with the fix `fpIsNaN` returns `True`.

> Note: `test_div` (unrelated, a division rounding/bit-comparison case) was already failing before this change and is left untouched, as it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qEtnYLwkRFbBkBn5kjQDA

---
_Generated by [Claude Code](https://claude.ai/code/session_018qEtnYLwkRFbBkBn5kjQDA)_