### PR TITLE
test: standardize Python tests on unittest

### DIFF
--- a/crates/clarirs_py/tests/test_annotations.py
+++ b/crates/clarirs_py/tests/test_annotations.py
@@ -183,7 +183,3 @@ class TestAnnotationRoundtrip(unittest.TestCase):
         self.assertIsInstance(roundtripped, claripy.RegionAnnotation)
         self.assertEqual(roundtripped.region_id, "heap")
         self.assertEqual(roundtripped.region_base_addr, 0x20)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_batch_eval.py
+++ b/crates/clarirs_py/tests/test_batch_eval.py
@@ -1,48 +1,54 @@
+from __future__ import annotations
+
+import unittest
+
 import claripy
 
 
-def test_batch_eval_joint_model():
-    # Each tuple must be drawn from a single model: x + y == 10 has to hold for
-    # every returned (x, y) pair, which evaluating the expressions independently
-    # would not guarantee.
-    s = claripy.Solver()
-    x = claripy.BVS("x", 8)
-    y = claripy.BVS("y", 8)
-    s.add(x + y == 10)
+class TestBatchEval(unittest.TestCase):
+    def test_batch_eval_joint_model(self):
+        # Each tuple must be drawn from a single model: x + y == 10 has to hold
+        # for every returned (x, y) pair, which evaluating the expressions
+        # independently would not guarantee.
+        s = claripy.Solver()
+        x = claripy.BVS("x", 8)
+        y = claripy.BVS("y", 8)
+        s.add(x + y == 10)
 
-    results = s.batch_eval([x, y], 50)
-    assert results
-    assert all(isinstance(t, tuple) and len(t) == 2 for t in results)
-    for xv, yv in results:
-        assert (xv + yv) % 256 == 10
-    # Tuples are distinct.
-    assert len(set(results)) == len(results)
+        results = s.batch_eval([x, y], 50)
+        self.assertTrue(results)
+        self.assertTrue(all(isinstance(t, tuple) and len(t) == 2 for t in results))
+        for xv, yv in results:
+            self.assertEqual((xv + yv) % 256, 10)
+        # Tuples are distinct.
+        self.assertEqual(len(set(results)), len(results))
+
+    def test_batch_eval_mixed_types(self):
+        s = claripy.Solver()
+        x = claripy.BVS("x", 8)
+        s.add(x == 7)
+        flag = claripy.BVS("flag", 8)
+        s.add(flag == 1)
+        cond = flag == 1  # a Bool expression
+        f = claripy.FPS("f", claripy.FSORT_DOUBLE)
+        s.add(f == claripy.FPV(2.5, claripy.FSORT_DOUBLE))
+
+        (row,) = s.batch_eval([x, cond, f], 1)
+        xv, cv, fv = row
+        self.assertEqual(xv, 7)
+        self.assertIs(cv, True)
+        self.assertEqual(fv, 2.5)
+
+    def test_batch_eval_string(self):
+        s = claripy.Solver()
+        st = claripy.StringS("s")
+        s.add(st == claripy.StringV("hi"))
+        self.assertEqual(s.batch_eval([st], 1), [("hi",)])
+
+    def test_batch_eval_empty(self):
+        s = claripy.Solver()
+        self.assertEqual(s.batch_eval([], 5), [])
 
 
-def test_batch_eval_mixed_types():
-    s = claripy.Solver()
-    x = claripy.BVS("x", 8)
-    s.add(x == 7)
-    flag = claripy.BVS("flag", 8)
-    s.add(flag == 1)
-    cond = flag == 1  # a Bool expression
-    f = claripy.FPS("f", claripy.FSORT_DOUBLE)
-    s.add(f == claripy.FPV(2.5, claripy.FSORT_DOUBLE))
-
-    (row,) = s.batch_eval([x, cond, f], 1)
-    xv, cv, fv = row
-    assert xv == 7
-    assert cv is True
-    assert fv == 2.5
-
-
-def test_batch_eval_string():
-    s = claripy.Solver()
-    st = claripy.StringS("s")
-    s.add(st == claripy.StringV("hi"))
-    assert s.batch_eval([st], 1) == [("hi",)]
-
-
-def test_batch_eval_empty():
-    s = claripy.Solver()
-    assert s.batch_eval([], 5) == []
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/clarirs_py/tests/test_batch_eval.py
+++ b/crates/clarirs_py/tests/test_batch_eval.py
@@ -48,7 +48,3 @@ class TestBatchEval(unittest.TestCase):
     def test_batch_eval_empty(self):
         s = claripy.Solver()
         self.assertEqual(s.batch_eval([], 5), [])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_bool_ops.py
+++ b/crates/clarirs_py/tests/test_bool_ops.py
@@ -227,7 +227,3 @@ class TestBoolOperations(unittest.TestCase):
         }
         result = claripy.ast.bool.ite_dict(self.bv_sym, d, self.bool_sym)
         self.assertTrue(result.op != 'BoolV')
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_bv_ops.py
+++ b/crates/clarirs_py/tests/test_bv_ops.py
@@ -447,7 +447,3 @@ class TestBVOperations(unittest.TestCase):
         # Test with symbolic values
         sym_pos = +self.sym_x
         self._check_symbolic_evaluation(sym_pos, lambda solver: solver.satisfiable())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_canonicalize.py
+++ b/crates/clarirs_py/tests/test_canonicalize.py
@@ -62,7 +62,3 @@ class TestCanonicalize(unittest.TestCase):
         self.assertIs(returned, counter)
         # Two distinct variables consumed v0 and v1; next value is 2.
         self.assertEqual(next(counter), 2)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_composite_unsat.py
+++ b/crates/clarirs_py/tests/test_composite_unsat.py
@@ -34,7 +34,3 @@ class TestCompositeUnsat(unittest.TestCase):
         self.assertTrue(solver.satisfiable())
         solver.add(claripy.BoolV(False))
         self.assertFalse(solver.satisfiable())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_fp_ops.py
+++ b/crates/clarirs_py/tests/test_fp_ops.py
@@ -781,7 +781,3 @@ class TestFPOperations(unittest.TestCase):
         inf_bv = self.fp_inf.to_bv()
         neg_inf_bv = self.fp_neg_inf.to_bv()
         self.assertNotEqual(self.z3.eval(inf_bv, 1)[0], self.z3.eval(neg_inf_bv, 1)[0])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_get_bytes.py
+++ b/crates/clarirs_py/tests/test_get_bytes.py
@@ -266,7 +266,3 @@ class TestGetBytes(unittest.TestCase):
         self.assertEqual(sequential.get_bytes(1, 2).args[0], 0x0203)
         self.assertEqual(sequential.get_bytes(0, 3).args[0], 0x010203)
         self.assertEqual(sequential.get_bytes(1, 3).args[0], 0x020304)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_simplify_construction.py
+++ b/crates/clarirs_py/tests/test_simplify_construction.py
@@ -29,7 +29,3 @@ class TestSimplifyConstruction(unittest.TestCase):
         hi = v.chop(8)[0]
         self.assertFalse(hi.symbolic)
         self.assertEqual(hi.concrete_value, 0xAA)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_solver_cacheless.py
+++ b/crates/clarirs_py/tests/test_solver_cacheless.py
@@ -1,97 +1,88 @@
+from __future__ import annotations
+
 import pickle
+import unittest
 
 import claripy
 
 
-def test_solver_cacheless_exists():
-    """SolverCacheless is exported and constructible."""
-    s = claripy.SolverCacheless()
-    assert isinstance(s, claripy.Solver)
+class TestSolverCacheless(unittest.TestCase):
+    def test_solver_cacheless_exists(self):
+        """SolverCacheless is exported and constructible."""
+        s = claripy.SolverCacheless()
+        self.assertIsInstance(s, claripy.Solver)
 
+    def test_cacheless_matches_caching_solver(self):
+        """The caching Solver and SolverCacheless must agree on every query."""
+        x = claripy.BVS("x", 32)
 
-def test_cacheless_matches_caching_solver():
-    """The caching Solver and SolverCacheless must agree on every query."""
-    x = claripy.BVS("x", 32)
+        cached = claripy.Solver()
+        cacheless = claripy.SolverCacheless()
+        for s in (cached, cacheless):
+            s.add(x >= 10)
+            s.add(x <= 20)
 
-    cached = claripy.Solver()
-    cacheless = claripy.SolverCacheless()
-    for s in (cached, cacheless):
+        self.assertEqual(cached.satisfiable(), cacheless.satisfiable())
+        # Repeated checks (the caching solver answers the second from cache).
+        self.assertTrue(cached.satisfiable())
+
+        cached_vals = set(cached.eval(x, 5))
+        cacheless_vals = set(cacheless.eval(x, 5))
+        # Every solution lies within the constraints for both solvers.
+        for vals in (cached_vals, cacheless_vals):
+            self.assertTrue(vals)
+            self.assertTrue(all(10 <= v <= 20 for v in vals))
+
+    def test_cacheless_unsat(self):
+        s = claripy.SolverCacheless()
+        x = claripy.BVS("x", 8)
+        s.add(x == 1)
+        s.add(x == 2)
+        self.assertFalse(s.satisfiable())
+
+    def test_caching_solver_repeated_eval_consistent(self):
+        """Reusing a cached model must stay consistent with the constraints."""
+        s = claripy.Solver()
+        x = claripy.BVS("x", 32)
+        y = claripy.BVS("y", 32)
+        s.add(y == x + 1)
+        s.add(x == 7)
+
+        # The cache should serve these without changing the answer.
+        self.assertEqual(s.eval(x, 1)[0], 7)
+        self.assertEqual(s.eval(y, 1)[0], 8)
+        self.assertTrue(s.satisfiable())
+
+    def test_cacheless_extra_constraints(self):
+        s = claripy.SolverCacheless()
+        x = claripy.BVS("x", 32)
         s.add(x >= 10)
-        s.add(x <= 20)
 
-    assert cached.satisfiable() == cacheless.satisfiable()
-    # Repeated checks (the caching solver answers the second from cache).
-    assert cached.satisfiable()
+        self.assertTrue(s.satisfiable(extra_constraints=[x == 15]))
+        self.assertFalse(s.satisfiable(extra_constraints=[x == 5]))
+        # Extra constraints must not persist.
+        self.assertTrue(s.satisfiable())
 
-    cached_vals = set(cached.eval(x, 5))
-    cacheless_vals = set(cacheless.eval(x, 5))
-    # Every solution lies within the constraints for both solvers.
-    for vals in (cached_vals, cacheless_vals):
-        assert vals
-        assert all(10 <= v <= 20 for v in vals)
+    def test_cacheless_branch_stays_cacheless(self):
+        s = claripy.SolverCacheless()
+        x = claripy.BVS("x", 8)
+        s.add(x > 3)
 
+        b = s.branch()
+        self.assertIsInstance(b, claripy.Solver)
+        self.assertTrue(b.satisfiable())
+        # The branch carries the constraints over.
+        self.assertTrue(any(c is not None for c in b.constraints))
 
-def test_cacheless_unsat():
-    s = claripy.SolverCacheless()
-    x = claripy.BVS("x", 8)
-    s.add(x == 1)
-    s.add(x == 2)
-    assert not s.satisfiable()
+    def test_cacheless_pickle_roundtrip(self):
+        s = claripy.SolverCacheless()
+        x = claripy.BVS("x", 16)
+        s.add(x == 42)
 
-
-def test_caching_solver_repeated_eval_consistent():
-    """Reusing a cached model must stay consistent with the constraints."""
-    s = claripy.Solver()
-    x = claripy.BVS("x", 32)
-    y = claripy.BVS("y", 32)
-    s.add(y == x + 1)
-    s.add(x == 7)
-
-    # The cache should serve these without changing the answer.
-    assert s.eval(x, 1)[0] == 7
-    assert s.eval(y, 1)[0] == 8
-    assert s.satisfiable()
-
-
-def test_cacheless_extra_constraints():
-    s = claripy.SolverCacheless()
-    x = claripy.BVS("x", 32)
-    s.add(x >= 10)
-
-    assert s.satisfiable(extra_constraints=[x == 15])
-    assert not s.satisfiable(extra_constraints=[x == 5])
-    # Extra constraints must not persist.
-    assert s.satisfiable()
-
-
-def test_cacheless_branch_stays_cacheless():
-    s = claripy.SolverCacheless()
-    x = claripy.BVS("x", 8)
-    s.add(x > 3)
-
-    b = s.branch()
-    assert isinstance(b, claripy.Solver)
-    assert b.satisfiable()
-    # The branch carries the constraints over.
-    assert any(c is not None for c in b.constraints)
-
-
-def test_cacheless_pickle_roundtrip():
-    s = claripy.SolverCacheless()
-    x = claripy.BVS("x", 16)
-    s.add(x == 42)
-
-    restored = pickle.loads(pickle.dumps(s))
-    assert restored.satisfiable()
-    assert restored.eval(x, 1)[0] == 42
+        restored = pickle.loads(pickle.dumps(s))
+        self.assertTrue(restored.satisfiable())
+        self.assertEqual(restored.eval(x, 1)[0], 42)
 
 
 if __name__ == "__main__":
-    test_solver_cacheless_exists()
-    test_cacheless_matches_caching_solver()
-    test_cacheless_unsat()
-    test_caching_solver_repeated_eval_consistent()
-    test_cacheless_extra_constraints()
-    test_cacheless_branch_stays_cacheless()
-    test_cacheless_pickle_roundtrip()
-    print("All tests passed!")
+    unittest.main()

--- a/crates/clarirs_py/tests/test_solver_cacheless.py
+++ b/crates/clarirs_py/tests/test_solver_cacheless.py
@@ -82,7 +82,3 @@ class TestSolverCacheless(unittest.TestCase):
         restored = pickle.loads(pickle.dumps(s))
         self.assertTrue(restored.satisfiable())
         self.assertEqual(restored.eval(x, 1)[0], 42)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_solver_split.py
+++ b/crates/clarirs_py/tests/test_solver_split.py
@@ -51,7 +51,3 @@ class TestSolverSplit(unittest.TestCase):
         s.add(x > 0)
         s.add(x < 5)
         self.assertEqual(len(s.split()), 1)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_string_ops.py
+++ b/crates/clarirs_py/tests/test_string_ops.py
@@ -334,7 +334,3 @@ class TestStringOperations(unittest.TestCase):
         # Non-ASCII digits (like Arabic numerals) are considered valid digits by Z3
         result = StrIsDigit(claripy.StringV("١٢٣"))  # Arabic numerals
         self._check_equal(result, True)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_unknown_annotation_identity.py
+++ b/crates/clarirs_py/tests/test_unknown_annotation_identity.py
@@ -50,7 +50,3 @@ class TestUnknownAnnotationIdentity(unittest.TestCase):
     def test_same_object_is_stable(self):
         anno = KeyedAnnotation("a")
         self.assertEqual(self.base.annotate(anno).hash(), self.base.annotate(anno).hash())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_unsat_core.py
+++ b/crates/clarirs_py/tests/test_unsat_core.py
@@ -133,7 +133,3 @@ class TestUnsatCore(unittest.TestCase):
         s.add(y < 10)
         self.assertTrue(s.satisfiable())
         self.assertEqual(s.unsat_core(), [])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_unsat_core.py
+++ b/crates/clarirs_py/tests/test_unsat_core.py
@@ -1,148 +1,139 @@
-import pytest
+from __future__ import annotations
+
+import unittest
+
 import claripy
 
 
-def test_unsat_core_simple():
-    """Test basic unsat core functionality"""
-    # Create a solver with unsat_core enabled
-    s = claripy.Solver(track=True)
+class TestUnsatCore(unittest.TestCase):
+    def test_unsat_core_simple(self):
+        """Test basic unsat core functionality"""
+        # Create a solver with unsat_core enabled
+        s = claripy.Solver(track=True)
 
-    x = claripy.BVS("x", 8)
+        x = claripy.BVS("x", 8)
 
-    # Add contradictory constraints
-    s.add(x > 10)  # constraint 0
-    s.add(x < 5)  # constraint 1
-    s.add(x > 0)  # constraint 2 (not part of unsat core)
+        # Add contradictory constraints
+        s.add(x > 10)  # constraint 0
+        s.add(x < 5)  # constraint 1
+        s.add(x > 0)  # constraint 2 (not part of unsat core)
 
-    # Should be unsat
-    assert not s.satisfiable()
+        # Should be unsat
+        self.assertFalse(s.satisfiable())
 
-    # Get unsat core
-    core = s.unsat_core()
+        # Get unsat core
+        core = s.unsat_core()
 
-    # Core should contain the contradictory constraints
-    assert len(core) > 0
-    assert 0 in core
-    assert 1 in core
-    # constraint 2 should not be necessary for unsat
+        # Core should contain the contradictory constraints
+        self.assertGreater(len(core), 0)
+        self.assertIn(0, core)
+        self.assertIn(1, core)
+        # constraint 2 should not be necessary for unsat
 
+    def test_unsat_core_bool(self):
+        """Test unsat core with boolean constraints"""
+        s = claripy.Solver(track=True)
 
-def test_unsat_core_bool():
-    """Test unsat core with boolean constraints"""
-    s = claripy.Solver(track=True)
+        a = claripy.BoolS("a")
+        b = claripy.BoolS("b")
 
-    a = claripy.BoolS("a")
-    b = claripy.BoolS("b")
+        # Add contradictory constraints
+        s.add(a == b)  # constraint 0
+        s.add(a)  # constraint 1: a is true
+        s.add(claripy.Not(b))  # constraint 2: b is false
 
-    # Add contradictory constraints
-    s.add(a == b)  # constraint 0
-    s.add(a)  # constraint 1: a is true
-    s.add(claripy.Not(b))  # constraint 2: b is false
+        # Should be unsat
+        self.assertFalse(s.satisfiable())
 
-    # Should be unsat
-    assert not s.satisfiable()
+        # Get unsat core - all three constraints are necessary
+        core = s.unsat_core()
+        self.assertGreater(len(core), 0)
 
-    # Get unsat core - all three constraints are necessary
-    core = s.unsat_core()
-    assert len(core) > 0
+    def test_unsat_core_not_enabled(self):
+        """Test that unsat_core raises error when not enabled"""
+        s = claripy.Solver()  # unsat_core not enabled
 
+        x = claripy.BVS("x", 8)
+        s.add(x > 10)
+        s.add(x < 5)
 
-def test_unsat_core_not_enabled():
-    """Test that unsat_core raises error when not enabled"""
-    s = claripy.Solver()  # unsat_core not enabled
+        self.assertFalse(s.satisfiable())
 
-    x = claripy.BVS("x", 8)
-    s.add(x > 10)
-    s.add(x < 5)
+        # Should raise an error
+        with self.assertRaises(Exception):
+            s.unsat_core()
 
-    assert not s.satisfiable()
+    def test_unsat_core_on_sat(self):
+        """Test that unsat_core raises error on SAT result"""
+        s = claripy.Solver(track=True)
 
-    # Should raise an error
-    with pytest.raises(Exception):
-        s.unsat_core()
+        x = claripy.BVS("x", 8)
+        s.add(x > 5)
 
+        # Should be sat
+        self.assertTrue(s.satisfiable())
 
-def test_unsat_core_on_sat():
-    """Test that unsat_core raises error on SAT result"""
-    s = claripy.Solver(track=True)
+        # Should raise an error because it's SAT
+        with self.assertRaises(Exception):
+            s.unsat_core()
 
-    x = claripy.BVS("x", 8)
-    s.add(x > 5)
+    def test_unsat_core_complex(self):
+        """Test unsat core with more complex constraints"""
+        s = claripy.Solver(track=True)
 
-    # Should be sat
-    assert s.satisfiable()
+        x = claripy.BVS("x", 32)
+        y = claripy.BVS("y", 32)
 
-    # Should raise an error because it's SAT
-    with pytest.raises(Exception):
-        s.unsat_core()
+        # Add various constraints
+        s.add(x + y == 100)  # constraint 0
+        s.add(x > 60)  # constraint 1
+        s.add(y > 50)  # constraint 2 - makes it unsat with 0 and 1
+        s.add(x < 200)  # constraint 3 - not relevant
+        s.add(y < 200)  # constraint 4 - not relevant
 
+        # Should be unsat (x > 60 and y > 50 means x + y > 110)
+        self.assertFalse(s.satisfiable())
 
-def test_unsat_core_complex():
-    """Test unsat core with more complex constraints"""
-    s = claripy.Solver(track=True)
+        # Get unsat core
+        core = s.unsat_core()
+        self.assertGreater(len(core), 0)
+        # Core should contain 0, 1, and 2
+        self.assertIn(0, core)
+        self.assertIn(1, core)
+        self.assertIn(2, core)
 
-    x = claripy.BVS("x", 32)
-    y = claripy.BVS("y", 32)
+    def test_unsat_core_composite(self):
+        """SolverComposite returns the core of whichever independent child is unsat."""
+        s = claripy.SolverComposite(track=True)
 
-    # Add various constraints
-    s.add(x + y == 100)  # constraint 0
-    s.add(x > 60)  # constraint 1
-    s.add(y > 50)  # constraint 2 - makes it unsat with 0 and 1
-    s.add(x < 200)  # constraint 3 - not relevant
-    s.add(y < 200)  # constraint 4 - not relevant
+        x = claripy.BVS("x", 8)
+        y = claripy.BVS("y", 8)
 
-    # Should be unsat (x > 60 and y > 50 means x + y > 110)
-    assert not s.satisfiable()
+        # Contradictory group on x (constraints 0, 1) plus an independent,
+        # satisfiable group on y (constraint 2).
+        s.add(x > 10)
+        s.add(x < 5)
+        s.add(y == 3)
 
-    # Get unsat core
-    core = s.unsat_core()
-    assert len(core) > 0
-    # Core should contain 0, 1, and 2
-    assert 0 in core
-    assert 1 in core
-    assert 2 in core
+        self.assertFalse(s.satisfiable())
 
+        core = s.unsat_core()
+        self.assertGreater(len(core), 0)
+        self.assertIn(0, core)
+        self.assertIn(1, core)
+        # The independent, satisfiable constraint is not part of the core.
+        self.assertNotIn(2, core)
 
-def test_unsat_core_composite():
-    """SolverComposite returns the core of whichever independent child is unsat."""
-    s = claripy.SolverComposite(track=True)
-
-    x = claripy.BVS("x", 8)
-    y = claripy.BVS("y", 8)
-
-    # Contradictory group on x (constraints 0, 1) plus an independent,
-    # satisfiable group on y (constraint 2).
-    s.add(x > 10)
-    s.add(x < 5)
-    s.add(y == 3)
-
-    assert not s.satisfiable()
-
-    core = s.unsat_core()
-    assert len(core) > 0
-    assert 0 in core
-    assert 1 in core
-    # The independent, satisfiable constraint is not part of the core.
-    assert 2 not in core
-
-
-def test_unsat_core_composite_on_sat():
-    """A satisfiable composite solver has an empty unsat core."""
-    s = claripy.SolverComposite(track=True)
-    x = claripy.BVS("x", 8)
-    y = claripy.BVS("y", 8)
-    s.add(x > 1)
-    s.add(y < 10)
-    assert s.satisfiable()
-    assert s.unsat_core() == []
+    def test_unsat_core_composite_on_sat(self):
+        """A satisfiable composite solver has an empty unsat core."""
+        s = claripy.SolverComposite(track=True)
+        x = claripy.BVS("x", 8)
+        y = claripy.BVS("y", 8)
+        s.add(x > 1)
+        s.add(y < 10)
+        self.assertTrue(s.satisfiable())
+        self.assertEqual(s.unsat_core(), [])
 
 
 if __name__ == "__main__":
-    test_unsat_core_simple()
-    test_unsat_core_bool()
-    test_unsat_core_not_enabled()
-    test_unsat_core_on_sat()
-    test_unsat_core_complex()
-    test_unsat_core_composite()
-    test_unsat_core_composite_on_sat()
-    print("All tests passed!")
+    unittest.main()

--- a/crates/clarirs_py/tests/test_verbatim_annotations.py
+++ b/crates/clarirs_py/tests/test_verbatim_annotations.py
@@ -97,7 +97,3 @@ class TestVerbatimConstruction(unittest.TestCase):
         x = claripy.BVS("x", 64, explicit_name=True)
         expr = x + claripy.BVV(5, 64)
         self.assertEqual(pickle.loads(pickle.dumps(expr)).op, expr.op)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_vsa_bool_ops.py
+++ b/crates/clarirs_py/tests/test_vsa_bool_ops.py
@@ -208,7 +208,3 @@ class TestVSABoolOperations(unittest.TestCase):
         # like no solutions can be evaluated from it
         solutions = self.solver.eval(self.si_bottom, 100)
         self.assertEqual(len(solutions), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_vsa_bv_ops.py
+++ b/crates/clarirs_py/tests/test_vsa_bv_ops.py
@@ -965,7 +965,3 @@ class TestVSAPrecisionLoss(unittest.TestCase):
                 break
 
         self.assertTrue(found, "Result should contain some expected values after operations")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/crates/clarirs_py/tests/test_vsa_simplify_solving.py
+++ b/crates/clarirs_py/tests/test_vsa_simplify_solving.py
@@ -310,7 +310,3 @@ class TestVSASimplificationAndSolving(unittest.TestCase):
             self.assertFalse(self.solver.solution(self.si_bottom, 0))  # Nothing is a solution
         except AssertionError:
             pass  # Skip if the assertion fails
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
## Summary

Standardizes the `clarirs_py` Python test suite on `unittest`, matching the convention already documented in `.github/copilot-instructions.md` ("Python tests use `unittest`").

- Converted the three remaining pytest-style files (`test_batch_eval.py`, `test_solver_cacheless.py`, `test_unsat_core.py`) into `unittest.TestCase` classes:
  - bare `assert` → `self.assert*` (`assertTrue`/`assertEqual`/`assertIn`/`assertGreater`/`assertIs`/...)
  - `pytest.raises(Exception)` → `self.assertRaises(Exception)`, dropping the `import pytest`
- Removed the `if __name__ == "__main__": unittest.main()` guard from all 18 test files, since tests are only run through a runner.

## Testing

Tests remain discoverable and runnable under the CI's `pytest crates/clarirs_py/tests/` invocation. All test files pass `python -m py_compile`.

Note: I could not execute the suite in the sandbox — building the `claripy` extension requires `clarirs_z3`, whose `z3-sys` build script downloads z3 from GitHub releases, which is blocked in this environment. The changes are a mechanical assertion rewrite plus boilerplate removal, so runtime behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByqdUYabyQ2Vior3Taouzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByqdUYabyQ2Vior3Taouzh)_