### PR TITLE
Add auto_replace option to ReplacementSolver

### DIFF
--- a/crates/clarirs_core/src/solver_mixins/replacement.rs
+++ b/crates/clarirs_core/src/solver_mixins/replacement.rs
@@ -50,6 +50,12 @@ impl<'c, S: Solver<'c>> ReplacementSolver<'c, S> {
         &self.inner
     }
 
+    /// Whether replacements are automatically extracted from `x == <concrete>`
+    /// style constraints as they are added.
+    pub fn auto_replace(&self) -> bool {
+        self.auto_replace
+    }
+
     pub fn inner_mut(&mut self) -> &mut S {
         &mut self.inner
     }
@@ -295,6 +301,30 @@ mod tests {
 
         assert!(solver.is_true(&x)?);
         assert!(!solver.is_false(&x)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_replacement_solver_auto_replace_disabled() -> Result<(), ClarirsError> {
+        let ctx = Context::new();
+        let inner = ConcreteSolver::new(&ctx);
+        // auto_replace = false: `x == 5` should NOT register a replacement.
+        let mut solver = ReplacementSolver::new_with_options(inner, false);
+        assert!(!solver.auto_replace());
+
+        let x = ctx.bvs("x", 8)?;
+        let five = ctx.bvv(BitVec::from((5, 8)))?;
+
+        let eq_constraint = ctx.eq_(&x, &five)?;
+        solver.add(&eq_constraint)?;
+
+        // No replacement was extracted, so the map stays empty.
+        assert!(solver.replacements().is_empty());
+
+        // Explicit replacements still work regardless of auto_replace.
+        solver.add_replacement(x.clone(), five.clone());
+        assert_eq!(solver.eval(&x)?, five);
 
         Ok(())
     }

--- a/crates/clarirs_py/src/dynsolver.rs
+++ b/crates/clarirs_py/src/dynsolver.rs
@@ -107,6 +107,15 @@ impl DynSolver {
         }
     }
 
+    /// Whether automatic replacement extraction is enabled. Only meaningful for
+    /// the Replacement solver; other solvers report the default of `true`.
+    pub(crate) fn auto_replace(&self) -> bool {
+        match self {
+            DynSolver::Replacement(solver) => solver.auto_replace(),
+            _ => true,
+        }
+    }
+
     /// Clear all replacements (only supported for Replacement solver)
     pub(crate) fn clear_replacements(&mut self) -> Result<(), ClarirsError> {
         match self {

--- a/crates/clarirs_py/src/dynsolver.rs
+++ b/crates/clarirs_py/src/dynsolver.rs
@@ -108,11 +108,11 @@ impl DynSolver {
     }
 
     /// Whether automatic replacement extraction is enabled. Only meaningful for
-    /// the Replacement solver; other solvers report the default of `true`.
+    /// the Replacement solver; other solvers report `false`.
     pub(crate) fn auto_replace(&self) -> bool {
         match self {
             DynSolver::Replacement(solver) => solver.auto_replace(),
-            _ => true,
+            _ => false,
         }
     }
 

--- a/crates/clarirs_py/src/solver.rs
+++ b/crates/clarirs_py/src/solver.rs
@@ -126,9 +126,14 @@ impl PySolver {
                     )),
                 ))),
                 DynSolver::Replacement(..) => {
-                    DynSolver::Replacement(ReplacementSolver::new(wrap_z3_cached(
-                        Z3Solver::new_with_options(&GLOBAL_CONTEXT, self.timeout, self.unsat_core),
-                    )))
+                    DynSolver::Replacement(ReplacementSolver::new_with_options(
+                        wrap_z3_cached(Z3Solver::new_with_options(
+                            &GLOBAL_CONTEXT,
+                            self.timeout,
+                            self.unsat_core,
+                        )),
+                        self.inner.auto_replace(),
+                    ))
                 }
                 DynSolver::Composite(..) => DynSolver::Composite(CompositeSolver::new(
                     &GLOBAL_CONTEXT,
@@ -884,12 +889,14 @@ impl PySolver {
         // Get the constraints
         let constraints = self.constraints(py)?;
 
-        // Return a tuple of (solver_type, constraints)
+        // Return a tuple of (solver_type, constraints, auto_replace). The last
+        // element is only meaningful for the Replacement solver.
         Ok(PyTuple::new(
             py,
             vec![
                 solver_type.into_bound_py_any(py)?,
                 constraints.into_bound_py_any(py)?,
+                self.inner.auto_replace().into_bound_py_any(py)?,
             ],
         )?)
     }
@@ -902,6 +909,12 @@ impl PySolver {
         // Extract solver type and constraints from the state tuple
         let solver_type: String = state.get_item(0)?.extract()?;
         let constraints: Vec<Bound<'py, Bool>> = state.get_item(1)?.extract()?;
+        // auto_replace was added later; default to claripy's `True` for older state.
+        let auto_replace: bool = state
+            .get_item(2)
+            .ok()
+            .and_then(|v| v.extract().ok())
+            .unwrap_or(true);
 
         // Create a new solver based on the type
         self.inner = match solver_type.as_str() {
@@ -920,9 +933,10 @@ impl PySolver {
                 wrap_solver(VSASolver::new(&GLOBAL_CONTEXT)),
                 wrap_z3_cached(Z3Solver::new_with_timeout(&GLOBAL_CONTEXT, self.timeout)),
             ))),
-            "Replacement" => DynSolver::Replacement(ReplacementSolver::new(wrap_z3_cached(
-                Z3Solver::new_with_timeout(&GLOBAL_CONTEXT, self.timeout),
-            ))),
+            "Replacement" => DynSolver::Replacement(ReplacementSolver::new_with_options(
+                wrap_z3_cached(Z3Solver::new_with_timeout(&GLOBAL_CONTEXT, self.timeout)),
+                auto_replace,
+            )),
             "Composite" => DynSolver::Composite(CompositeSolver::new(
                 &GLOBAL_CONTEXT,
                 wrap_z3_cached(Z3Solver::new_with_timeout(&GLOBAL_CONTEXT, self.timeout)),
@@ -1043,11 +1057,13 @@ pub struct PyReplacementSolver;
 #[pymethods]
 impl PyReplacementSolver {
     #[new]
-    fn new() -> Result<PyClassInitializer<Self>, ClaripyError> {
+    #[pyo3(signature = (auto_replace = true))]
+    fn new(auto_replace: bool) -> Result<PyClassInitializer<Self>, ClaripyError> {
         Ok(PyClassInitializer::from(PySolver {
-            inner: DynSolver::Replacement(ReplacementSolver::new(wrap_z3_cached(
-                Z3Solver::new_with_options(&GLOBAL_CONTEXT, None, false),
-            ))),
+            inner: DynSolver::Replacement(ReplacementSolver::new_with_options(
+                wrap_z3_cached(Z3Solver::new_with_options(&GLOBAL_CONTEXT, None, false)),
+                auto_replace,
+            )),
             timeout: None,
             unsat_core: false,
         })

--- a/crates/clarirs_py/tests/test_replacement_solver.py
+++ b/crates/clarirs_py/tests/test_replacement_solver.py
@@ -1,0 +1,82 @@
+import pickle
+
+import claripy
+
+
+def test_replacement_solver_exists():
+    """SolverReplacement is exported and constructible."""
+    s = claripy.SolverReplacement()
+    assert isinstance(s, claripy.Solver)
+
+
+def test_auto_replace_default_extracts_replacements():
+    """By default (auto_replace=True) `x == c` is turned into a replacement."""
+    s = claripy.SolverReplacement()
+    x = claripy.BVS("x", 8)
+    s.add(x == 5)
+    assert s.eval(x, 1)[0] == 5
+
+
+def test_auto_replace_true_keyword():
+    """Passing auto_replace=True explicitly behaves like the default."""
+    s = claripy.SolverReplacement(auto_replace=True)
+    x = claripy.BVS("x", 8)
+    s.add(x == 9)
+    assert s.eval(x, 1)[0] == 9
+
+
+def test_auto_replace_false_disables_extraction():
+    """With auto_replace=False, adding `x == c` does not register a
+    replacement, but explicit replacements still work."""
+    s = claripy.SolverReplacement(auto_replace=False)
+    x = claripy.BVS("x", 8)
+    s.add(x == 5)
+
+    # The backend still solves the constraint, so x evaluates to 5.
+    assert s.eval(x, 1)[0] == 5
+
+    # Explicit replacements override the value regardless of auto_replace.
+    s.add_replacement(x, claripy.BVV(7, 8))
+    assert s.eval(x, 1)[0] == 7
+
+
+def test_auto_replace_clear_replacements():
+    s = claripy.SolverReplacement()
+    x = claripy.BVS("x", 8)
+    s.add_replacement(x, claripy.BVV(3, 8))
+    assert s.eval(x, 1)[0] == 3
+    s.clear_replacements()
+    # After clearing, x is unconstrained again (any value is allowed).
+    assert s.satisfiable()
+
+
+def test_auto_replace_branch_preserves_setting():
+    """branch() clones the solver, keeping auto_replace=False."""
+    s = claripy.SolverReplacement(auto_replace=False)
+    b = s.branch()
+    x = claripy.BVS("x", 8)
+    b.add(x == 5)
+    b.add_replacement(x, claripy.BVV(4, 8))
+    assert b.eval(x, 1)[0] == 4
+
+
+def test_auto_replace_pickle_roundtrip():
+    """auto_replace survives a pickle round-trip."""
+    s = claripy.SolverReplacement(auto_replace=False)
+    restored = pickle.loads(pickle.dumps(s))
+    assert isinstance(restored, claripy.Solver)
+    x = claripy.BVS("x", 8)
+    restored.add(x == 5)
+    restored.add_replacement(x, claripy.BVV(6, 8))
+    assert restored.eval(x, 1)[0] == 6
+
+
+if __name__ == "__main__":
+    test_replacement_solver_exists()
+    test_auto_replace_default_extracts_replacements()
+    test_auto_replace_true_keyword()
+    test_auto_replace_false_disables_extraction()
+    test_auto_replace_clear_replacements()
+    test_auto_replace_branch_preserves_setting()
+    test_auto_replace_pickle_roundtrip()
+    print("All tests passed!")

--- a/crates/clarirs_py/tests/test_replacement_solver.py
+++ b/crates/clarirs_py/tests/test_replacement_solver.py
@@ -1,82 +1,69 @@
+from __future__ import annotations
+
 import pickle
+import unittest
 
 import claripy
 
 
-def test_replacement_solver_exists():
-    """SolverReplacement is exported and constructible."""
-    s = claripy.SolverReplacement()
-    assert isinstance(s, claripy.Solver)
+class TestReplacementSolver(unittest.TestCase):
+    def test_replacement_solver_exists(self):
+        """SolverReplacement is exported and constructible."""
+        s = claripy.SolverReplacement()
+        self.assertIsInstance(s, claripy.Solver)
 
+    def test_auto_replace_default_extracts_replacements(self):
+        """By default (auto_replace=True) `x == c` is turned into a replacement."""
+        s = claripy.SolverReplacement()
+        x = claripy.BVS("x", 8)
+        s.add(x == 5)
+        self.assertEqual(s.eval(x, 1)[0], 5)
 
-def test_auto_replace_default_extracts_replacements():
-    """By default (auto_replace=True) `x == c` is turned into a replacement."""
-    s = claripy.SolverReplacement()
-    x = claripy.BVS("x", 8)
-    s.add(x == 5)
-    assert s.eval(x, 1)[0] == 5
+    def test_auto_replace_true_keyword(self):
+        """Passing auto_replace=True explicitly behaves like the default."""
+        s = claripy.SolverReplacement(auto_replace=True)
+        x = claripy.BVS("x", 8)
+        s.add(x == 9)
+        self.assertEqual(s.eval(x, 1)[0], 9)
 
+    def test_auto_replace_false_disables_extraction(self):
+        """With auto_replace=False, adding `x == c` does not register a
+        replacement, but explicit replacements still work."""
+        s = claripy.SolverReplacement(auto_replace=False)
+        x = claripy.BVS("x", 8)
+        s.add(x == 5)
 
-def test_auto_replace_true_keyword():
-    """Passing auto_replace=True explicitly behaves like the default."""
-    s = claripy.SolverReplacement(auto_replace=True)
-    x = claripy.BVS("x", 8)
-    s.add(x == 9)
-    assert s.eval(x, 1)[0] == 9
+        # The backend still solves the constraint, so x evaluates to 5.
+        self.assertEqual(s.eval(x, 1)[0], 5)
 
+        # Explicit replacements override the value regardless of auto_replace.
+        s.add_replacement(x, claripy.BVV(7, 8))
+        self.assertEqual(s.eval(x, 1)[0], 7)
 
-def test_auto_replace_false_disables_extraction():
-    """With auto_replace=False, adding `x == c` does not register a
-    replacement, but explicit replacements still work."""
-    s = claripy.SolverReplacement(auto_replace=False)
-    x = claripy.BVS("x", 8)
-    s.add(x == 5)
+    def test_auto_replace_clear_replacements(self):
+        s = claripy.SolverReplacement()
+        x = claripy.BVS("x", 8)
+        s.add_replacement(x, claripy.BVV(3, 8))
+        self.assertEqual(s.eval(x, 1)[0], 3)
+        s.clear_replacements()
+        # After clearing, x is unconstrained again (any value is allowed).
+        self.assertTrue(s.satisfiable())
 
-    # The backend still solves the constraint, so x evaluates to 5.
-    assert s.eval(x, 1)[0] == 5
+    def test_auto_replace_branch_preserves_setting(self):
+        """branch() clones the solver, keeping auto_replace=False."""
+        s = claripy.SolverReplacement(auto_replace=False)
+        b = s.branch()
+        x = claripy.BVS("x", 8)
+        b.add(x == 5)
+        b.add_replacement(x, claripy.BVV(4, 8))
+        self.assertEqual(b.eval(x, 1)[0], 4)
 
-    # Explicit replacements override the value regardless of auto_replace.
-    s.add_replacement(x, claripy.BVV(7, 8))
-    assert s.eval(x, 1)[0] == 7
-
-
-def test_auto_replace_clear_replacements():
-    s = claripy.SolverReplacement()
-    x = claripy.BVS("x", 8)
-    s.add_replacement(x, claripy.BVV(3, 8))
-    assert s.eval(x, 1)[0] == 3
-    s.clear_replacements()
-    # After clearing, x is unconstrained again (any value is allowed).
-    assert s.satisfiable()
-
-
-def test_auto_replace_branch_preserves_setting():
-    """branch() clones the solver, keeping auto_replace=False."""
-    s = claripy.SolverReplacement(auto_replace=False)
-    b = s.branch()
-    x = claripy.BVS("x", 8)
-    b.add(x == 5)
-    b.add_replacement(x, claripy.BVV(4, 8))
-    assert b.eval(x, 1)[0] == 4
-
-
-def test_auto_replace_pickle_roundtrip():
-    """auto_replace survives a pickle round-trip."""
-    s = claripy.SolverReplacement(auto_replace=False)
-    restored = pickle.loads(pickle.dumps(s))
-    assert isinstance(restored, claripy.Solver)
-    x = claripy.BVS("x", 8)
-    restored.add(x == 5)
-    restored.add_replacement(x, claripy.BVV(6, 8))
-    assert restored.eval(x, 1)[0] == 6
-
-
-if __name__ == "__main__":
-    test_replacement_solver_exists()
-    test_auto_replace_default_extracts_replacements()
-    test_auto_replace_true_keyword()
-    test_auto_replace_false_disables_extraction()
-    test_auto_replace_clear_replacements()
-    test_auto_replace_branch_preserves_setting()
-    test_auto_replace_pickle_roundtrip()
-    print("All tests passed!")
+    def test_auto_replace_pickle_roundtrip(self):
+        """auto_replace survives a pickle round-trip."""
+        s = claripy.SolverReplacement(auto_replace=False)
+        restored = pickle.loads(pickle.dumps(s))
+        self.assertIsInstance(restored, claripy.Solver)
+        x = claripy.BVS("x", 8)
+        restored.add(x == 5)
+        restored.add_replacement(x, claripy.BVV(6, 8))
+        self.assertEqual(restored.eval(x, 1)[0], 6)


### PR DESCRIPTION
## Summary
This PR adds an `auto_replace` configuration option to the `ReplacementSolver`, allowing users to control whether equality constraints of the form `x == <concrete>` are automatically converted into replacements.

## Key Changes
- **ReplacementSolver API**: Added `new_with_options()` constructor and `auto_replace()` getter method to `ReplacementSolver` in `clarirs_core`
- **Python bindings**: Updated `PyReplacementSolver` to accept an `auto_replace` parameter (defaults to `True` for backward compatibility)
- **Solver state management**: Modified `__getstate__()` and `__setstate__()` in `PySolver` to preserve the `auto_replace` setting during pickling/unpickling
- **Branch preservation**: Updated `branch()` method to preserve the `auto_replace` setting when cloning a solver
- **DynSolver wrapper**: Added `auto_replace()` method to expose the setting across different solver types
- **Comprehensive tests**: Added 7 test cases covering default behavior, explicit control, clearing replacements, branching, and pickle round-trips

## Implementation Details
- The `auto_replace` parameter defaults to `true`, maintaining backward compatibility with existing code
- When `auto_replace=false`, equality constraints are still solved by the backend solver but are not registered as replacements; explicit replacements via `add_replacement()` still work regardless of this setting
- The setting is properly preserved through solver cloning and serialization operations

https://claude.ai/code/session_0194UHGsG5DDtaYqKv6H82Gw