### PR TITLE
z3: apply solver params (timeout) in eval_n

### DIFF
--- a/crates/clarirs-z3/src/solver.rs
+++ b/crates/clarirs-z3/src/solver.rs
@@ -530,8 +530,9 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
 
         let z3_aux = aux.to_z3()?;
 
-        // Create and fill the Z3 solver once
-        let mut z3_solver = RcSolver::new()?;
+        // Create and fill the Z3 solver once, applying this solver's params
+        // (timeout in particular) so eval cannot run unbounded.
+        let mut z3_solver = self.new_z3_solver()?;
 
         for assertion in &self.assertions {
             let converted = assertion.to_z3()?;


### PR DESCRIPTION
## Summary

`eval_n` built its Z3 solver with `RcSolver::new()` directly, bypassing `new_z3_solver()` which sets the timeout and unsat_core params — so `eval`-family calls ran unbounded regardless of the solver's configured timeout.

Found via angr's `manyfloatsum_symbolic` tests, where a hard FP formula kept a `Solver(timeout=900_000)` solving for 14+ minutes inside `eval` with the timeout silently ignored.

## Verification

With this fix, `Solver(timeout=10_000).eval(...)` on that formula returns after ~11s instead of running for minutes. `cargo test -p clarirs_z3`: 338 passed.

## Note

The optimize (min/max) path has the same gap — `RcOptimize` has no params support at all — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)