### PR TITLE
Optimize variable set sharing with Arc to avoid redundant allocations

### DIFF
--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -23,10 +23,8 @@ pub struct AstNode<'c> {
     ctx: &'c Context<'c>,
     #[serde(skip)]
     hash: u64,
-    /// The variables appearing in this subtree. Stored behind an `Arc` so that
-    /// nodes whose variable set is identical to a child's (unary ops, binary ops
-    /// with a concrete operand, etc.) share a single allocation instead of each
-    /// rebuilding the set. See [`AstOp::variables`].
+    /// Variables in this subtree, shared via `Arc` to avoid rebuilding sets
+    /// identical to a child's. See [`AstOp::variables`].
     #[serde(skip)]
     variables: Arc<BTreeSet<InternedString>>,
     #[serde(skip)]
@@ -149,9 +147,7 @@ impl<'c> AstNode<'c> {
         &self.variables
     }
 
-    /// A cheap, refcounted handle to this node's variable set. Cloning it only
-    /// bumps a reference count, and parents reuse it directly when their own
-    /// variable set is identical (see [`AstOp::variables`]).
+    /// A cheap, refcounted handle to this node's variable set.
     pub fn variables_arc(&self) -> Arc<BTreeSet<InternedString>> {
         self.variables.clone()
     }

--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -23,8 +23,12 @@ pub struct AstNode<'c> {
     ctx: &'c Context<'c>,
     #[serde(skip)]
     hash: u64,
+    /// The variables appearing in this subtree. Stored behind an `Arc` so that
+    /// nodes whose variable set is identical to a child's (unary ops, binary ops
+    /// with a concrete operand, etc.) share a single allocation instead of each
+    /// rebuilding the set. See [`AstOp::variables`].
     #[serde(skip)]
-    variables: BTreeSet<InternedString>,
+    variables: Arc<BTreeSet<InternedString>>,
     #[serde(skip)]
     depth: u32,
     #[serde(skip)]
@@ -143,6 +147,13 @@ impl<'c> AstNode<'c> {
 
     pub fn variables(&self) -> &BTreeSet<InternedString> {
         &self.variables
+    }
+
+    /// A cheap, refcounted handle to this node's variable set. Cloning it only
+    /// bumps a reference count, and parents reuse it directly when their own
+    /// variable set is identical (see [`AstOp::variables`]).
+    pub fn variables_arc(&self) -> Arc<BTreeSet<InternedString>> {
+        self.variables.clone()
     }
 
     pub fn size(&self) -> u32 {

--- a/crates/clarirs_core/src/ast/op.rs
+++ b/crates/clarirs_core/src/ast/op.rs
@@ -7,8 +7,7 @@ use serde::Serialize;
 use crate::ast::node::AstRef;
 use crate::prelude::*;
 
-/// A single shared, empty variable set reused by every concrete node, so that
-/// the common "no variables" case never allocates per node.
+/// A single shared, empty variable set reused by every concrete node.
 fn empty_variables() -> Arc<BTreeSet<InternedString>> {
     static EMPTY: LazyLock<Arc<BTreeSet<InternedString>>> =
         LazyLock::new(|| Arc::new(BTreeSet::new()));
@@ -361,14 +360,10 @@ impl<'c> AstOp<'c> {
         )
     }
 
-    /// The set of variables appearing in this operation's subtree.
-    ///
-    /// Returned behind an `Arc` so that identical sets are shared rather than
-    /// reallocated on every node. In particular, when exactly one child
-    /// contributes variables (or several children share the very same set), the
-    /// parent reuses that child's `Arc` directly and performs no allocation at
-    /// all — only nodes that genuinely merge distinct variable sets build a new
-    /// one.
+    /// The set of variables in this operation's subtree, behind an `Arc` so that
+    /// identical sets are shared rather than reallocated on every node. When a
+    /// single child contributes all the variables (or children share the same
+    /// set) the parent reuses that child's `Arc`; only genuine merges allocate.
     pub fn variables(&self) -> Arc<BTreeSet<InternedString>> {
         match self {
             AstOp::BoolS(s) | AstOp::BVS(s, _) | AstOp::FPS(s, _) | AstOp::StringS(s) => {
@@ -377,8 +372,6 @@ impl<'c> AstOp<'c> {
                 Arc::new(set)
             }
             _ => {
-                // `shared` holds a child's Arc we can hand back untouched;
-                // `owned` holds a freshly-merged set once two distinct sets meet.
                 let mut shared: Option<Arc<BTreeSet<InternedString>>> = None;
                 let mut owned: Option<BTreeSet<InternedString>> = None;
 
@@ -389,20 +382,15 @@ impl<'c> AstOp<'c> {
                     }
 
                     match (&mut owned, &shared) {
-                        // Already merging: fold this child in.
                         (Some(set), _) => set.extend(child_vars.iter().cloned()),
-                        // First contributing child: tentatively reuse its Arc.
                         (None, None) => shared = Some(child_vars),
-                        // A second contributing child arrives.
                         (None, Some(prev)) => {
                             if !Arc::ptr_eq(prev, &child_vars) {
-                                // Distinct sets: start an owned merge of both.
                                 let mut set = (**prev).clone();
                                 set.extend(child_vars.iter().cloned());
                                 owned = Some(set);
                                 shared = None;
                             }
-                            // Same underlying set: keep sharing, nothing to do.
                         }
                     }
                 }

--- a/crates/clarirs_core/src/ast/op.rs
+++ b/crates/clarirs_core/src/ast/op.rs
@@ -1,10 +1,19 @@
 use std::collections::BTreeSet;
 use std::fmt::Debug;
+use std::sync::{Arc, LazyLock};
 
 use serde::Serialize;
 
 use crate::ast::node::AstRef;
 use crate::prelude::*;
+
+/// A single shared, empty variable set reused by every concrete node, so that
+/// the common "no variables" case never allocates per node.
+fn empty_variables() -> Arc<BTreeSet<InternedString>> {
+    static EMPTY: LazyLock<Arc<BTreeSet<InternedString>>> =
+        LazyLock::new(|| Arc::new(BTreeSet::new()));
+    EMPTY.clone()
+}
 
 /// The runtime type ("sort") of an AST node. Stored on every [`AstNode`] so the
 /// type of an expression can be queried without inspecting its operation, and
@@ -352,19 +361,56 @@ impl<'c> AstOp<'c> {
         )
     }
 
-    pub fn variables(&self) -> BTreeSet<InternedString> {
+    /// The set of variables appearing in this operation's subtree.
+    ///
+    /// Returned behind an `Arc` so that identical sets are shared rather than
+    /// reallocated on every node. In particular, when exactly one child
+    /// contributes variables (or several children share the very same set), the
+    /// parent reuses that child's `Arc` directly and performs no allocation at
+    /// all — only nodes that genuinely merge distinct variable sets build a new
+    /// one.
+    pub fn variables(&self) -> Arc<BTreeSet<InternedString>> {
         match self {
             AstOp::BoolS(s) | AstOp::BVS(s, _) | AstOp::FPS(s, _) | AstOp::StringS(s) => {
                 let mut set = BTreeSet::new();
                 set.insert(s.clone());
-                set
+                Arc::new(set)
             }
             _ => {
-                let mut set = BTreeSet::new();
+                // `shared` holds a child's Arc we can hand back untouched;
+                // `owned` holds a freshly-merged set once two distinct sets meet.
+                let mut shared: Option<Arc<BTreeSet<InternedString>>> = None;
+                let mut owned: Option<BTreeSet<InternedString>> = None;
+
                 for child in self.child_iter() {
-                    set.extend(child.variables().iter().cloned());
+                    let child_vars = child.variables_arc();
+                    if child_vars.is_empty() {
+                        continue;
+                    }
+
+                    match (&mut owned, &shared) {
+                        // Already merging: fold this child in.
+                        (Some(set), _) => set.extend(child_vars.iter().cloned()),
+                        // First contributing child: tentatively reuse its Arc.
+                        (None, None) => shared = Some(child_vars),
+                        // A second contributing child arrives.
+                        (None, Some(prev)) => {
+                            if !Arc::ptr_eq(prev, &child_vars) {
+                                // Distinct sets: start an owned merge of both.
+                                let mut set = (**prev).clone();
+                                set.extend(child_vars.iter().cloned());
+                                owned = Some(set);
+                                shared = None;
+                            }
+                            // Same underlying set: keep sharing, nothing to do.
+                        }
+                    }
                 }
-                set
+
+                match owned {
+                    Some(set) => Arc::new(set),
+                    None => shared.unwrap_or_else(empty_variables),
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR optimizes memory usage and performance by sharing variable sets across AST nodes using `Arc` (atomic reference counting). Instead of cloning variable sets at every node, identical sets are now shared via reference counting, reducing allocations and improving cache locality.

## Key Changes
- **Changed `variables()` return type** from `BTreeSet<InternedString>` to `Arc<BTreeSet<InternedString>>` to enable sharing
- **Implemented smart set merging logic** that:
  - Reuses a child's `Arc` when it's the only contributor or all children share the same set
  - Only allocates a new set when genuinely merging different variable sets from multiple children
  - Skips empty variable sets to avoid unnecessary processing
- **Added `variables_arc()` method** to `AstNode` for cheap cloning of the refcounted handle
- **Added `empty_variables()` helper** using `LazyLock` to provide a single shared empty set instance across all nodes
- **Updated `AstNode` struct** to store variables as `Arc<BTreeSet<InternedString>>` with documentation explaining the sharing strategy

## Implementation Details
The variable collection logic now tracks state with two optional fields (`shared` and `owned`) to determine whether to reuse an existing `Arc` or create a new merged set. This approach minimizes allocations by:
- Reusing the first non-empty child's `Arc` if no merging is needed
- Using pointer equality checks (`Arc::ptr_eq`) to detect when children already share the same set
- Only cloning and merging when encountering genuinely different variable sets

https://claude.ai/code/session_01RSxAHXhjzDF1ffHyvaUVGS