### PR TITLE
Upgrade Rust toolchain to 1.96

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.92"
+channel = "1.96"


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from **1.92** to **1.96** — the latest stable release (2026-05-25).

CI resolves the toolchain from `rust-toolchain.toml` via `actions-rust-lang/setup-rust-toolchain`, so updating the channel is the only change required; no workflow edits are needed.

## Verification

Ran the CI check set locally on 1.96:

| Check | Command | Result |
| --- | --- | --- |
| Clippy | `cargo clippy --all-features -- -D warnings` | ✅ clean |
| Formatting | `cargo fmt --all -- --check` | ✅ clean |
| Tests | `cargo test --all-features --no-fail-fast` | ✅ 585 passing |

The upgrade introduces **no new clippy warnings**. For completeness I also ran `cargo clippy --all-targets`; the only warnings it surfaces are in test code and are pre-existing — they appear identically under 1.92 and are not checked by the CI clippy job, so they are out of scope for this toolchain bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwAsv1ppE6ixJkbRPFX6ZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwAsv1ppE6ixJkbRPFX6ZG)_