### PR TITLE
Inline simplify_inner function and update documentation

### DIFF
--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -77,7 +77,7 @@ impl<'c> SimplifyState<'c> {
     /// missing, returns `MissingChildren` listing every missing index so the
     /// main simplify loop can schedule them in one batch. This is crucial for
     /// n-ary ops (like Concat) with many children: fetching them one at a
-    /// time causes quadratic re-runs of simplify_inner.
+    /// time causes quadratic re-runs of simplification.
     fn get_all_simplified(&self) -> Result<Vec<AstRef<'c>>, SimplifyError<'c>> {
         let missing: Vec<usize> = self
             .children
@@ -106,21 +106,6 @@ impl<'c> SimplifyState<'c> {
     }
 }
 
-fn simplify_inner<'c>(
-    state: &mut SimplifyState<'c>,
-    error_on_dbz: bool,
-) -> Result<AstRef<'c>, SimplifyError<'c>> {
-    let expr = &state.expr.clone();
-    expr.context()
-        .simplification_cache
-        .get_or_insert(state.expr.hash(), || match expr.ast_type() {
-            AstType::Bool => bool::simplify_bool(state),
-            AstType::BitVec(_) => bv::simplify_bv(state, error_on_dbz),
-            AstType::Float(_) => float::simplify_float(state),
-            AstType::String => string::simplify_string(state),
-        })
-}
-
 fn simplify<'c>(
     ast: &AstRef<'c>,
     respect_annotations: bool,
@@ -146,7 +131,21 @@ fn simplify<'c>(
             || !state.expr.simplifiable();
         let should_simplify = !respect_annotations || !blocked;
         if should_simplify {
-            let inner_result = simplify_inner(&mut state, error_on_dbz);
+            // Look up (or compute) the simplified form of this node, dispatching
+            // to the per-type simplifier. The result is memoized in the
+            // context's simplification cache so identical sub-expressions
+            // elsewhere in the tree hit the cache instead of re-simplifying.
+            let inner_result = {
+                let expr = &state.expr.clone();
+                expr.context()
+                    .simplification_cache
+                    .get_or_insert(state.expr.hash(), || match expr.ast_type() {
+                        AstType::Bool => bool::simplify_bool(&mut state),
+                        AstType::BitVec(_) => bv::simplify_bv(&mut state, error_on_dbz),
+                        AstType::Float(_) => float::simplify_float(&mut state),
+                        AstType::String => string::simplify_string(&mut state),
+                    })
+            };
             match inner_result {
                 Ok(result) => {
                     let relocatable_annotations: Vec<Annotation> = state
@@ -199,8 +198,8 @@ fn simplify<'c>(
                         }
                     }
                     // All requested children are now cached; re-push the
-                    // state so simplify_inner will run again with children
-                    // available.
+                    // state so the simplification dispatch will run again with
+                    // children available.
                     work_stack.push(state);
                 }
                 Err(SimplifyError::ReRun(new_ast)) => {

--- a/crates/clarirs_core/src/algorithms/simplify/bv.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/bv.rs
@@ -1241,7 +1241,7 @@ pub(crate) fn simplify_bv<'c>(
         }
         AstOp::Concat(_) => {
             // Simplify all children in one batch. Fetching them one at a
-            // time would make simplify_inner re-run for every child and
+            // time would make simplification re-run for every child and
             // turn wide Concats into a quadratic cost.
             let simplified_args = state.get_all_simplified()?;
 


### PR DESCRIPTION
## Summary
This PR inlines the `simplify_inner` function directly into its call site in the `simplify` function, and updates related documentation to reflect the change.

## Key Changes
- **Removed `simplify_inner` function**: The standalone function that dispatched to per-type simplifiers has been removed
- **Inlined simplification logic**: The caching and type dispatch logic is now directly embedded in the `simplify` function with improved documentation
- **Updated comments**: References to `simplify_inner` in comments have been updated to use more generic terminology like "simplification" or "simplification dispatch"

## Implementation Details
- The inlined code maintains the exact same behavior: looking up or computing the simplified form of a node via the context's simplification cache, then dispatching to the appropriate per-type simplifier (bool, bitvec, float, or string)
- Added a more detailed comment block explaining the caching and memoization strategy at the inlined location
- The change improves code locality by keeping the dispatch logic closer to where it's used, making the control flow easier to follow
- All function signatures remain unchanged; the `&mut state` references are now passed directly to the type-specific simplifiers instead of through an intermediate function

https://claude.ai/code/session_016RAHTKsnTqs3kf4zqTqwZ6