### PR TITLE
fix: simplify sets (not adds) the original node's relocatable annotations

### DIFF
--- a/crates/clarirs_core/src/algorithms/simplify.rs
+++ b/crates/clarirs_core/src/algorithms/simplify.rs
@@ -8,6 +8,7 @@ mod test_bool;
 #[cfg(test)]
 mod test_bv;
 
+use std::collections::BTreeSet;
 use std::sync::{Arc, atomic::Ordering};
 
 use crate::{cache::Cache, prelude::*};
@@ -148,17 +149,24 @@ fn simplify<'c>(
             };
             match inner_result {
                 Ok(result) => {
-                    let relocatable_annotations: Vec<Annotation> = state
-                        .expr
+                    let mut new_annotations: BTreeSet<Annotation> = result
                         .annotations()
                         .iter()
-                        .filter(|a| a.relocatable())
+                        .filter(|a| !a.relocatable())
                         .cloned()
                         .collect();
+                    new_annotations.extend(
+                        state
+                            .expr
+                            .annotations()
+                            .iter()
+                            .filter(|a| a.relocatable())
+                            .cloned(),
+                    );
                     let annotated = state
                         .expr
                         .context()
-                        .annotate(&result, relocatable_annotations)?;
+                        .make_ast_exact(result.op().clone(), new_annotations)?;
 
                     // Cache the simplified form inline for shared sub-exprs.
                     state


### PR DESCRIPTION
## Summary

claripy is **lazy** — it never rebuilds a node, so a node's relocatable annotations stay exactly as set (e.g. by `replace_annotations`). clarirs is **eager** — every operation rebuilds operand subtrees, and `make_ast_annotated` re-collects the children's relocatable annotations during that rebuild. `simplify` then *added* the original node's relocatable annotations on top of the rebuilt `result`, so annotations **accumulated** — re-adding ones an explicit `replace_annotations` had removed.

## Repro

```python
import claripy
class Va(claripy.Annotation):
    def __init__(self, tag): self.tag = tag
    @property
    def relocatable(self): return True
    @property
    def eliminatable(self): return False
    def __eq__(self, o): return type(o) is Va and o.tag == self.tag
    def __hash__(self): return hash(("Va", self.tag))

a = claripy.BVS("a", 32).annotate(Va("A"))
b = claripy.BVS("b", 32).annotate(Va("B"))
y = (a - b).replace_annotations((Va("NEW"),))   # y has exactly {NEW}
z = y - b
# claripy: {NEW, B}        clarirs (before): {A, NEW, B}   <- A leaked back from inside y
```

## Fix

`simplify` now **sets** the simplified node's relocatable annotations to exactly the original node's (via `make_ast_exact`, which does not re-collect children), while **preserving** `result`'s non-relocatable annotations that simplification itself computes (e.g. VSA strided intervals — keeping those is what distinguishes this from a naive replace).

## Impact

This aligns clarirs annotation propagation with claripy through simplification. Concretely it fixes a downstream over-merge in angr's variable recovery, which tracks variables via relocatable annotations: the accumulation made a stack-slot phi pull in a register, another stack slot, and a global memory variable. With this fix the recovered phi matches claripy exactly.

## Testing

`cargo test -p clarirs_core --lib simplify` / `annotation` pass. Validated end-to-end against angr's clarirs build: clarirs_py suite unchanged (VSA tests pass), and the angr decompiler / variable-recovery / balancer / VFG / veritesting tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)