### PR TITLE
Refactor AST factory to separate node construction from interning

### DIFF
--- a/crates/clarirs_core/src/ast/factory.rs
+++ b/crates/clarirs_core/src/ast/factory.rs
@@ -10,16 +10,26 @@ pub trait AstFactory<'c>: Sized {
     // Required methods
     fn intern_string(&self, s: impl AsRef<str>) -> InternedString;
 
-    /// The single node constructor. All other `make_*` helpers delegate here;
-    /// the node's type is inferred from the operation. The node gets exactly
-    /// `annotations`; relocatable annotations of children are NOT collected.
+    /// Intern a fully-constructed node into its canonical shared handle.
+    fn intern_ast(&'c self, node: AstNode<'c>) -> Result<AstRef<'c>, ClarirsError>;
+
+    /// The context that owns the nodes this factory builds.
+    fn context(&'c self) -> &'c Context<'c>;
+
+    // Provided methods
+
+    /// The single node constructor entry point all `make_*` helpers delegate to.
+    /// The node gets exactly `annotations`; relocatable annotations of children
+    /// are NOT collected.
     fn make_ast_exact(
         &'c self,
         op: AstOp<'c>,
         annotations: BTreeSet<Annotation>,
-    ) -> Result<AstRef<'c>, ClarirsError>;
-
-    // Provided methods
+    ) -> Result<AstRef<'c>, ClarirsError> {
+        op.validate()?;
+        let ast_type = op.infer_type();
+        self.intern_ast(AstNode::new(self.context(), op, annotations, ast_type))
+    }
 
     /// Construct a node with `annotations` plus the relocatable annotations of
     /// the op's children, mirroring how operations propagate annotations.

--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -7,6 +7,7 @@ use std::{
 
 use crate::{
     ast::op::{AstOp, AstOpChildIter, AstType},
+    context::structural_hash,
     prelude::*,
 };
 
@@ -33,12 +34,6 @@ pub struct AstNode<'c> {
     /// Hash of this node's simplified form (`0` = none), resolved via the AST cache.
     #[serde(skip)]
     pub(crate) simplified: AtomicU64,
-}
-
-impl Drop for AstNode<'_> {
-    fn drop(&mut self) {
-        self.ctx.drop_cache(self.hash);
-    }
 }
 
 impl Debug for AstNode<'_> {
@@ -68,11 +63,11 @@ impl<'c> HasContext<'c> for AstNode<'c> {
 }
 
 impl<'c> AstNode<'c> {
+    /// Build a node, deriving its cached metadata including the structural hash.
     pub(crate) fn new(
         ctx: &'c Context<'c>,
         op: AstOp<'c>,
         annotations: BTreeSet<Annotation>,
-        hash: u64,
         ast_type: AstType,
     ) -> Self {
         let variables = op.variables();
@@ -88,6 +83,8 @@ impl<'c> AstNode<'c> {
                 .iter()
                 .any(|a| !a.eliminatable() && !a.relocatable()))
             && op.child_iter().all(|c| c.simplifiable());
+
+        let hash = structural_hash(ast_type, &op, &annotations);
 
         Self {
             op,

--- a/crates/clarirs_core/src/cache.rs
+++ b/crates/clarirs_core/src/cache.rs
@@ -17,8 +17,6 @@ pub trait Cache<K, V> {
 
     fn insert(&self, key: K, value: &V);
 
-    fn drop(&self, key: K);
-
     fn get_or_insert<E>(&self, key: K, value_cv: impl FnOnce() -> Result<V, E>) -> Result<V, E> {
         if let Some(value) = self.get(&key) {
             return Ok(value);
@@ -35,10 +33,6 @@ impl<K, V> Cache<K, V> for () {
     }
 
     fn insert(&self, _key: K, _value: &V) {
-        // No-op
-    }
-
-    fn drop(&self, _key: K) {
         // No-op
     }
 }
@@ -60,10 +54,6 @@ impl<K: Hash + Eq, V: Clone> Cache<K, V> for GenericCache<K, V> {
 
     fn insert(&self, key: K, value: &V) {
         self.0.write().unwrap().insert(key, value.clone());
-    }
-
-    fn drop(&self, key: K) {
-        self.0.write().unwrap().remove(&key);
     }
 }
 
@@ -90,10 +80,6 @@ impl<'c> Cache<u64, AstRef<'c>> for AstCache<'c> {
         }
 
         inner.insert(key, Arc::downgrade(value));
-    }
-
-    fn drop(&self, key: u64) {
-        self.0.write().unwrap().remove(&key);
     }
 
     // Collision detection must recompute and compare on every call, even a cache

--- a/crates/clarirs_core/src/context.rs
+++ b/crates/clarirs_core/src/context.rs
@@ -143,11 +143,6 @@ impl Context<'_> {
         interner.insert(Arc::clone(&arc), Arc::clone(&arc));
         InternedString(arc)
     }
-
-    pub fn drop_cache(&self, hash: u64) {
-        self.ast_cache.drop(hash);
-        self.excavate_ite_cache.drop(hash);
-    }
 }
 
 impl<'c> AstFactory<'c> for Context<'c> {
@@ -155,30 +150,14 @@ impl<'c> AstFactory<'c> for Context<'c> {
         self.intern_string(s)
     }
 
-    fn make_ast_exact(
-        &'c self,
-        op: AstOp<'c>,
-        annotations: BTreeSet<Annotation>,
-    ) -> Result<AstRef<'c>, ClarirsError> {
-        // Every construction funnels through here, so checking the op's child
-        // types in this one place gives the whole API runtime type checking.
-        op.validate()?;
+    fn context(&'c self) -> &'c Context<'c> {
+        self
+    }
 
-        // The node's type is inferred from the op and its children's cached
-        // types; this also provides domain separation in the hash so that
-        // structurally-identical ops of different sorts hash differently.
-        let ast_type = op.infer_type();
-        let hash = structural_hash(ast_type, &op, &annotations);
-
-        self.ast_cache.get_or_insert::<ClarirsError>(hash, || {
-            Ok(Arc::new(AstNode::new(
-                self,
-                op.clone(),
-                annotations.clone(),
-                hash,
-                ast_type,
-            )))
-        })
+    fn intern_ast(&'c self, node: AstNode<'c>) -> Result<AstRef<'c>, ClarirsError> {
+        let hash = node.hash();
+        self.ast_cache
+            .get_or_insert::<ClarirsError>(hash, || Ok(Arc::new(node)))
     }
 }
 


### PR DESCRIPTION
## Summary
This PR refactors the AST factory pattern to cleanly separate node construction from cache interning, improving the separation of concerns and simplifying the caching layer.

## Key Changes

- **Split `AstFactory` trait responsibilities**: 
  - Moved `make_ast_exact` from a required method to a provided method with a default implementation
  - Added two new required methods: `intern_ast` (for cache interning) and `context` (for accessing the owning context)
  - This allows `make_ast_exact` to be implemented once in the trait rather than duplicated across implementations

- **Simplified cache trait**:
  - Removed the `drop` method from the `Cache` trait and all implementations
  - Cache entries are now managed purely through insertion and retrieval, relying on standard Rust ownership semantics

- **Removed manual cache invalidation**:
  - Deleted `Context::drop_cache` method that was previously called in `AstNode::Drop`
  - Removed the `Drop` impl from `AstNode` entirely, eliminating manual cache management

- **Moved hash computation**:
  - Hash is now computed inside `AstNode::new` rather than being passed as a parameter
  - This ensures the hash is always correctly derived from the node's content

## Implementation Details

The refactoring moves the structural hash computation into `AstNode::new`, making it a derived property rather than an external input. The `AstFactory::make_ast_exact` method now has a single, canonical implementation that validates the operation, infers the type, constructs the node, and interns it through the new `intern_ast` method.

This eliminates the need for manual cache invalidation via `Drop` implementations, simplifying the lifecycle management of AST nodes and reducing the surface area of the cache trait.

https://claude.ai/code/session_013NceVGcsfBHcoEVsUUB9ZV