### PR TITLE
Improve error handling in coercion functions

### DIFF
--- a/crates/clarirs_py/src/ast/coerce.rs
+++ b/crates/clarirs_py/src/ast/coerce.rs
@@ -32,15 +32,19 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBool<'py> {
         if let Ok(bool_val) = val.cast::<Bool>() {
             Ok(CoerceBool(bool_val.to_owned()))
         } else if let Ok(bool_val) = val.extract::<bool>() {
-            Ok(CoerceBool(
-                Bool::new(val.py(), &GLOBAL_CONTEXT.boolv(bool_val).unwrap()).unwrap(),
-            ))
+            Ok(CoerceBool(Bool::new(
+                val.py(),
+                &GLOBAL_CONTEXT.boolv(bool_val).map_err(ClaripyError::from)?,
+            )?))
         } else if let Ok(int_val) = val.cast::<PyInt>() {
             // Coerce int (0 or non-zero) to Bool
             let i: BigInt = int_val.extract()?;
-            Ok(CoerceBool(
-                Bool::new(val.py(), &GLOBAL_CONTEXT.boolv(i != BigInt::ZERO).unwrap()).unwrap(),
-            ))
+            Ok(CoerceBool(Bool::new(
+                val.py(),
+                &GLOBAL_CONTEXT
+                    .boolv(i != BigInt::ZERO)
+                    .map_err(ClaripyError::from)?,
+            )?))
         } else if let Ok(bv_val) = val.cast::<BV>() {
             // Coerce BV to Bool: concrete fast-path, otherwise `bv != 0`.
             Ok(CoerceBool(Bool::new(val.py(), &bv_to_bool(bv_val.get())?)?))
@@ -201,7 +205,7 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBV<'py> {
         if let Ok(bv_val) = val.cast::<BV>() {
             Ok(CoerceBV::from(bv_val.to_owned()))
         } else if let Ok(int_val) = val.cast::<PyInt>() {
-            Ok(CoerceBV::from(int_val.to_owned()))
+            Ok(CoerceBV::Int(int_val.extract::<BigInt>()?))
         } else if let Ok(bool_val) = val.cast::<Bool>() {
             Ok(CoerceBV::Bool(bool_val.to_owned()))
         } else if let Ok(bytes_val) = val.extract::<Vec<u8>>() {
@@ -224,12 +228,6 @@ impl<'py> FromPyObject<'_, 'py> for CoerceBV<'py> {
 impl<'py> From<Bound<'py, BV>> for CoerceBV<'py> {
     fn from(val: Bound<'py, BV>) -> Self {
         CoerceBV::BV(val)
-    }
-}
-
-impl<'py> From<Bound<'py, PyInt>> for CoerceBV<'py> {
-    fn from(val: Bound<'py, PyInt>) -> Self {
-        CoerceBV::Int(val.extract::<BigInt>().unwrap())
     }
 }
 
@@ -337,9 +335,12 @@ impl<'py> FromPyObject<'_, 'py> for CoerceString<'py> {
         if let Ok(string_val) = val.cast::<PyAstString>() {
             Ok(CoerceString(string_val.to_owned()))
         } else if let Ok(string_val) = val.extract::<&str>() {
-            Ok(CoerceString(
-                PyAstString::new(val.py(), &GLOBAL_CONTEXT.stringv(string_val).unwrap()).unwrap(),
-            ))
+            Ok(CoerceString(PyAstString::new(
+                val.py(),
+                &GLOBAL_CONTEXT
+                    .stringv(string_val)
+                    .map_err(ClaripyError::from)?,
+            )?))
         } else {
             Err(ClaripyError::InvalidArgumentType("Expected String".to_string()).into())
         }


### PR DESCRIPTION
## Summary
This PR improves error handling in the AST coercion module by replacing `.unwrap()` calls with proper error propagation using the `?` operator and `map_err()`. Additionally, it removes an unused `From` implementation and simplifies type coercion logic.

## Key Changes
- **CoerceBool**: Replaced chained `.unwrap()` calls with `map_err(ClaripyError::from)?` to properly propagate errors from `GLOBAL_CONTEXT.boolv()` and `Bool::new()`
- **CoerceBV**: Simplified `PyInt` coercion by directly extracting to `BigInt` instead of using the removed `From<Bound<'py, PyInt>>` implementation
- **Removed unused impl**: Deleted the `From<Bound<'py, PyInt>> for CoerceBV<'py>` implementation that was using `.unwrap()` and replaced its usage with explicit extraction
- **CoerceString**: Replaced `.unwrap()` calls with proper error handling using `map_err(ClaripyError::from)?` for `GLOBAL_CONTEXT.stringv()` and `PyAstString::new()`

## Implementation Details
- All error handling now uses the `?` operator for cleaner error propagation
- Errors from `GLOBAL_CONTEXT` operations are converted to `ClaripyError` using `map_err()`
- The changes maintain the same functionality while improving robustness by avoiding panics from `.unwrap()` calls
- Code formatting was also improved with better line breaks for readability

https://claude.ai/code/session_01DiUBYmvNoRw9VuPEqHWZmY