### PR TITLE
Fix clippy warnings across workspace

### DIFF
--- a/crates/clarirs_core/src/algorithms/find_variable.rs
+++ b/crates/clarirs_core/src/algorithms/find_variable.rs
@@ -20,7 +20,7 @@ mod tests {
         let ctx = Context::new();
         let x = ctx.bvs("x", 32)?;
         let y_name = ctx.intern_string("y");
-        let result = find_variable(x.into(), &y_name);
+        let result = find_variable(x, &y_name);
         assert!(result.is_none());
         Ok(())
     }
@@ -30,7 +30,7 @@ mod tests {
         let ctx = Context::new();
         let x = ctx.bvs("x", 32)?;
         let x_name = ctx.intern_string("x");
-        let result = find_variable(x.clone().into(), &x_name);
+        let result = find_variable(x.clone(), &x_name);
         assert!(result.is_some());
         assert_eq!(result.unwrap().variables(), x.variables());
         Ok(())
@@ -44,7 +44,7 @@ mod tests {
         let expr = ctx.add(&x, &y)?;
 
         let x_name = ctx.intern_string("x");
-        let result = find_variable(expr.into(), &x_name);
+        let result = find_variable(expr, &x_name);
         assert!(result.is_some());
         let found = result.unwrap();
         assert!(found.variables().contains("x"));
@@ -60,7 +60,7 @@ mod tests {
         let expr = ctx.mul(&ctx.add(&x, &y)?, &z)?;
 
         let x_name = ctx.intern_string("x");
-        let result = find_variable(expr.into(), &x_name);
+        let result = find_variable(expr, &x_name);
         assert!(result.is_some());
         let found = result.unwrap();
         assert!(found.variables().contains("x"));

--- a/crates/clarirs_core/src/algorithms/post_order.rs
+++ b/crates/clarirs_core/src/algorithms/post_order.rs
@@ -200,10 +200,7 @@ mod tests {
 
         // Compute expected counts:
         // First run should process: x, y, add1, x, y, add2, mul => 7 nodes
-        assert_eq!(
-            first_visited,
-            vec![x.into(), y.into(), add1.into(), mul.into()],
-        );
+        assert_eq!(first_visited, vec![x, y, add1, mul]);
 
         // Second run should process nothing new
         assert!(second_visited.is_empty());

--- a/crates/clarirs_core/src/algorithms/simplify/test_bv.rs
+++ b/crates/clarirs_core/src/algorithms/simplify/test_bv.rs
@@ -888,7 +888,7 @@ fn test_extract() -> Result<()> {
     let ctx = Context::new();
 
     // Whole bitvector, concrete
-    let bv = ctx.bvv(BitVec::from((0x1234_5678_9ABC_DEF0_, 64))).unwrap();
+    let bv = ctx.bvv(BitVec::from((0x1234_5678_9ABC_DEF0, 64))).unwrap();
     let extract = ctx.extract(&bv, 63, 0)?.simplify()?;
     assert_eq!(extract, bv);
 
@@ -899,7 +899,7 @@ fn test_extract() -> Result<()> {
 
     // Partial extraction, concrete
     let extract = ctx.extract(&bv, 63, 32)?.simplify()?;
-    let expected = ctx.bvv(BitVec::from((0x1234_5678_, 32))).unwrap();
+    let expected = ctx.bvv(BitVec::from((0x1234_5678, 32))).unwrap();
     assert_eq!(extract, expected);
 
     Ok(())

--- a/crates/clarirs_num/src/bitvec/conversion.rs
+++ b/crates/clarirs_num/src/bitvec/conversion.rs
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), 0);
 
-        let bv = BitVec::from((u64::MAX as u64, 64));
+        let bv = BitVec::from((u64::MAX, 64));
         assert_eq!(bv.len(), 64);
         assert_eq!(bv.to_u64().unwrap(), u64::MAX);
     }

--- a/crates/clarirs_z3/src/astext/test_float.rs
+++ b/crates/clarirs_z3/src/astext/test_float.rs
@@ -39,7 +39,7 @@ mod to_z3 {
     #[test]
     fn value_f32() {
         let ctx = Context::new();
-        let f = ctx.fpv(Float::F32(3.14f32)).unwrap();
+        let f = ctx.fpv(Float::F32(std::f32::consts::PI)).unwrap();
         let z3_ast = f.to_z3().unwrap();
         // Z3 represents float numerals as FpaNum
         assert_eq!(z3_ast.decl_kind(), DeclKind::FpaNum);
@@ -48,7 +48,7 @@ mod to_z3 {
     #[test]
     fn value_f64() {
         let ctx = Context::new();
-        let f = ctx.fpv(Float::F64(2.718281828459045f64)).unwrap();
+        let f = ctx.fpv(Float::F64(std::f64::consts::E)).unwrap();
         let z3_ast = f.to_z3().unwrap();
         assert_eq!(z3_ast.decl_kind(), DeclKind::FpaNum);
     }
@@ -365,18 +365,18 @@ mod from_z3 {
     #[test]
     fn value_f32() {
         let ctx = Context::new();
-        let z3_ast = RcAst::mk_fp_val_f32(3.14f32);
+        let z3_ast = RcAst::mk_fp_val_f32(std::f32::consts::PI);
         let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
-        let expected = ctx.fpv(Float::F32(3.14f32)).unwrap();
+        let expected = ctx.fpv(Float::F32(std::f32::consts::PI)).unwrap();
         assert_eq!(expected, result);
     }
 
     #[test]
     fn value_f64() {
         let ctx = Context::new();
-        let z3_ast = RcAst::mk_fp_val_f64(2.718281828459045f64);
+        let z3_ast = RcAst::mk_fp_val_f64(std::f64::consts::E);
         let result = AstRef::from_z3(&ctx, z3_ast).unwrap();
-        let expected = ctx.fpv(Float::F64(2.718281828459045f64)).unwrap();
+        let expected = ctx.fpv(Float::F64(std::f64::consts::E)).unwrap();
         assert_eq!(expected, result);
     }
 

--- a/crates/clarirs_z3/src/solver.rs
+++ b/crates/clarirs_z3/src/solver.rs
@@ -646,13 +646,13 @@ mod tests {
         );
 
         // A satisfiable extra constraint reachable by a cached model.
-        let extra_sat = ctx.eq_(&x, &v.clone().into_bitvec().unwrap())?;
+        let extra_sat = ctx.eq_(&x, v.clone().into_bitvec().unwrap())?;
         assert!(cached.satisfiable_with_extra(&[extra_sat])?);
 
         // An unsatisfiable extra constraint must fall through and report unsat.
         let extra_unsat = ctx.eq_(&x, &ctx.bvv(BitVec::from((100, 32)))?)?;
         assert_eq!(
-            cached.satisfiable_with_extra(&[extra_unsat.clone()])?,
+            cached.satisfiable_with_extra(std::slice::from_ref(&extra_unsat))?,
             cacheless.satisfiable_with_extra(&[extra_unsat])?,
         );
         assert!(


### PR DESCRIPTION
## Summary

Runs `cargo fmt` and `cargo clippy --workspace --all-targets --all-features` and fixes every reported lint. `cargo fmt` reported no formatting changes; all fixes address clippy warnings (19 total across `clarirs_core`, `clarirs_num`, and `clarirs_z3` — mostly in test code).

## Changes

- **clarirs_core**
  - `find_variable` / `post_order` tests: remove identity `.into()` conversions on `AstRef` (`useless_conversion`).
  - `simplify::test_bv`: drop trailing underscores from hex literals so digits group evenly (`unusual_byte_groupings`).
- **clarirs_num**
  - `bitvec::conversion` test: drop the redundant `u64::MAX as u64` cast (`unnecessary_cast`).
- **clarirs_z3**
  - `solver` tests: remove a needless borrow of a generic argument (`needless_borrows_for_generic_args`) and use `std::slice::from_ref` instead of cloning a value into a one-element slice (`cloned_ref_to_slice_refs`).
  - `astext::test_float`: replace the PI/E-approximating float literals with `std::f32::consts::PI` / `std::f64::consts::E` (`approximate_constant`). Both sides of each round-trip assertion use the same constant, so the tests are unchanged in meaning.

## Verification

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --all-features` — 0 warnings.
- `cargo test -p clarirs_core -p clarirs_num --lib` — all pass (including the touched tests).

All changes are confined to test code and are behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuEfSFqJ12C5n33xWYa33c)_