### PR TITLE
perf(clarirs_py): cache Python annotations on Base

### DIFF
--- a/crates/clarirs_py/src/ast/base.rs
+++ b/crates/clarirs_py/src/ast/base.rs
@@ -16,21 +16,39 @@ pub struct Base {
     errored: Py<PySet>,
     name: Option<String>,
     encoded_name: Option<Vec<u8>>,
+    /// The Python annotation objects for this AST, materialized once at
+    /// construction. Holding the completed collection here lets the annotation
+    /// read accessors answer entirely from Python objects, without reaching
+    /// back into the Rust core annotations (and the pickle/cache round-trip
+    /// that reconstructing them entails) on every access. It is kept in the
+    /// same order as `inner.annotations()` (the core `BTreeSet`'s sorted
+    /// order), so the two can be zipped when rebuilding the AST.
+    annotations: Vec<Py<PyAnnotation>>,
 }
 
 impl Base {
-    pub fn new(py: Python, inner: &AstRef<'static>) -> Self {
+    pub fn new(py: Python, inner: &AstRef<'static>) -> Result<Self, ClaripyError> {
         Self::new_with_name(py, inner, None)
     }
 
-    pub fn new_with_name(py: Python, inner: &AstRef<'static>, name: Option<String>) -> Self {
+    pub fn new_with_name(
+        py: Python,
+        inner: &AstRef<'static>,
+        name: Option<String>,
+    ) -> Result<Self, ClaripyError> {
         let encoded_name = name.as_ref().map(|name| name.as_bytes().to_vec());
-        Self {
+        let annotations = inner
+            .annotations()
+            .iter()
+            .map(|annotation| PyAnnotation::from_annotation(py, annotation).map(Bound::unbind))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
             inner: inner.clone(),
             errored: PySet::empty(py).expect("Failed to create PySet").unbind(),
             name,
             encoded_name,
-        }
+            annotations,
+        })
     }
 
     pub fn to_ast(self_: Bound<'_, Base>) -> Result<AstRef<'static>, ClaripyError> {
@@ -114,14 +132,10 @@ impl Base {
     }
 
     #[getter]
-    pub fn annotations<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> Result<Vec<Bound<'py, PyAnnotation>>, ClaripyError> {
-        self.inner
-            .annotations()
+    pub fn annotations<'py>(&self, py: Python<'py>) -> Vec<Bound<'py, PyAnnotation>> {
+        self.annotations
             .iter()
-            .map(|annotation| PyAnnotation::from_annotation(py, annotation))
+            .map(|annotation| annotation.bind(py).clone())
             .collect()
     }
 
@@ -258,8 +272,8 @@ impl Base {
         annotation_type: Bound<'_, PyType>,
     ) -> Result<bool, ClaripyError> {
         let py = annotation_type.py();
-        for annotation in self.inner.annotations() {
-            if PyAnnotation::from_annotation(py, annotation)?.is_instance(&annotation_type)? {
+        for annotation in &self.annotations {
+            if annotation.bind(py).is_instance(&annotation_type)? {
                 return Ok(true);
             }
         }
@@ -272,10 +286,10 @@ impl Base {
     ) -> Result<Vec<Bound<'py, PyAnnotation>>, ClaripyError> {
         let py = annotation_type.py();
         let mut matching = Vec::new();
-        for annotation in self.inner.annotations() {
-            let annotation = PyAnnotation::from_annotation(py, annotation)?;
+        for annotation in &self.annotations {
+            let annotation = annotation.bind(py);
             if annotation.is_instance(&annotation_type)? {
-                matching.push(annotation);
+                matching.push(annotation.clone());
             }
         }
         Ok(matching)
@@ -286,10 +300,10 @@ impl Base {
         annotation_type: Bound<'py, PyType>,
     ) -> Result<Option<Bound<'py, PyAnnotation>>, ClaripyError> {
         let py = annotation_type.py();
-        for annotation in self.inner.annotations() {
-            let annotation = PyAnnotation::from_annotation(py, annotation)?;
+        for annotation in &self.annotations {
+            let annotation = annotation.bind(py);
             if annotation.is_instance(&annotation_type)? {
-                return Ok(Some(annotation));
+                return Ok(Some(annotation.clone()));
             }
         }
         Ok(None)
@@ -440,8 +454,11 @@ impl Base {
     ) -> Result<Bound<'py, Base>, ClaripyError> {
         let py = annotation_type.py();
         let mut kept = BTreeSet::new();
-        for annotation in self.inner.annotations() {
-            if !PyAnnotation::from_annotation(py, annotation)?.is_instance(&annotation_type)? {
+        // `self.annotations` mirrors `self.inner.annotations()` in order, so the
+        // cached Python objects can drive the type check while the core
+        // annotations are what we rebuild from.
+        for (py_annotation, annotation) in self.annotations.iter().zip(self.inner.annotations()) {
+            if !py_annotation.bind(py).is_instance(&annotation_type)? {
                 kept.insert(annotation.clone());
             }
         }

--- a/crates/clarirs_py/src/ast/base.rs
+++ b/crates/clarirs_py/src/ast/base.rs
@@ -16,13 +16,7 @@ pub struct Base {
     errored: Py<PySet>,
     name: Option<String>,
     encoded_name: Option<Vec<u8>>,
-    /// The Python annotation objects for this AST, materialized once at
-    /// construction. Holding the completed collection here lets the annotation
-    /// read accessors answer entirely from Python objects, without reaching
-    /// back into the Rust core annotations (and the pickle/cache round-trip
-    /// that reconstructing them entails) on every access. It is kept in the
-    /// same order as `inner.annotations()` (the core `BTreeSet`'s sorted
-    /// order), so the two can be zipped when rebuilding the AST.
+    /// Python annotation objects materialized once at construction, in the same order as `inner.annotations()`, so reads avoid the Rust round-trip.
     annotations: Vec<Py<PyAnnotation>>,
 }
 

--- a/crates/clarirs_py/src/ast/bool.rs
+++ b/crates/clarirs_py/src/ast/bool.rs
@@ -50,9 +50,11 @@ impl Bool {
         } else {
             let this = Bound::new(
                 py,
-                PyClassInitializer::from(Base::new_with_name(py, inner, name)?).add_subclass(Bool {
-                    inner: inner.clone(),
-                }),
+                PyClassInitializer::from(Base::new_with_name(py, inner, name)?).add_subclass(
+                    Bool {
+                        inner: inner.clone(),
+                    },
+                ),
             )?;
             let weakref = PyWeakrefReference::new(&this)?;
             PY_BOOL_CACHE.insert(inner.hash(), weakref.unbind());

--- a/crates/clarirs_py/src/ast/bool.rs
+++ b/crates/clarirs_py/src/ast/bool.rs
@@ -50,7 +50,7 @@ impl Bool {
         } else {
             let this = Bound::new(
                 py,
-                PyClassInitializer::from(Base::new_with_name(py, inner, name)).add_subclass(Bool {
+                PyClassInitializer::from(Base::new_with_name(py, inner, name)?).add_subclass(Bool {
                     inner: inner.clone(),
                 }),
             )?;

--- a/crates/clarirs_py/src/ast/bv.rs
+++ b/crates/clarirs_py/src/ast/bv.rs
@@ -48,7 +48,7 @@ impl BV {
         } else {
             let this = Bound::new(
                 py,
-                PyClassInitializer::from(Base::new_with_name(py, inner, name))
+                PyClassInitializer::from(Base::new_with_name(py, inner, name)?)
                     .add_subclass(Bits::new())
                     .add_subclass(BV {
                         inner: inner.clone(),

--- a/crates/clarirs_py/src/ast/fp.rs
+++ b/crates/clarirs_py/src/ast/fp.rs
@@ -183,7 +183,7 @@ impl FP {
         } else {
             let this = Py::new(
                 py,
-                PyClassInitializer::from(Base::new_with_name(py, inner, name))
+                PyClassInitializer::from(Base::new_with_name(py, inner, name)?)
                     .add_subclass(Bits::new())
                     .add_subclass(FP {
                         inner: inner.clone(),

--- a/crates/clarirs_py/src/ast/string.rs
+++ b/crates/clarirs_py/src/ast/string.rs
@@ -44,7 +44,7 @@ impl PyAstString {
         } else {
             let this = Py::new(
                 py,
-                PyClassInitializer::from(Base::new_with_name(py, inner, name)).add_subclass(
+                PyClassInitializer::from(Base::new_with_name(py, inner, name)?).add_subclass(
                     PyAstString {
                         inner: inner.clone(),
                     },


### PR DESCRIPTION
## Problem

Annotation read accessors on `Base` reconstructed the Python annotation objects from the Rust core annotations on every access. For user-defined annotations that meant a `pickle.loads` round-trip (plus a weakref-cache lookup) *per read*, which was slow for code that reads annotations repeatedly.

## Change

`Base` now holds a completed collection of its annotations so reads never touch the Rust side:

- Added an `annotations: Vec<Py<PyAnnotation>>` field to `Base`, materialized **once** at construction in `new_with_name`, kept in the same order as the core `BTreeSet<Annotation>`.
- The read accessors now answer entirely from these cached objects:
  - `annotations` getter — returns cheap clones of the cached `Py` handles (no longer fallible).
  - `has_annotation_type`, `get_annotations_by_type`, `get_annotation` — iterate the cached objects for the `isinstance` checks.
- `clear_annotation_type` (which rebuilds the AST) zips the cached Python objects against `self.inner.annotations()`, driving the type check from the Python objects while rebuilding from the core values. The order match is sound because the cache is built directly from the same sorted `BTreeSet`.
- `Base::new`/`new_with_name` now return a `Result` (building the cached objects can fail); the four AST subclass constructors (`bool`, `bv`, `fp`, `string`) propagate it with `?`.

The write paths (`annotate`, `remove_annotation`, etc.) already rebuild a fresh AST and wrap it via `from_ast` → `new_with_name`, so the cache is rebuilt from the new inner each time and stays consistent.

## Verification

- `cargo build -p clarirs_py` compiles cleanly.
- Built the extension with `maturin develop` and ran the Python test suite: **195 passed, 1 skipped**, including the annotation suites (`test_annotations.py`, `test_verbatim_annotations.py`, `test_unknown_annotation_identity.py`), which cover identity preservation (`assertIs`) and the `cleared.annotations == []` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YG8KXPw61ocM9V7pmytSSf)_