### PR TITLE
Infer AstNode type in constructor instead of passing it in

### DIFF
--- a/crates/clarirs_core/src/ast/factory.rs
+++ b/crates/clarirs_core/src/ast/factory.rs
@@ -27,8 +27,7 @@ pub trait AstFactory<'c>: Sized {
         annotations: BTreeSet<Annotation>,
     ) -> Result<AstRef<'c>, ClarirsError> {
         op.validate()?;
-        let ast_type = op.infer_type();
-        self.intern_ast(AstNode::new(self.context(), op, annotations, ast_type))
+        self.intern_ast(AstNode::new(self.context(), op, annotations))
     }
 
     /// Construct a node with `annotations` plus the relocatable annotations of

--- a/crates/clarirs_core/src/ast/node.rs
+++ b/crates/clarirs_core/src/ast/node.rs
@@ -64,12 +64,13 @@ impl<'c> HasContext<'c> for AstNode<'c> {
 
 impl<'c> AstNode<'c> {
     /// Build a node, deriving its cached metadata including the structural hash.
+    /// The node's [`AstType`] is inferred from the operation.
     pub(crate) fn new(
         ctx: &'c Context<'c>,
         op: AstOp<'c>,
         annotations: BTreeSet<Annotation>,
-        ast_type: AstType,
     ) -> Self {
+        let ast_type = op.infer_type();
         let variables = op.variables();
         let depth = 1 + op.child_iter().map(|c| c.depth()).max().unwrap_or(0);
         // Symbolic propagates from: having variables, the op itself being inherently


### PR DESCRIPTION
## Summary

`AstNode::new` no longer takes an `AstType` parameter. Instead it infers the node's type internally by calling `op.infer_type()`.

The sole caller, `AstFactory::make_ast_exact`, already computed `op.infer_type()` immediately before constructing the node and threaded the result through. Moving the inference into the constructor removes that redundant plumbing and keeps type derivation co-located with the rest of the node's cached-metadata computation.

## Changes

- `crates/clarirs_core/src/ast/node.rs`: `AstNode::new` drops the `ast_type` argument and computes `let ast_type = op.infer_type();` itself.
- `crates/clarirs_core/src/ast/factory.rs`: `make_ast_exact` no longer computes/passes `ast_type`.

## Testing

- `cargo build -p clarirs_core`
- `cargo test -p clarirs_core` (134 unit tests + doctests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1NQuBTGTJYDg9qic7Uiw4)_