### PR TITLE
Refactor Cache trait to use primitive get/insert methods

### DIFF
--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -165,12 +165,11 @@ fn simplify<'c>(
                     // simplified result so that identical unsimplified
                     // sub-expressions elsewhere in the tree get a cache hit.
                     if state.expr.hash() != annotated.hash() {
-                        let ctx = state.expr.context();
-                        let hash = state.expr.hash();
-                        let annotated_ref = annotated.clone();
-                        let _ = ctx
+                        state
+                            .expr
+                            .context()
                             .simplification_cache
-                            .get_or_insert::<SimplifyError<'c>>(hash, || Ok(annotated_ref.clone()));
+                            .insert(state.expr.hash(), &annotated);
                     }
 
                     last_result = Some(annotated)

--- a/crates/clarirs_core/src/cache.rs
+++ b/crates/clarirs_core/src/cache.rs
@@ -9,23 +9,16 @@ use crate::prelude::*;
 /// A trait for caching values based on a key. In the context of clarirs, this
 /// is used to cache ASTs, as well as the results of various algorithms.
 ///
-/// Implementations only need to provide the two primitives [`get`](Cache::get)
-/// and [`insert`](Cache::insert); [`get_or_insert`](Cache::get_or_insert) is
-/// derived from them. An implementation should override `get_or_insert` only
-/// when it needs behaviour the default cannot express (for example, recomputing
-/// the value on every call to detect hash collisions).
+/// Implementations provide `get` and `insert`; `get_or_insert` is derived from
+/// them, and need only be overridden when that default is insufficient.
 pub trait Cache<K, V> {
     /// Probe the cache without computing a value on miss.
     fn get(&self, key: &K) -> Option<V>;
 
-    /// Insert a value into the cache, replacing any existing entry for `key`.
     fn insert(&self, key: K, value: &V);
 
-    /// Remove the entry for `key`, if present.
     fn drop(&self, key: K);
 
-    /// Return the cached value for `key`, or compute one with `value_cv`, insert
-    /// it, and return it on a miss.
     fn get_or_insert<E>(&self, key: K, value_cv: impl FnOnce() -> Result<V, E>) -> Result<V, E> {
         if let Some(value) = self.get(&key) {
             return Ok(value);
@@ -88,8 +81,7 @@ impl<'c> Cache<u64, AstRef<'c>> for AstCache<'c> {
     fn insert(&self, key: u64, value: &AstRef<'c>) {
         let mut inner = self.0.write().unwrap();
 
-        // In collision-detection builds, finding a different live value already
-        // stored under this hash means two distinct ASTs share a hash.
+        // A different live value under this hash means two distinct ASTs collide.
         #[cfg(feature = "panic-on-hash-collision")]
         if let Some(existing) = inner.get(&key).and_then(Weak::upgrade)
             && existing != *value
@@ -104,17 +96,14 @@ impl<'c> Cache<u64, AstRef<'c>> for AstCache<'c> {
         self.0.write().unwrap().remove(&key);
     }
 
-    /// Collision detection has to compute the value and compare it on *every*
-    /// call — even on a cache hit — which the derived get-then-insert cannot
-    /// express, so `get_or_insert` is overridden in that build only. The
-    /// comparison itself lives in [`insert`](Self::insert).
+    // Collision detection must recompute and compare on every call, even a cache
+    // hit, which the derived get-then-insert cannot express.
     #[cfg(feature = "panic-on-hash-collision")]
     fn get_or_insert<E>(
         &self,
         key: u64,
         value_cv: impl FnOnce() -> Result<AstRef<'c>, E>,
     ) -> Result<AstRef<'c>, E> {
-        // This may call `simplify()` and recurse, so compute without a lock held.
         let arc = value_cv()?;
         self.insert(key, &arc);
         Ok(arc)

--- a/crates/clarirs_core/src/cache.rs
+++ b/crates/clarirs_core/src/cache.rs
@@ -8,24 +8,41 @@ use crate::prelude::*;
 
 /// A trait for caching values based on a key. In the context of clarirs, this
 /// is used to cache ASTs, as well as the results of various algorithms.
-/// The `get_or_insert` method will either return the cached value or compute
-/// a new value and insert it into the cache.
+///
+/// Implementations only need to provide the two primitives [`get`](Cache::get)
+/// and [`insert`](Cache::insert); [`get_or_insert`](Cache::get_or_insert) is
+/// derived from them. An implementation should override `get_or_insert` only
+/// when it needs behaviour the default cannot express (for example, recomputing
+/// the value on every call to detect hash collisions).
 pub trait Cache<K, V> {
-    fn get_or_insert<E>(&self, key: K, value_cv: impl FnMut() -> Result<V, E>) -> Result<V, E>;
-
     /// Probe the cache without computing a value on miss.
     fn get(&self, key: &K) -> Option<V>;
 
+    /// Insert a value into the cache, replacing any existing entry for `key`.
+    fn insert(&self, key: K, value: &V);
+
+    /// Remove the entry for `key`, if present.
     fn drop(&self, key: K);
+
+    /// Return the cached value for `key`, or compute one with `value_cv`, insert
+    /// it, and return it on a miss.
+    fn get_or_insert<E>(&self, key: K, value_cv: impl FnOnce() -> Result<V, E>) -> Result<V, E> {
+        if let Some(value) = self.get(&key) {
+            return Ok(value);
+        }
+        let value = value_cv()?;
+        self.insert(key, &value);
+        Ok(value)
+    }
 }
 
 impl<K, V> Cache<K, V> for () {
-    fn get_or_insert<E>(&self, _: K, mut value_cv: impl FnMut() -> Result<V, E>) -> Result<V, E> {
-        value_cv()
-    }
-
     fn get(&self, _key: &K) -> Option<V> {
         None
+    }
+
+    fn insert(&self, _key: K, _value: &V) {
+        // No-op
     }
 
     fn drop(&self, _key: K) {
@@ -44,32 +61,16 @@ impl<K, V> Default for GenericCache<K, V> {
 }
 
 impl<K: Hash + Eq, V: Clone> Cache<K, V> for GenericCache<K, V> {
-    fn get_or_insert<E>(&self, key: K, mut value_cv: impl FnMut() -> Result<V, E>) -> Result<V, E> {
-        // Fast path: check with read lock
-        {
-            let locked = self.0.read().unwrap();
-            if let Some(value) = locked.get(&key) {
-                return Ok(value.clone());
-            }
-        }
-        // Slow path: compute and insert with write lock
-        let mut locked = self.0.write().unwrap();
-        // Double-check after acquiring write lock
-        if let Some(value) = locked.get(&key) {
-            return Ok(value.clone());
-        }
-        let value = value_cv()?;
-        locked.insert(key, value.clone());
-        Ok(value)
-    }
-
     fn get(&self, key: &K) -> Option<V> {
         self.0.read().unwrap().get(key).cloned()
     }
 
+    fn insert(&self, key: K, value: &V) {
+        self.0.write().unwrap().insert(key, value.clone());
+    }
+
     fn drop(&self, key: K) {
-        let mut locked = self.0.write().unwrap();
-        locked.remove(&key);
+        self.0.write().unwrap().remove(&key);
     }
 }
 
@@ -80,68 +81,43 @@ impl<K: Hash + Eq, V: Clone> Cache<K, V> for GenericCache<K, V> {
 pub struct AstCache<'c>(RwLock<HashMap<u64, Weak<AstNode<'c>>>>);
 
 impl<'c> Cache<u64, AstRef<'c>> for AstCache<'c> {
-    fn get_or_insert<E>(
-        &self,
-        hash: u64,
-        f: impl FnOnce() -> Result<AstRef<'c>, E>,
-    ) -> Result<AstRef<'c>, E> {
-        #[cfg(not(feature = "panic-on-hash-collision"))]
-        {
-            // Normal mode: Try to get from cache first, compute only if needed
-            // Step 1: Try to get a read lock and check if the value is already in the cache
-            {
-                let inner = self.0.read().unwrap();
-                if let Some(weak) = inner.get(&hash)
-                    && let Some(arc) = weak.upgrade()
-                {
-                    return Ok(arc);
-                }
-                // Value not found or expired; we'll compute it next
-            } // Read lock is dropped here
-
-            // Step 2: Compute the value without holding any lock
-            let arc = f()?; // This may call `simplify()` and recurse
-
-            // Step 3: Acquire a write lock to insert the new value
-            let mut inner = self.0.write().unwrap();
-            inner.insert(hash, Arc::downgrade(&arc));
-
-            Ok(arc)
-        }
-
-        #[cfg(feature = "panic-on-hash-collision")]
-        {
-            // Collision detection mode: Always compute first, then check for collisions
-            // Step 1: Compute the value without holding any lock
-            let arc = f()?; // This may call `simplify()` and recurse
-
-            // Step 2: Acquire a write lock to check for collisions and insert
-            let mut inner = self.0.write().unwrap();
-
-            // Check for hash collision
-            if let Some(weak) = inner.get(&hash)
-                && let Some(existing_arc) = weak.upgrade()
-                && existing_arc != arc
-            {
-                panic!(
-                    "Hash collision detected! Hash: {hash}, Existing: {existing_arc:?}, New: {arc:?}"
-                );
-            }
-
-            // Insert the new value
-            inner.insert(hash, Arc::downgrade(&arc));
-
-            Ok(arc)
-        }
-    }
-
     fn get(&self, key: &u64) -> Option<AstRef<'c>> {
         self.0.read().unwrap().get(key).and_then(Weak::upgrade)
     }
 
+    fn insert(&self, key: u64, value: &AstRef<'c>) {
+        let mut inner = self.0.write().unwrap();
+
+        // In collision-detection builds, finding a different live value already
+        // stored under this hash means two distinct ASTs share a hash.
+        #[cfg(feature = "panic-on-hash-collision")]
+        if let Some(existing) = inner.get(&key).and_then(Weak::upgrade)
+            && existing != *value
+        {
+            panic!("Hash collision detected! Hash: {key}, Existing: {existing:?}, New: {value:?}");
+        }
+
+        inner.insert(key, Arc::downgrade(value));
+    }
+
     fn drop(&self, key: u64) {
-        let mut locked = self.0.write().unwrap();
-        locked.remove(&key);
+        self.0.write().unwrap().remove(&key);
+    }
+
+    /// Collision detection has to compute the value and compare it on *every*
+    /// call — even on a cache hit — which the derived get-then-insert cannot
+    /// express, so `get_or_insert` is overridden in that build only. The
+    /// comparison itself lives in [`insert`](Self::insert).
+    #[cfg(feature = "panic-on-hash-collision")]
+    fn get_or_insert<E>(
+        &self,
+        key: u64,
+        value_cv: impl FnOnce() -> Result<AstRef<'c>, E>,
+    ) -> Result<AstRef<'c>, E> {
+        // This may call `simplify()` and recurse, so compute without a lock held.
+        let arc = value_cv()?;
+        self.insert(key, &arc);
+        Ok(arc)
     }
 }
 


### PR DESCRIPTION
## Summary
Refactored the `Cache` trait to follow a more composable design pattern by making `get` and `insert` the primitive operations, with `get_or_insert` derived from them as a default implementation. This reduces code duplication and makes cache implementations simpler and more maintainable.

## Key Changes

- **Cache trait redesign**: Moved `get_or_insert` from a required method to a provided default implementation that composes `get` and `insert`
  - Added `insert` as a new required primitive method
  - Updated trait documentation to clarify the relationship between primitives and derived methods
  - Allows implementations to override `get_or_insert` only when special behavior is needed (e.g., collision detection)

- **GenericCache simplification**: Removed the complex double-checked locking pattern from `get_or_insert`
  - Now relies on the default `get_or_insert` implementation
  - Implements only the simpler `get` and `insert` primitives
  - Reduces lock contention and code complexity

- **AstCache refactoring**: Restructured to use the new trait design
  - Moved collision detection logic from `get_or_insert` into the `insert` method
  - Only overrides `get_or_insert` in collision-detection builds to compute values before checking for collisions
  - Cleaner separation of concerns between caching and collision detection

- **Simplify algorithm update**: Changed from `get_or_insert` to direct `insert` call
  - Simplified the cache update logic in `simplify.rs` to use `insert` directly instead of wrapping in `get_or_insert`
  - Removed unnecessary closure and error handling for a cache operation that doesn't need it

## Notable Implementation Details

- The `()` no-op cache implementation now properly implements `insert` as a no-op
- The default `get_or_insert` implementation uses `FnOnce` instead of `FnMut`, making the intent clearer that the closure is called at most once
- Collision detection in `AstCache` is now localized to the `insert` method, making the logic easier to understand and maintain

https://claude.ai/code/session_014V1LkLCriRY5xRj4owEscM