### PR TITLE
fix: make the parameterless annotations picklable

### DIFF
--- a/crates/clarirs_py/src/annotation.rs
+++ b/crates/clarirs_py/src/annotation.rs
@@ -260,6 +260,10 @@ impl SimplificationAvoidanceAnnotation {
         false
     }
 
+    fn __reduce__<'py>(slf: PyRef<'py, Self>) -> (Bound<'py, PyType>, ()) {
+        (slf.py().get_type::<Self>(), ())
+    }
+
     fn __repr__(&self) -> &'static str {
         "SimplificationAvoidanceAnnotation()"
     }
@@ -345,6 +349,10 @@ impl EmptyStridedIntervalAnnotation {
         false
     }
 
+    fn __reduce__<'py>(slf: PyRef<'py, Self>) -> (Bound<'py, PyType>, ()) {
+        (slf.py().get_type::<Self>(), ())
+    }
+
     fn __repr__(&self) -> &'static str {
         "EmptyStridedIntervalAnnotation()"
     }
@@ -417,6 +425,10 @@ impl UninitializedAnnotation {
     #[classattr]
     fn eliminatable() -> bool {
         false
+    }
+
+    fn __reduce__<'py>(slf: PyRef<'py, Self>) -> (Bound<'py, PyType>, ()) {
+        (slf.py().get_type::<Self>(), ())
     }
 
     fn __repr__(&self) -> &'static str {


### PR DESCRIPTION
## Summary

`UninitializedAnnotation`, `SimplificationAvoidanceAnnotation`, and `EmptyStridedIntervalAnnotation` have no `__reduce__`, so pickling any of them raises:

```
TypeError: cannot pickle 'claripy.annotation.UninitializedAnnotation' object
```

The parameterized annotations (`StridedIntervalAnnotation`, `RegionAnnotation`) already implement `__reduce__`. This adds the trivial `(type, ())` form to the three parameterless ones so they round-trip through pickle.

## Impact

Surfaced by angr, where an `UninitializedAnnotation` rides on uninitialized memory and breaks serialization of any state/simulation-manager that touches it — `tests/serialization/test_serialization.py` and `tests/sim/test_fauxware.py::test_pickling_*` fail without this.

## Testing

`pickle.loads(pickle.dumps(A()))` round-trips for all three; the affected angr serialization/pickling tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)