### PR TITLE
Fix unicode dashes and unused variable in tests

### DIFF
--- a/crates/clarirs_py/tests/test_canonicalize.py
+++ b/crates/clarirs_py/tests/test_canonicalize.py
@@ -58,7 +58,7 @@ class TestCanonicalize(unittest.TestCase):
         # claripy passes an itertools.count; it is advanced in place and
         # returned as-is.
         counter = itertools.count(0)
-        _, returned, canon = (x + y).canonicalize(counter=counter)
+        _, returned, _canon = (x + y).canonicalize(counter=counter)
         self.assertIs(returned, counter)
         # Two distinct variables consumed v0 and v1; next value is 2.
         self.assertEqual(next(counter), 2)

--- a/crates/clarirs_py/tests/test_fp_ops.py
+++ b/crates/clarirs_py/tests/test_fp_ops.py
@@ -314,7 +314,7 @@ class TestFPOperations(unittest.TestCase):
         result = self.fp_neg1 < self.fp1
         self._check_equal(result, True)
 
-        # zeros (+0 and −0 are equal, so < is False both ways)
+        # zeros (+0 and -0 are equal, so < is False both ways)
         result = self.fp_neg_zero < self.fp_zero
         self._check_equal(result, False)
 
@@ -355,7 +355,7 @@ class TestFPOperations(unittest.TestCase):
         self._check_equal(result, False)
 
     def test_leq(self):
-        """Test less‑than‑or‑equal (<=) for all operand kinds"""
+        """Test less-than-or-equal (<=) for all operand kinds"""
 
         # Finite positives
         result = self.fp1 <= self.fp2
@@ -396,7 +396,7 @@ class TestFPOperations(unittest.TestCase):
         result = self.fp_neg1 <= self.fp1
         self._check_equal(result, True)
 
-        # zeros (+0 and −0 are equal, so ≤ is True both ways)
+        # zeros (+0 and -0 are equal, so ≤ is True both ways)
         result = self.fp_neg_zero <= self.fp_zero
         self._check_equal(result, True)
 
@@ -471,7 +471,7 @@ class TestFPOperations(unittest.TestCase):
         result = self.fp_neg1 > self.fp1
         self._check_equal(result, False)
 
-        # Zeros (+0 and −0 are equal: > is False both ways)
+        # Zeros (+0 and -0 are equal: > is False both ways)
         result = self.fp_neg_zero > self.fp_zero
         self._check_equal(result, False)
 
@@ -501,7 +501,7 @@ class TestFPOperations(unittest.TestCase):
         result = self.fp_inf > self.fp_inf  # ∞ > ∞ is False
         self._check_equal(result, False)
 
-        result = self.fp_neg_inf > self.fp_neg_inf  # −∞ > −∞ is False
+        result = self.fp_neg_inf > self.fp_neg_inf  # -∞ > -∞ is False
         self._check_equal(result, False)
 
         # NaN comparisons: all ordered comparisons are False
@@ -555,7 +555,7 @@ class TestFPOperations(unittest.TestCase):
         result = self.fp_neg1 >= self.fp1
         self._check_equal(result, False)
 
-        # Zeros (+0 and −0 are equal: ≥ is True both ways)
+        # Zeros (+0 and -0 are equal: ≥ is True both ways)
         result = self.fp_neg_zero >= self.fp_zero
         self._check_equal(result, True)
 
@@ -585,7 +585,7 @@ class TestFPOperations(unittest.TestCase):
         result = self.fp_inf >= self.fp_inf  # ∞ ≥ ∞
         self._check_equal(result, True)
 
-        result = self.fp_neg_inf >= self.fp_neg_inf  # −∞ ≥ −∞
+        result = self.fp_neg_inf >= self.fp_neg_inf  # -∞ ≥ -∞
         self._check_equal(result, True)
 
         # NaN comparisons: all ordered comparisons are False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ manifest-path = "crates/clarirs_py/Cargo.toml"
 dev = [
     "pytest",
 ]
+
+[tool.ruff.lint]
+select = ["RUF"]


### PR DESCRIPTION
This PR makes minor cleanup changes to the test suite to improve code quality and consistency.

**Key changes:**
- Replaced unicode minus signs (−) and dashes (‑) with standard ASCII hyphens (-) in test comments across `test_fp_ops.py` for better readability and consistency
- Renamed unused variable `canon` to `_canon` in `test_canonicalize.py` to follow Python conventions for intentionally unused variables
- Added Ruff linting configuration to `pyproject.toml` to enforce code quality standards

These changes improve code consistency and prepare the codebase for stricter linting rules.

https://claude.ai/code/session_01TnWdefhPWHAkHR5tMnusB5