### PR TITLE
Remove Clone derive from AstNode

### DIFF
--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// A node in an AST. A single node type serves every sort; the node caches its
 /// [`AstType`] so its sort can be queried in O(1) without inspecting the operation.
-#[derive(Clone, Eq, serde::Serialize)]
+#[derive(Eq, serde::Serialize)]
 pub struct AstNode<'c> {
     op: AstOp<'c>,
     annotations: BTreeSet<Annotation>,


### PR DESCRIPTION
## Summary
Removed the `Clone` derive from the `AstNode` struct to prevent automatic cloning of AST nodes.

## Changes
- Removed `Clone` from the `#[derive(...)]` attribute on `AstNode<'c>`
- Kept other derives: `Eq` and `serde::Serialize`

## Details
This change prevents `AstNode` instances from being cloned implicitly. This is likely intentional to enforce explicit handling of AST node ownership and avoid unintended duplication of potentially expensive AST structures. Code that needs to clone AST nodes will now need to implement cloning explicitly or use alternative approaches.

https://claude.ai/code/session_01N4m1F1dBK64bhZzsGnCDKu