### PR TITLE
Remove py-clone feature and from_py_object derive attribute

### DIFF
--- a/crates/clarirs_py/Cargo.toml
+++ b/crates/clarirs_py/Cargo.toml
@@ -10,7 +10,7 @@ categories = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-pyo3 = { version = "0.29.0", features = ["py-clone", "num-bigint"] }
+pyo3 = { version = "0.29.0", features = ["num-bigint"] }
 clarirs_core = { path = "../clarirs_core", features = ["runtime-checks"] }
 clarirs_num = { path = "../clarirs_num" }
 clarirs-vsa = { path = "../clarirs-vsa" }

--- a/crates/clarirs_py/src/ast/base.rs
+++ b/crates/clarirs_py/src/ast/base.rs
@@ -10,8 +10,7 @@ use crate::prelude::*;
 /// (structure queries, hashing, simplification, replacement, annotation
 /// management). The sort-specific subclasses (`Bool`, `BV`, `FP`, `String`)
 /// inherit these and add only their own typed operations.
-#[pyclass(subclass, frozen, weakref, module = "claripy.ast.base", from_py_object)]
-#[derive(Clone)]
+#[pyclass(subclass, frozen, weakref, module = "claripy.ast.base")]
 pub struct Base {
     inner: AstRef<'static>,
     errored: Py<PySet>,
@@ -77,8 +76,8 @@ impl Base {
     }
 
     #[getter]
-    pub fn _errored(&self) -> Py<PySet> {
-        self.errored.clone()
+    pub fn _errored(&self, py: Python<'_>) -> Py<PySet> {
+        self.errored.clone_ref(py)
     }
 
     #[getter]

--- a/crates/clarirs_py/src/ast/bits.rs
+++ b/crates/clarirs_py/src/ast/bits.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
-#[pyclass(extends=Base, subclass, frozen, weakref, module="claripy.ast.bits", from_py_object)]
-#[derive(Clone, Default)]
+#[pyclass(extends=Base, subclass, frozen, weakref, module="claripy.ast.bits")]
+#[derive(Default)]
 pub struct Bits;
 
 impl Bits {


### PR DESCRIPTION
## Summary
This PR removes the `py-clone` feature from pyo3 dependencies and eliminates the `from_py_object` attribute from PyO3 class definitions, replacing manual `clone()` calls with `clone_ref(py)` where appropriate.

## Key Changes
- Removed `py-clone` feature from pyo3 dependency in `Cargo.toml`
- Removed `from_py_object` attribute from `#[pyclass]` macro in `Base` struct
- Removed `from_py_object` attribute from `#[pyclass]` macro in `Bits` struct
- Removed `#[derive(Clone)]` from `Base` struct
- Removed `#[derive(Clone)]` from `Bits` struct (kept `Default`)
- Updated `_errored` getter in `Base` to accept `py: Python<'_>` parameter and use `clone_ref(py)` instead of `clone()`

## Implementation Details
The changes align with PyO3 best practices by:
- Eliminating the `py-clone` feature which is no longer necessary
- Removing the `from_py_object` derive attribute which is not needed for these class definitions
- Using `clone_ref(py)` for proper reference counting of Python objects, which requires the Python GIL token
- Simplifying the struct derives by removing unnecessary `Clone` implementations

https://claude.ai/code/session_01AtaoNNkoagziB7ULbVvKJd