### PR TITLE
Merge excavate_ite's two caches into one

### DIFF
--- a/crates/clarirs_core/src/algorithms/excavate_ite.rs
+++ b/crates/clarirs_core/src/algorithms/excavate_ite.rs
@@ -37,15 +37,6 @@ impl<'c> AstNode<'c> {
 /// An `ITE` is already in excavated form, so its branches are left in place;
 /// for any other op we distribute over its first `ITE` child and recurse to
 /// hoist any remaining ones, yielding the fully expanded decision tree.
-///
-/// The intermediate child arrays produced by that recursion never correspond to
-/// a real input node, so they cannot be short-circuited by [`walk_post_order`]'s
-/// keyed-by-input-node cache. We instead memoize them in the same
-/// `excavate_ite_cache`, keyed by the structural hash of the op-shape being
-/// distributed. Sharing one map is sound because that is exactly the key space
-/// `walk_post_order` already uses (a node's hash *is* its structural hash), and
-/// structurally identical shapes always excavate to the same result — so any
-/// key that coincides legitimately maps to one value.
 fn excavate_node<'c>(
     ast: &AstRef<'c>,
     children: &[AstRef<'c>],

--- a/crates/clarirs_core/src/algorithms/excavate_ite.rs
+++ b/crates/clarirs_core/src/algorithms/excavate_ite.rs
@@ -37,6 +37,15 @@ impl<'c> AstNode<'c> {
 /// An `ITE` is already in excavated form, so its branches are left in place;
 /// for any other op we distribute over its first `ITE` child and recurse to
 /// hoist any remaining ones, yielding the fully expanded decision tree.
+///
+/// The intermediate child arrays produced by that recursion never correspond to
+/// a real input node, so they cannot be short-circuited by [`walk_post_order`]'s
+/// keyed-by-input-node cache. We instead memoize them in the same
+/// `excavate_ite_cache`, keyed by the structural hash of the op-shape being
+/// distributed. Sharing one map is sound because that is exactly the key space
+/// `walk_post_order` already uses (a node's hash *is* its structural hash), and
+/// structurally identical shapes always excavate to the same result — so any
+/// key that coincides legitimately maps to one value.
 fn excavate_node<'c>(
     ast: &AstRef<'c>,
     children: &[AstRef<'c>],
@@ -57,7 +66,7 @@ fn excavate_node<'c>(
 
     let op = rebuild_op(ast, children).expect("a node being distributed is not a leaf");
     let key = structural_hash(op.infer_type(), &op, &BTreeSet::new());
-    if let Some(cached) = ctx.excavate_ite_distribute_cache.get(&key) {
+    if let Some(cached) = ctx.excavate_ite_cache.get(&key) {
         return Ok(cached);
     }
 
@@ -72,7 +81,7 @@ fn excavate_node<'c>(
     let else_branch = excavate_node(ast, &branch)?;
     let result = ctx.ite(cond, then_branch, else_branch)?;
 
-    ctx.excavate_ite_distribute_cache.insert(key, &result);
+    ctx.excavate_ite_cache.insert(key, &result);
     Ok(result)
 }
 

--- a/crates/clarirs_core/src/context.rs
+++ b/crates/clarirs_core/src/context.rs
@@ -102,7 +102,6 @@ pub struct Context<'c> {
     pub(crate) ast_cache: AstCache<'c>,
     pub(crate) simplification_cache: AstCache<'c>,
     pub(crate) excavate_ite_cache: AstCache<'c>,
-    pub(crate) excavate_ite_distribute_cache: AstCache<'c>,
     string_interner: RwLock<HashMap<Arc<str>, Arc<str>>>,
 }
 
@@ -151,7 +150,6 @@ impl Context<'_> {
         self.ast_cache.drop(hash);
         self.simplification_cache.drop(hash);
         self.excavate_ite_cache.drop(hash);
-        self.excavate_ite_distribute_cache.drop(hash);
     }
 }
 


### PR DESCRIPTION
## Summary

`excavate_ite` kept two context-level `AstCache`s, and this consolidates them into one.

- **`excavate_ite_cache`** — the `walk_post_order` memo, keyed by the input node's hash, storing each subtree's fully-excavated result (so DAG-shared subtrees and repeated calls skip re-traversal).
- **`excavate_ite_distribute_cache`** — the ITE-distribution memo used inside `excavate_node`, keyed by the structural hash of an op whose children are already excavated (the recursive branch-expansion produces synthetic child arrays that don't correspond to any real input node, so cache #1 can't short-circuit them).

They looked up at two different points but didn't need to be different maps: both are `AstCache<u64, AstRef>`, both keys come from `structural_hash`, and both store the same kind of value (the excavated result of a node shape). Sharing one map is sound — a node's hash *is* its structural hash, so the distribution keys live in the same key space `walk_post_order` already uses, and structurally identical shapes always excavate to the same result, so any coinciding key legitimately maps to one value.

This drops the second cache field (and its `drop_cache` line) and routes the distribution memo through `excavate_ite_cache`.

## Testing

- `cargo test -p clarirs_core` — full suite passes.
- `cargo test -p clarirs_core --features panic-on-hash-collision` — the excavate tests pass under collision detection, which recomputes and compares on every cache hit and would panic if two distinct ASTs ever shared a key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARY6iYzy2YZHDPwQsGjpy7)_