### PR TITLE
Refactor annotation class initialization to use PyClassInitializer

### DIFF
--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -193,7 +193,8 @@ impl PyAnnotation {
             }
             AnnotationType::SimplificationAvoidance => upcast(Bound::new(
                 py,
-                (SimplificationAvoidanceAnnotation, PyAnnotation),
+                PyClassInitializer::from(PyAnnotation)
+                    .add_subclass(SimplificationAvoidanceAnnotation),
             )?),
             AnnotationType::StridedInterval {
                 stride,
@@ -201,35 +202,30 @@ impl PyAnnotation {
                 upper_bound,
             } => upcast(Bound::new(
                 py,
-                (
-                    StridedIntervalAnnotation {
-                        stride: stride.clone(),
-                        lower_bound: lower_bound.clone(),
-                        upper_bound: upper_bound.clone(),
-                    },
-                    PyAnnotation,
-                ),
+                PyClassInitializer::from(PyAnnotation).add_subclass(StridedIntervalAnnotation {
+                    stride: stride.clone(),
+                    lower_bound: lower_bound.clone(),
+                    upper_bound: upper_bound.clone(),
+                }),
             )?),
             AnnotationType::EmptyStridedInterval => upcast(Bound::new(
                 py,
-                (EmptyStridedIntervalAnnotation, PyAnnotation),
+                PyClassInitializer::from(PyAnnotation).add_subclass(EmptyStridedIntervalAnnotation),
             )?),
             AnnotationType::Region {
                 region_id,
                 region_base_addr,
             } => upcast(Bound::new(
                 py,
-                (
-                    RegionAnnotation {
-                        region_id: region_id.clone(),
-                        region_base_addr: region_base_addr.clone(),
-                    },
-                    PyAnnotation,
-                ),
+                PyClassInitializer::from(PyAnnotation).add_subclass(RegionAnnotation {
+                    region_id: region_id.clone(),
+                    region_base_addr: region_base_addr.clone(),
+                }),
             )?),
-            AnnotationType::Uninitialized => {
-                upcast(Bound::new(py, (UninitializedAnnotation, PyAnnotation))?)
-            }
+            AnnotationType::Uninitialized => upcast(Bound::new(
+                py,
+                PyClassInitializer::from(PyAnnotation).add_subclass(UninitializedAnnotation),
+            )?),
         }
     }
 }


### PR DESCRIPTION
## Summary
Refactored the annotation class initialization pattern in `crates/clarirs_py/src/annotation.rs` to use PyO3's `PyClassInitializer` API instead of tuple-based initialization. This modernizes the code to follow current PyO3 best practices.

## Key Changes
- Replaced tuple-based class initialization `(SubClass, PyAnnotation)` with `PyClassInitializer::from(PyAnnotation).add_subclass(SubClass)` pattern across all annotation types
- Updated initialization for the following annotation types:
  - `SimplificationAvoidanceAnnotation`
  - `StridedIntervalAnnotation`
  - `EmptyStridedIntervalAnnotation`
  - `RegionAnnotation`
  - `UninitializedAnnotation`
- Reformatted `UninitializedAnnotation` case from single-line to multi-line for consistency with other cases

## Implementation Details
The change uses PyO3's `PyClassInitializer` builder pattern, which provides a more explicit and type-safe way to initialize class hierarchies. This approach is clearer about the parent-child relationship between `PyAnnotation` and its subclasses, improving code readability and maintainability.

https://claude.ai/code/session_01W2S5tP4tveMw27FKGNoQ2K