### PR TITLE
Replace panics with proper error handling in AST operations

### DIFF
--- a/crates/clarirs_py/src/ast/mod.rs
+++ b/crates/clarirs_py/src/ast/mod.rs
@@ -30,7 +30,9 @@ pub fn not<'py>(py: Python<'py>, b: Bound<'py, Base>) -> Result<Bound<'py, Base>
         )
         .map(|b| b.into_any().cast_into::<Base>().unwrap());
     } else {
-        panic!("unsupported type")
+        Err(ClaripyError::TypeError(format!(
+            "Not: unsupported type {b:?}, expected Bool or BV"
+        )))
     }
 }
 
@@ -141,7 +143,9 @@ pub fn xor<'py>(
             )
             .map(|b| b.into_any().cast_into::<Base>().unwrap());
         } else {
-            panic!("mismatched types")
+            Err(ClaripyError::TypeError(format!(
+                "Xor: mismatched types, expected Bool but got {b:?}"
+            )))
         }
     } else if let Ok(a_bv) = a.extract::<CoerceBV>() {
         if let Ok(b_bv) = b.extract::<CoerceBV>() {
@@ -154,10 +158,14 @@ pub fn xor<'py>(
             )
             .map(|b| b.into_any().cast_into::<Base>().unwrap());
         } else {
-            panic!("mismatched types")
+            Err(ClaripyError::TypeError(format!(
+                "Xor: mismatched types, expected BV but got {b:?}"
+            )))
         }
     } else {
-        panic!("unsupported type")
+        Err(ClaripyError::TypeError(format!(
+            "Xor: unsupported types {a:?} and {b:?}"
+        )))
     }
 }
 
@@ -251,7 +259,9 @@ pub fn r#if<'py>(
             )))
         }
     } else {
-        panic!("unsupported type")
+        Err(ClaripyError::TypeError(format!(
+            "Unsupported type in if-then-else: {then_:?}"
+        )))
     }
 }
 

--- a/crates/clarirs_py/src/lib.rs
+++ b/crates/clarirs_py/src/lib.rs
@@ -70,7 +70,9 @@ fn py_simplify<'py>(
         PyAstString::new(py, &string_value.get().inner.simplify().unwrap())
             .map(|b| b.into_any().cast_into::<Base>().unwrap())
     } else {
-        panic!("Unsupported type");
+        Err(ClaripyError::TypeError(format!(
+            "simplify: unsupported type {expr:?}"
+        )))
     }
 }
 


### PR DESCRIPTION
## Summary
This PR replaces panic calls with proper error handling by returning `ClaripyError::TypeError` in several AST operation functions. This improves the robustness and debuggability of the codebase by providing meaningful error messages instead of crashing.

## Key Changes
- **`not()` function**: Replaced `panic!("unsupported type")` with a `TypeError` that includes the actual type received
- **`xor()` function**: Replaced three panic calls with descriptive `TypeError` variants:
  - Mismatched types when Bool operand is invalid
  - Mismatched types when BV operand is invalid
  - Unsupported types for both operands
- **`r#if()` function**: Replaced `panic!("unsupported type")` with a `TypeError` indicating the problematic type in if-then-else
- **`py_simplify()` function**: Replaced `panic!("Unsupported type")` with a `TypeError` for unsupported expression types

## Implementation Details
All error messages now include debug information about the problematic values (using `{:?}` formatting), making it easier to diagnose issues. The error handling follows the existing `Result<T, ClaripyError>` pattern used throughout the codebase.

https://claude.ai/code/session_018an64qDNavHDE7PK9jripu