### PR TITLE
Remove unnecessary clones in PyO3 bindings

### DIFF
--- a/crates/clarirs_py/src/ast/bool.rs
+++ b/crates/clarirs_py/src/ast/bool.rs
@@ -492,7 +492,7 @@ pub fn reverse_ite_cases<'py>(
                     queue.push((new_cond_true, true_branch));
 
                     // Queue: And(condition, Not(if_cond))
-                    let not_if_cond = not(py, if_cond.cast::<Base>()?.clone())?;
+                    let not_if_cond = not(py, if_cond.cast_into::<Base>()?)?;
                     let new_cond_false =
                         and(py, vec![condition.clone(), not_if_cond.into_any()])?.into_any();
                     queue.push((new_cond_false, false_branch));
@@ -531,7 +531,7 @@ pub fn ite_dict<'py>(
     if d.len() <= 4 {
         let mut cases = Vec::new();
         for (k, v) in d.iter() {
-            let cond = i.call_method1("__eq__", (k.clone(),))?;
+            let cond = i.call_method1("__eq__", (k,))?;
             let tuple = PyTuple::new(py, &[cond, v])?;
             cases.push(tuple.into_any());
         }
@@ -580,13 +580,11 @@ pub fn ite_dict<'py>(
     // Combine with an if-then-else
     let cond = i
         .call_method1("__le__", (split_val,))?
-        .cast::<Bool>()?
-        .clone();
+        .cast_into::<Bool>()?;
 
     // Create If expression: If(cond, val_low, val_high)
-    let result = r#if(py, CoerceBool(cond), val_low.clone(), val_high.clone())?;
-    let coerced = result.clone().into_any();
-    Ok(coerced)
+    let result = r#if(py, CoerceBool(cond), val_low, val_high)?;
+    Ok(result.into_any())
 }
 
 pub(crate) fn import(_: Python, m: &Bound<PyModule>) -> PyResult<()> {

--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -1155,12 +1155,12 @@ pub fn BVS(
     explicit_name: bool,
 ) -> Result<Bound<'_, BV>, ClaripyError> {
     let name: String = if explicit_name {
-        name.to_string()
+        name
     } else {
         let counter = BVS_COUNTER.fetch_add(1, Ordering::Relaxed);
         format!("{name}_{counter}_{size}")
     };
-    BV::new_with_name(py, &GLOBAL_CONTEXT.bvs(&name, size)?, Some(name.clone()))
+    BV::new_with_name(py, &GLOBAL_CONTEXT.bvs(&name, size)?, Some(name))
 }
 
 #[allow(non_snake_case)]

--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -369,20 +369,20 @@ impl<'a, 'py> FromPyObject<'a, 'py> for CoerceBase<'py> {
         // would incorrectly turn a BV expression into a Bool expression in contexts
         // like solver.solution(bv_expr, value) that need to preserve the original type.
         if let Ok(bool_val) = val.cast::<Bool>() {
-            Ok(CoerceBase(bool_val.to_owned().cast()?.clone()))
+            Ok(CoerceBase(bool_val.to_owned().cast_into()?))
         } else if let Ok(bv_val) = val.cast::<BV>() {
-            Ok(CoerceBase(bv_val.to_owned().cast()?.clone()))
+            Ok(CoerceBase(bv_val.to_owned().cast_into()?))
         } else if let Ok(fp_val) = val.cast::<FP>() {
-            Ok(CoerceBase(fp_val.to_owned().cast()?.clone()))
+            Ok(CoerceBase(fp_val.to_owned().cast_into()?))
         } else if let Ok(string_val) = val.cast::<PyAstString>() {
-            Ok(CoerceBase(string_val.to_owned().cast()?.clone()))
+            Ok(CoerceBase(string_val.to_owned().cast_into()?))
         } else if let Ok(py_bool) = val.extract::<bool>() {
             // Handle Python bool literals by wrapping in BoolV
             let bool_ast = Bool::new(
                 val.py(),
                 &GLOBAL_CONTEXT.boolv(py_bool).map_err(ClaripyError::from)?,
             )?;
-            Ok(CoerceBase(bool_ast.cast()?.clone()))
+            Ok(CoerceBase(bool_ast.cast_into()?))
         } else if let Ok(int_val) = val.cast::<PyInt>() {
             // Handle Python int literals by wrapping in BVV (64-bit default)
             let int: BigInt = int_val.extract()?;
@@ -391,16 +391,16 @@ impl<'a, 'py> FromPyObject<'a, 'py> for CoerceBase<'py> {
                 val.py(),
                 &GLOBAL_CONTEXT.bvv(bv).map_err(ClaripyError::from)?,
             )?;
-            Ok(CoerceBase(bv_ast.cast()?.clone()))
+            Ok(CoerceBase(bv_ast.cast_into()?))
         } else if let Ok(fp) = CoerceFP::extract(val) {
             match fp {
-                CoerceFP::FP(fp) => Ok(CoerceBase(fp.cast()?.clone())),
+                CoerceFP::FP(fp) => Ok(CoerceBase(fp.cast_into()?)),
                 CoerceFP::Py(_) => {
                     Err(ClaripyError::InvalidArgumentType("Expected FP".to_string()).into())
                 }
             }
         } else if let Ok(string) = CoerceString::extract(val) {
-            Ok(CoerceBase(string.0.cast()?.clone()))
+            Ok(CoerceBase(string.0.cast_into()?))
         } else {
             Err(
                 ClaripyError::InvalidArgumentType("Expected Bool, BV, FP, or String".to_string())

--- a/crates/clarirs_py/src/ast/mod.rs
+++ b/crates/clarirs_py/src/ast/mod.rs
@@ -18,17 +18,17 @@ pub static GLOBAL_CONTEXT: LazyLock<Context<'static>> = LazyLock::new(Context::n
 
 #[pyfunction(name = "Not")]
 pub fn not<'py>(py: Python<'py>, b: Bound<'py, Base>) -> Result<Bound<'py, Base>, ClaripyError> {
-    if let Ok(b_bool) = b.clone().into_any().cast::<Bool>() {
+    if let Ok(b_bool) = b.cast::<Bool>() {
         return Bool::new(py, &GLOBAL_CONTEXT.not(&b_bool.get().inner)?.simplify()?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
-    } else if let Ok(b_bv) = b.clone().into_any().cast::<BV>() {
+            .map(|b| b.into_any().cast_into::<Base>().unwrap());
+    } else if let Ok(b_bv) = b.cast::<BV>() {
         return BV::new(
             py,
             &GLOBAL_CONTEXT
                 .not(&b_bv.get().inner)?
                 .simplify_ext(true, true)?,
         )
-        .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+        .map(|b| b.into_any().cast_into::<Base>().unwrap());
     } else {
         panic!("unsupported type")
     }
@@ -42,7 +42,7 @@ pub fn and<'py>(
     // No operands: the identity element, true.
     if args.is_empty() {
         return Bool::new(py, &GLOBAL_CONTEXT.true_()?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+            .map(|b| b.into_any().cast_into::<Base>().unwrap());
     }
     // If all args are actually Bools (or Python bool literals) — not BVs
     // being coerced through the Bool path — use the Bool And. Otherwise fall
@@ -60,7 +60,7 @@ pub fn and<'py>(
             })
             .collect::<Result<Vec<_>, _>>()?;
         return Bool::new(py, &GLOBAL_CONTEXT.and(bool_args)?.simplify()?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+            .map(|b| b.into_any().cast_into::<Base>().unwrap());
     }
     if args.len() == 2
         && let Some(lhs) = args[0].extract::<CoerceBV>().ok()
@@ -73,7 +73,7 @@ pub fn and<'py>(
                 .and2(&lhs.get().inner, &rhs.get().inner)?
                 .simplify_ext(true, true)?,
         )
-        .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+        .map(|b| b.into_any().cast_into::<Base>().unwrap());
     }
     Err(ClaripyError::TypeError(
         "And: expected Bools or exactly two BVs".to_string(),
@@ -88,7 +88,7 @@ pub fn or<'py>(
     // No operands: the identity element, false.
     if args.is_empty() {
         return Bool::new(py, &GLOBAL_CONTEXT.false_()?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+            .map(|b| b.into_any().cast_into::<Base>().unwrap());
     }
     // Same policy as And: prefer the Bool path whenever every arg is a Bool.
     let all_bools = args
@@ -104,7 +104,7 @@ pub fn or<'py>(
             })
             .collect::<Result<Vec<_>, _>>()?;
         return Bool::new(py, &GLOBAL_CONTEXT.or(bool_args)?.simplify()?)
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+            .map(|b| b.into_any().cast_into::<Base>().unwrap());
     }
     if args.len() == 2
         && let Some(lhs) = args[0].extract::<CoerceBV>().ok()
@@ -117,7 +117,7 @@ pub fn or<'py>(
                 .or2(&lhs.get().inner, &rhs.get().inner)?
                 .simplify_ext(true, true)?,
         )
-        .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+        .map(|b| b.into_any().cast_into::<Base>().unwrap());
     }
     Err(ClaripyError::TypeError(
         "Or: expected Bools or exactly two BVs".to_string(),
@@ -131,20 +131,20 @@ pub fn xor<'py>(
     a: Bound<'py, PyAny>,
     b: Bound<'py, PyAny>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
-    if let Ok(a_bool) = a.clone().into_any().cast::<Bool>() {
-        if let Ok(b_bool) = b.clone().into_any().cast::<Bool>() {
+    if let Ok(a_bool) = a.cast::<Bool>() {
+        if let Ok(b_bool) = b.cast::<Bool>() {
             return Bool::new(
                 py,
                 &GLOBAL_CONTEXT
                     .xor2(&a_bool.get().inner, &b_bool.get().inner)?
                     .simplify()?,
             )
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+            .map(|b| b.into_any().cast_into::<Base>().unwrap());
         } else {
             panic!("mismatched types")
         }
-    } else if let Ok(a_bv) = a.clone().into_any().extract::<CoerceBV>() {
-        if let Ok(b_bv) = b.clone().into_any().extract::<CoerceBV>() {
+    } else if let Ok(a_bv) = a.extract::<CoerceBV>() {
+        if let Ok(b_bv) = b.extract::<CoerceBV>() {
             let (a_bv, b_bv) = CoerceBV::unpack_pair(py, &a_bv, &b_bv)?;
             return BV::new(
                 py,
@@ -152,7 +152,7 @@ pub fn xor<'py>(
                     .xor2(&a_bv.get().inner, &b_bv.get().inner)?
                     .simplify_ext(true, true)?,
             )
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone());
+            .map(|b| b.into_any().cast_into::<Base>().unwrap());
         } else {
             panic!("mismatched types")
         }
@@ -168,8 +168,8 @@ pub fn r#if<'py>(
     then_: Bound<'py, PyAny>,
     else_: Bound<'py, PyAny>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
-    if let Ok(then_bv) = then_.clone().into_any().extract::<CoerceBV>() {
-        if let Ok(else_bv) = else_.clone().into_any().extract::<CoerceBV>() {
+    if let Ok(then_bv) = then_.extract::<CoerceBV>() {
+        if let Ok(else_bv) = else_.extract::<CoerceBV>() {
             let (then_bv, else_bv) = CoerceBV::unpack_pair(py, &then_bv, &else_bv)?;
             BV::new(
                 py,
@@ -181,14 +181,14 @@ pub fn r#if<'py>(
                     )?
                     .simplify_ext(true, true)?,
             )
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone())
+            .map(|b| b.into_any().cast_into::<Base>().unwrap())
         } else {
             Err(ClaripyError::TypeError(format!(
                 "Sort mismatch in if-then-else: {then_:?} and {else_:?}"
             )))
         }
-    } else if let Ok(then_bool) = then_.clone().into_any().extract::<CoerceBool>() {
-        if let Ok(else_bv) = else_.clone().into_any().extract::<CoerceBool>() {
+    } else if let Ok(then_bool) = then_.extract::<CoerceBool>() {
+        if let Ok(else_bv) = else_.extract::<CoerceBool>() {
             let then_bv = then_bool.0.get().inner.clone();
             let else_bv = else_bv.0.get().inner.clone();
             Bool::new(
@@ -197,14 +197,14 @@ pub fn r#if<'py>(
                     .ite(&cond.0.get().inner, &then_bv, &else_bv)?
                     .simplify()?,
             )
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone())
+            .map(|b| b.into_any().cast_into::<Base>().unwrap())
         } else {
             Err(ClaripyError::TypeError(format!(
                 "Sort mismatch in if-then-else: {then_:?} and {else_:?}"
             )))
         }
-    } else if let Ok(then_fp) = then_.clone().into_any().extract::<CoerceFP>() {
-        if let Ok(else_fp) = else_.clone().into_any().extract::<CoerceFP>() {
+    } else if let Ok(then_fp) = then_.extract::<CoerceFP>() {
+        if let Ok(else_fp) = else_.extract::<CoerceFP>() {
             let (then_fp, else_fp) = CoerceFP::unpack_pair(py, &then_fp, &else_fp)?;
             FP::new(
                 py,
@@ -216,14 +216,14 @@ pub fn r#if<'py>(
                     )?
                     .simplify()?,
             )
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone())
+            .map(|b| b.into_any().cast_into::<Base>().unwrap())
         } else {
             Err(ClaripyError::TypeError(format!(
                 "Sort mismatch in if-then-else: {then_:?} and {else_:?}"
             )))
         }
-    } else if let Ok(then_string) = then_.clone().into_any().extract::<CoerceString>() {
-        if let Ok(else_string) = else_.clone().into_any().extract::<CoerceString>() {
+    } else if let Ok(then_string) = then_.extract::<CoerceString>() {
+        if let Ok(else_string) = else_.extract::<CoerceString>() {
             let then_bv = then_string.0.get().inner.clone();
             let else_bv = else_string.0.get().inner.clone();
             PyAstString::new(
@@ -232,7 +232,7 @@ pub fn r#if<'py>(
                     .ite(&cond.0.get().inner, &then_bv, &else_bv)?
                     .simplify()?,
             )
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone())
+            .map(|b| b.into_any().cast_into::<Base>().unwrap())
         } else {
             Err(ClaripyError::TypeError(format!(
                 "Sort mismatch in if-then-else: {then_:?} and {else_:?}"

--- a/crates/clarirs_py/src/lib.rs
+++ b/crates/clarirs_py/src/lib.rs
@@ -57,18 +57,18 @@ fn py_simplify<'py>(
     py: Python<'py>,
     expr: Bound<'py, Base>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
-    if let Ok(bv_value) = expr.clone().into_any().cast::<BV>() {
+    if let Ok(bv_value) = expr.cast::<BV>() {
         BV::new(py, &bv_value.get().inner.simplify().unwrap())
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone())
-    } else if let Ok(bool_value) = expr.clone().into_any().cast::<Bool>() {
+            .map(|b| b.into_any().cast_into::<Base>().unwrap())
+    } else if let Ok(bool_value) = expr.cast::<Bool>() {
         Bool::new(py, &bool_value.get().inner.simplify().unwrap())
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone())
-    } else if let Ok(fp_value) = expr.clone().into_any().cast::<FP>() {
+            .map(|b| b.into_any().cast_into::<Base>().unwrap())
+    } else if let Ok(fp_value) = expr.cast::<FP>() {
         FP::new(py, &fp_value.get().inner.simplify().unwrap())
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone())
-    } else if let Ok(string_value) = expr.clone().into_any().cast::<PyAstString>() {
+            .map(|b| b.into_any().cast_into::<Base>().unwrap())
+    } else if let Ok(string_value) = expr.cast::<PyAstString>() {
         PyAstString::new(py, &string_value.get().inner.simplify().unwrap())
-            .map(|b| b.into_any().cast::<Base>().unwrap().clone())
+            .map(|b| b.into_any().cast_into::<Base>().unwrap())
     } else {
         panic!("Unsupported type");
     }
@@ -80,8 +80,8 @@ fn py_replace<'py>(
     old: Bound<'py, Base>,
     new: Bound<'py, Base>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
-    let old_dyn = Base::to_ast(old.clone())?;
-    let new_dyn = Base::to_ast(new.clone())?;
+    let old_dyn = Base::to_ast(old)?;
+    let new_dyn = Base::to_ast(new)?;
 
     // Convert new type to old type, if they do not match and both are BV or FP
     let new_coerced = match (old_dyn.ast_type(), new_dyn.ast_type()) {
@@ -110,20 +110,20 @@ fn py_excavate_ite<'py>(
 
 #[pyfunction]
 fn is_true(expr: Bound<'_, PyAny>) -> Result<bool, ClaripyError> {
-    if let Ok(bool_expr) = expr.clone().extract::<CoerceBool>() {
+    if let Ok(bool_expr) = expr.extract::<CoerceBool>() {
         Ok(bool_expr.0.get().inner.simplify()?.is_true())
-    } else if let Ok(bv_expr) = expr.clone().extract::<CoerceBV>() {
+    } else if let Ok(bv_expr) = expr.extract::<CoerceBV>() {
         match bv_expr {
             CoerceBV::BV(bv_expr) => Ok(bv_expr.get().inner.simplify()?.is_true()),
             CoerceBV::Int(int_expr) => Ok(int_expr != BigInt::ZERO),
             CoerceBV::Bool(bool_expr) => Ok(bool_expr.get().inner.simplify()?.is_true()),
         }
-    } else if let Ok(fp_expr) = expr.clone().extract::<CoerceFP>() {
+    } else if let Ok(fp_expr) = expr.extract::<CoerceFP>() {
         match fp_expr {
             CoerceFP::FP(fp_expr) => Ok(fp_expr.get().inner.simplify()?.is_true()),
             CoerceFP::Py(float) => Ok(float.extract::<f64>()? != 0.0),
         }
-    } else if let Ok(string_expr) = expr.clone().extract::<CoerceString>() {
+    } else if let Ok(string_expr) = expr.extract::<CoerceString>() {
         Ok(string_expr.0.get().inner.simplify()?.is_true())
     } else {
         // Anything we cannot prove true is not true. This matches claripy
@@ -136,20 +136,20 @@ fn is_true(expr: Bound<'_, PyAny>) -> Result<bool, ClaripyError> {
 
 #[pyfunction]
 fn is_false(expr: Bound<'_, PyAny>) -> Result<bool, ClaripyError> {
-    if let Ok(bool_expr) = expr.clone().extract::<CoerceBool>() {
+    if let Ok(bool_expr) = expr.extract::<CoerceBool>() {
         Ok(bool_expr.0.get().inner.simplify()?.is_false())
-    } else if let Ok(bv_expr) = expr.clone().extract::<CoerceBV>() {
+    } else if let Ok(bv_expr) = expr.extract::<CoerceBV>() {
         match bv_expr {
             CoerceBV::BV(bv_expr) => Ok(bv_expr.get().inner.simplify()?.is_false()),
             CoerceBV::Int(int_expr) => Ok(int_expr == BigInt::ZERO),
             CoerceBV::Bool(bool_expr) => Ok(bool_expr.get().inner.simplify()?.is_false()),
         }
-    } else if let Ok(fp_expr) = expr.clone().extract::<CoerceFP>() {
+    } else if let Ok(fp_expr) = expr.extract::<CoerceFP>() {
         match fp_expr {
             CoerceFP::FP(fp_expr) => Ok(fp_expr.get().inner.simplify()?.is_false()),
             CoerceFP::Py(float) => Ok(float.extract::<f64>()? == 0.0),
         }
-    } else if let Ok(string_expr) = expr.clone().extract::<CoerceString>() {
+    } else if let Ok(string_expr) = expr.extract::<CoerceString>() {
         Ok(string_expr.0.get().inner.simplify()?.is_false())
     } else {
         // See is_true: claripy returns False for anything it cannot prove.

--- a/crates/clarirs_py/src/solver.rs
+++ b/crates/clarirs_py/src/solver.rs
@@ -364,13 +364,13 @@ impl PySolver {
         let mut seen: std::collections::HashSet<u64> =
             self.inner.constraints()?.iter().map(|c| c.hash()).collect();
         let mut added = Vec::with_capacity(bool_exprs.len());
-        for expr in &bool_exprs {
+        for expr in bool_exprs {
             let ast = expr.get().inner.clone();
             self.inner.add(&ast)?;
             if ast.simplify()?.is_true() || !seen.insert(ast.hash()) {
                 continue;
             }
-            added.push(expr.clone());
+            added.push(expr);
         }
 
         Ok(added)
@@ -421,7 +421,7 @@ impl PySolver {
         let exact = Self::extract_exact(exact);
         self.with_extra_constraints(extra_constraints, exact, |solver| {
             // Get multiple solutions based on expression type
-            if let Ok(bv_value) = expr.clone().into_any().cast::<BV>() {
+            if let Ok(bv_value) = expr.cast::<BV>() {
                 let solutions = solver.eval_n(&bv_value.get().inner, n)?;
                 let py_solutions = solutions
                     .into_iter()
@@ -429,9 +429,9 @@ impl PySolver {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(py_solutions
                     .into_iter()
-                    .map(|sol| sol.into_any().cast::<Base>().unwrap().clone())
+                    .map(|sol| sol.into_any().cast_into::<Base>().unwrap())
                     .collect())
-            } else if let Ok(bool_value) = expr.clone().into_any().cast::<Bool>() {
+            } else if let Ok(bool_value) = expr.cast::<Bool>() {
                 let solutions = solver.eval_n(&bool_value.get().inner, n)?;
                 let py_solutions = solutions
                     .into_iter()
@@ -439,9 +439,9 @@ impl PySolver {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(py_solutions
                     .into_iter()
-                    .map(|sol| sol.into_any().cast::<Base>().unwrap().clone())
+                    .map(|sol| sol.into_any().cast_into::<Base>().unwrap())
                     .collect())
-            } else if let Ok(fp_value) = expr.clone().into_any().cast::<FP>() {
+            } else if let Ok(fp_value) = expr.cast::<FP>() {
                 let solutions = solver.eval_n(&fp_value.get().inner, n)?;
                 let py_solutions = solutions
                     .into_iter()
@@ -449,9 +449,9 @@ impl PySolver {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(py_solutions
                     .into_iter()
-                    .map(|sol| sol.into_any().cast::<Base>().unwrap().clone())
+                    .map(|sol| sol.into_any().cast_into::<Base>().unwrap())
                     .collect())
-            } else if let Ok(string_value) = expr.clone().into_any().cast::<PyAstString>() {
+            } else if let Ok(string_value) = expr.cast::<PyAstString>() {
                 let solutions = solver.eval_n(&string_value.get().inner, n)?;
                 let py_solutions = solutions
                     .into_iter()
@@ -459,7 +459,7 @@ impl PySolver {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(py_solutions
                     .into_iter()
-                    .map(|sol| sol.into_any().cast::<Base>().unwrap().clone())
+                    .map(|sol| sol.into_any().cast_into::<Base>().unwrap())
                     .collect())
             } else {
                 Err(ClaripyError::TypeError("Unsupported type".to_string()))
@@ -480,25 +480,25 @@ impl PySolver {
             Ok(results) => results
                 .into_iter()
                 .filter_map(|r| {
-                    if let Ok(bv_value) = r.clone().into_any().cast::<BV>() {
+                    if let Ok(bv_value) = r.cast::<BV>() {
                         if let AstOp::BVV(bv) = bv_value.get().inner.op() {
                             Some(bv.to_biguint().into_bound_py_any(py))
                         } else {
                             None
                         }
-                    } else if let Ok(bool_value) = r.clone().into_any().cast::<Bool>() {
+                    } else if let Ok(bool_value) = r.cast::<Bool>() {
                         if let AstOp::BoolV(b) = bool_value.get().inner.op() {
                             Some(b.into_bound_py_any(py))
                         } else {
                             None
                         }
-                    } else if let Ok(fp_value) = r.clone().into_any().cast::<FP>() {
+                    } else if let Ok(fp_value) = r.cast::<FP>() {
                         if let AstOp::FPV(fp) = fp_value.get().inner.op() {
                             fp.to_f64().map(|f| f.into_bound_py_any(py))
                         } else {
                             None
                         }
-                    } else if let Ok(string_value) = r.clone().into_any().cast::<PyAstString>() {
+                    } else if let Ok(string_value) = r.cast::<PyAstString>() {
                         if let AstOp::StringV(s) = string_value.get().inner.op() {
                             Some(s.into_bound_py_any(py))
                         } else {
@@ -542,8 +542,8 @@ impl PySolver {
         }
 
         let asts: Vec<AstRef<'static>> = exprs
-            .iter()
-            .map(|expr| Base::to_ast(expr.clone()))
+            .into_iter()
+            .map(Base::to_ast)
             .collect::<Result<_, _>>()?;
         let exact = Self::extract_exact(exact);
 

--- a/crates/clarirs_py/src/vsa.rs
+++ b/crates/clarirs_py/src/vsa.rs
@@ -20,7 +20,7 @@ pub fn reduce<'py>(
     py: Python<'py>,
     expr: Bound<'py, Base>,
 ) -> Result<Bound<'py, Base>, ClaripyError> {
-    if let Ok(bool_expr) = expr.clone().into_any().cast::<Bool>() {
+    if let Ok(bool_expr) = expr.cast::<Bool>() {
         let reduced = bool_expr.get().inner.reduce()?.into_bool()?;
         let result = match reduced {
             ComparisonResult::True => Bool::new(py, &GLOBAL_CONTEXT.true_()?)?,
@@ -30,10 +30,10 @@ pub fn reduce<'py>(
                 BoolS(py, "maybe", false)?
             }
         };
-        return Ok(result.into_any().cast::<Base>()?.clone());
+        return Ok(result.into_any().cast_into::<Base>()?);
     }
 
-    if let Ok(bv_expr) = expr.clone().into_any().cast::<BV>() {
+    if let Ok(bv_expr) = expr.cast::<BV>() {
         let reduced = bv_expr.get().inner.reduce()?.into_bv()?;
         let result = match reduced {
             StridedInterval::Empty { .. } => bv_expr.clone(),
@@ -60,7 +60,7 @@ pub fn reduce<'py>(
                 }
             }
         };
-        return Ok(result.into_any().cast::<Base>()?.clone());
+        return Ok(result.into_any().cast_into::<Base>()?);
     }
 
     Err(ClaripyError::TypeError(
@@ -152,8 +152,8 @@ pub fn cardinality(expr: Bound<'_, BV>) -> Result<num_bigint::BigUint, ClaripyEr
 #[pyfunction]
 pub fn identical(a: Bound<'_, Base>, b: Bound<'_, Base>) -> Result<bool, ClaripyError> {
     // Try as BV first
-    if let Ok(a_bv) = a.clone().into_any().cast::<BV>()
-        && let Ok(b_bv) = b.clone().into_any().cast::<BV>()
+    if let Ok(a_bv) = a.cast::<BV>()
+        && let Ok(b_bv) = b.cast::<BV>()
     {
         let reduced_a = a_bv.get().inner.reduce()?.into_bv()?;
         let reduced_b = b_bv.get().inner.reduce()?.into_bv()?;
@@ -161,8 +161,8 @@ pub fn identical(a: Bound<'_, Base>, b: Bound<'_, Base>) -> Result<bool, Claripy
     }
 
     // Try as Bool
-    if let Ok(a_bool) = a.clone().into_any().cast::<Bool>()
-        && let Ok(b_bool) = b.clone().into_any().cast::<Bool>()
+    if let Ok(a_bool) = a.cast::<Bool>()
+        && let Ok(b_bool) = b.cast::<Bool>()
     {
         let reduced_a = a_bool.get().inner.reduce()?.into_bool()?;
         let reduced_b = b_bool.get().inner.reduce()?.into_bool()?;


### PR DESCRIPTION
This PR eliminates unnecessary `.clone()` calls throughout the PyO3 bindings by leveraging PyO3's ownership semantics more effectively.

## Summary
The changes optimize the codebase by removing redundant clones that were being performed on PyO3 `Bound` objects. These clones were unnecessary because:
1. `Bound` objects can be directly cast without cloning first
2. `cast_into()` consumes the object and returns the cast result, eliminating the need for a subsequent clone
3. Iterating over owned collections avoids unnecessary reference cloning

## Key Changes
- **Removed `.clone()` before `.cast()` calls**: Changed patterns like `b.clone().into_any().cast::<T>()` to `b.cast::<T>()` since casting doesn't require cloning
- **Replaced `.cast()` + `.clone()` with `.cast_into()`**: Used PyO3's `cast_into()` method which consumes the object and returns the cast result directly, eliminating the need for a separate clone
- **Optimized iteration patterns**: Changed `.iter()` to `.into_iter()` and removed unnecessary clones in loop bodies
- **Simplified variable assignments**: Removed intermediate clones in variable assignments and method calls
- **Cleaned up string handling**: Removed unnecessary `.to_string()` calls where `String` can be moved directly

## Files Modified
- `crates/clarirs_py/src/ast/mod.rs`: Optimized `not`, `and`, `or`, `xor`, and `if` functions
- `crates/clarirs_py/src/lib.rs`: Optimized `py_simplify`, `py_replace`, `is_true`, and `is_false` functions
- `crates/clarirs_py/src/solver.rs`: Optimized constraint handling and solution evaluation
- `crates/clarirs_py/src/ast/coerce.rs`: Optimized type coercion logic
- `crates/clarirs_py/src/vsa.rs`: Optimized VSA reduction and comparison functions
- `crates/clarirs_py/src/ast/bool.rs`: Optimized ITE dictionary handling
- `crates/clarirs_py/src/ast/bv.rs`: Optimized BVS symbol creation

These changes improve performance by reducing unnecessary memory allocations while maintaining the same functionality.

https://claude.ai/code/session_01EvnEAiruC6gQoq9H9toEEy