### PR TITLE
perf: fast-path annotate to reuse the source node's metadata

### DIFF
--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -103,6 +103,32 @@ impl<'c> AstNode<'c> {
         }
     }
 
+    /// Construct a copy of `source` carrying a new annotation set. The op is
+    /// unchanged, so variables/depth/symbolic/type are identical to `source`
+    /// and are reused as-is; only the hash (supplied by the caller) and the
+    /// simplifiability flag depend on the annotations. This skips the recompute
+    /// `AstNode::new` would do -- notably `op.variables()`, a union over the
+    /// children -- which dominates when annotating many nodes.
+    pub(crate) fn reannotated(source: &Self, annotations: BTreeSet<Annotation>, hash: u64) -> Self {
+        let simplifiable = (source.symbolic
+            || !annotations
+                .iter()
+                .any(|a| !a.eliminatable() && !a.relocatable()))
+            && source.op.child_iter().all(|c| c.simplifiable());
+        Self {
+            op: source.op.clone(),
+            ctx: source.ctx,
+            hash,
+            ast_type: source.ast_type,
+            variables: source.variables.clone(),
+            depth: source.depth,
+            annotations,
+            symbolic: source.symbolic,
+            simplifiable,
+            simplified: AtomicU64::new(0),
+        }
+    }
+
     pub fn simplifiable(&self) -> bool {
         self.simplifiable
     }
@@ -123,13 +149,21 @@ impl<'c> AstNode<'c> {
         self: Arc<Self>,
         annotations: impl IntoIterator<Item = Annotation>,
     ) -> Result<Arc<Self>, ClarirsError> {
-        let combined = self
-            .annotations()
+        let mut combined: BTreeSet<Annotation> = self
+            .annotations
             .iter()
             .cloned()
             .chain(annotations)
             .collect();
-        self.context().make_ast_annotated(self.op.clone(), combined)
+        // A node carries its children's relocatable annotations (as
+        // `make_ast_annotated` does); idempotent when `self` already has them.
+        combined.extend(
+            self.op
+                .child_iter()
+                .flat_map(|c| c.annotations().clone())
+                .filter(|a| a.relocatable()),
+        );
+        self.context().make_ast_reannotated(&self, combined)
     }
 
     pub fn hash(&self) -> u64 {

--- a/crates/clarirs_core/src/context.rs
+++ b/crates/clarirs_core/src/context.rs
@@ -150,6 +150,23 @@ impl Context<'_> {
     }
 }
 
+impl<'c> Context<'c> {
+    /// Intern `source`'s op under a new annotation set. Unlike `make_ast_exact`,
+    /// this reuses `source`'s already-computed metadata instead of recomputing
+    /// it, since the op (and thus its type, variables, and depth) is unchanged.
+    /// Backs `AstNode::annotate`, which is hot in annotation-heavy analyses.
+    pub(crate) fn make_ast_reannotated(
+        &'c self,
+        source: &AstNode<'c>,
+        annotations: BTreeSet<Annotation>,
+    ) -> Result<AstRef<'c>, ClarirsError> {
+        let hash = structural_hash(source.ast_type(), source.op(), &annotations);
+        self.ast_cache.get_or_insert(hash, || {
+            Ok(Arc::new(AstNode::reannotated(source, annotations, hash)))
+        })
+    }
+}
+
 impl<'c> AstFactory<'c> for Context<'c> {
     fn intern_string(&self, s: impl AsRef<str>) -> InternedString {
         self.intern_string(s)


### PR DESCRIPTION
## Summary

`AstNode::annotate` rebuilt the node through `make_ast_annotated` → `AstNode::new`, which recomputes `variables` (a `BTreeSet` union over the children), `depth`, `symbolic`, and the inferred `AstType` on every call. But `annotate` doesn't change the op — only the annotation set — so all of that metadata is identical to the source node. Only the hash and `simplifiable` flag depend on the annotations.

This adds a factory method, `Context::make_ast_reannotated`, that interns the op under the new annotation set while reusing the source node's already-computed metadata (constructed via a small `AstNode::reannotated` constructor). It recomputes only the structural hash and `simplifiable`. `annotate` now just assembles the annotation set — folding in the children's relocatable annotations, matching `make_ast_annotated` — and calls the factory, so the caching/interning stays in `context.rs` alongside `make_ast_exact`. The resulting node, and its interned hash, are identical to before.

## Impact

`annotate` is extremely hot in consumers that annotate large numbers of nodes. In angr's reaching-definitions analysis (every definition is annotated), it was the single biggest cost in a profiled run (~34s self across 110k calls). With this change, one such angr test (`test_string_obf_finder`) drops from ~168s to ~142s.

## Testing

`cargo test -p clarirs_core --lib annotation` passes; the angr clarirs_py suite is unchanged (188 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)