### PR TITLE
Raise ClaripySolverInterruptError on Z3 unknown instead of reporting unsat

### DIFF
--- a/crates/clarirs-core/src/error.rs
+++ b/crates/clarirs-core/src/error.rs
@@ -27,6 +27,8 @@ pub enum ClarirsError {
     ConversionError(String),
     #[error("UNSAT")]
     Unsat,
+    #[error("Solver returned unknown: {0}")]
+    SolverUnknown(String),
     #[error("Empty traversal result")]
     EmptyTraversal,
     #[error("Backend error ({0}): {1}")]

--- a/crates/clarirs-py/src/error.rs
+++ b/crates/clarirs-py/src/error.rs
@@ -37,6 +37,8 @@ pub enum ClaripyError {
     UnsupportedOperation(String),
     #[error("UNSAT")]
     Unsat,
+    #[error("Solver interrupted: {0}")]
+    SolverInterrupt(String),
 }
 
 impl From<ClarirsError> for ClaripyError {
@@ -58,6 +60,7 @@ impl From<ClarirsError> for ClaripyError {
             ClarirsError::TypeError(e) => ClaripyError::TypeError(e),
             ClarirsError::UnsupportedOperation(e) => ClaripyError::UnsupportedOperation(e),
             ClarirsError::Unsat => ClaripyError::Unsat,
+            ClarirsError::SolverUnknown(reason) => ClaripyError::SolverInterrupt(reason),
             _ => ClaripyError::ClarirsError(format!("{e}")),
         }
     }
@@ -97,6 +100,9 @@ impl From<ClaripyError> for PyErr {
                 Python::attach(|py| PyErr::from_value(o.bind(py).clone()))
             }
             ClaripyError::Unsat => py_err::UnsatError::new_err("UNSAT"),
+            ClaripyError::SolverInterrupt(reason) => {
+                py_err::ClaripySolverInterruptError::new_err(reason)
+            }
             _ => py_err::ClaripyError::new_err(format!("{e}")),
         }
     }

--- a/crates/clarirs-z3/src/rc.rs
+++ b/crates/clarirs-z3/src/rc.rs
@@ -332,6 +332,18 @@ impl RcSolver {
         })
     }
 
+    /// Why the last check() returned Z3_L_UNDEF (e.g. "timeout", "canceled").
+    pub fn reason_unknown(&self) -> String {
+        Z3_CONTEXT.with(|&ctx| unsafe {
+            let reason = Z3_solver_get_reason_unknown(ctx, self.0);
+            if reason.is_null() {
+                "unknown".to_string()
+            } else {
+                CStr::from_ptr(reason).to_string_lossy().into_owned()
+            }
+        })
+    }
+
     pub fn get_unsat_core(&mut self) -> Result<RcAstVector, ClarirsError> {
         Z3_CONTEXT.with(|&ctx| unsafe {
             let core = Z3_solver_get_unsat_core(ctx, self.0);
@@ -431,6 +443,18 @@ impl RcOptimize {
             let result = Z3_optimize_check(ctx, self.0, 0, std::ptr::null());
             check_z3_error()?;
             Ok(result)
+        })
+    }
+
+    /// Why the last check() returned Z3_L_UNDEF (e.g. "timeout", "canceled").
+    pub fn reason_unknown(&self) -> String {
+        Z3_CONTEXT.with(|&ctx| unsafe {
+            let reason = Z3_optimize_get_reason_unknown(ctx, self.0);
+            if reason.is_null() {
+                "unknown".to_string()
+            } else {
+                CStr::from_ptr(reason).to_string_lossy().into_owned()
+            }
         })
     }
 

--- a/crates/clarirs-z3/src/solver.rs
+++ b/crates/clarirs-z3/src/solver.rs
@@ -258,8 +258,10 @@ impl<'c> Z3Solver<'c> {
 
     fn make_model(&self) -> Result<RcModel, ClarirsError> {
         self.with_cached_solver(|z3_solver| {
-            if z3_solver.check()? != Z3_L_TRUE {
-                return Err(ClarirsError::Unsat);
+            match z3_solver.check()? {
+                Z3_L_TRUE => {}
+                Z3_L_FALSE => return Err(ClarirsError::Unsat),
+                _ => return Err(ClarirsError::SolverUnknown(z3_solver.reason_unknown())),
             }
             z3_solver.model()
         })
@@ -329,7 +331,11 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
     }
 
     fn satisfiable(&mut self) -> Result<bool, ClarirsError> {
-        self.with_cached_solver(|z3_solver| Ok(z3_solver.check()? == Z3_L_TRUE))
+        self.with_cached_solver(|z3_solver| match z3_solver.check()? {
+            Z3_L_TRUE => Ok(true),
+            Z3_L_FALSE => Ok(false),
+            _ => Err(ClarirsError::SolverUnknown(z3_solver.reason_unknown())),
+        })
     }
 
     fn satisfiable_with_extra(&mut self, extra: &[AstRef<'c>]) -> Result<bool, ClarirsError> {
@@ -340,9 +346,13 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         for c in extra {
             assumptions.push(c.simplify_z3()?.to_z3()?);
         }
-        self.with_cached_solver(|z3_solver| {
-            Ok(z3_solver.check_assumptions(&assumptions)? == Z3_L_TRUE)
-        })
+        self.with_cached_solver(
+            |z3_solver| match z3_solver.check_assumptions(&assumptions)? {
+                Z3_L_TRUE => Ok(true),
+                Z3_L_FALSE => Ok(false),
+                _ => Err(ClarirsError::SolverUnknown(z3_solver.reason_unknown())),
+            },
+        )
     }
 
     fn eval(&mut self, expr: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
@@ -393,8 +403,10 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
     fn min_unsigned(&mut self, expr: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
         let mut optimize = self.mk_filled_optimize()?;
         optimize.minimize(&expr.to_z3()?)?;
-        if optimize.check()? != Z3_L_TRUE {
-            return Err(ClarirsError::Unsat);
+        match optimize.check()? {
+            Z3_L_TRUE => {}
+            Z3_L_FALSE => return Err(ClarirsError::Unsat),
+            _ => return Err(ClarirsError::SolverUnknown(optimize.reason_unknown())),
         }
 
         let model = optimize.get_model()?;
@@ -406,8 +418,10 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
     fn max_unsigned(&mut self, expr: &AstRef<'c>) -> Result<AstRef<'c>, ClarirsError> {
         let mut optimize = self.mk_filled_optimize()?;
         optimize.maximize(&expr.to_z3()?)?;
-        if optimize.check()? != Z3_L_TRUE {
-            return Err(ClarirsError::Unsat);
+        match optimize.check()? {
+            Z3_L_TRUE => {}
+            Z3_L_FALSE => return Err(ClarirsError::Unsat),
+            _ => return Err(ClarirsError::SolverUnknown(optimize.reason_unknown())),
         }
 
         let model = optimize.get_model()?;
@@ -441,8 +455,10 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         // This will find the smallest value among those with the preferred sign bit
         optimize.minimize(&target.to_z3()?)?;
 
-        if optimize.check()? != Z3_L_TRUE {
-            return Err(ClarirsError::Unsat);
+        match optimize.check()? {
+            Z3_L_TRUE => {}
+            Z3_L_FALSE => return Err(ClarirsError::Unsat),
+            _ => return Err(ClarirsError::SolverUnknown(optimize.reason_unknown())),
         }
 
         let model = optimize.get_model()?;
@@ -476,8 +492,10 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         // This will find the largest value among those with the preferred sign bit
         optimize.maximize(&target.to_z3()?)?;
 
-        if optimize.check()? != Z3_L_TRUE {
-            return Err(ClarirsError::Unsat);
+        match optimize.check()? {
+            Z3_L_TRUE => {}
+            Z3_L_FALSE => return Err(ClarirsError::Unsat),
+            _ => return Err(ClarirsError::SolverUnknown(optimize.reason_unknown())),
         }
 
         let model = optimize.get_model()?;
@@ -540,8 +558,10 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
         z3_solver.assert(&link.to_z3()?)?;
 
         for _ in 0..n {
-            if z3_solver.check()? != Z3_L_TRUE {
-                break;
+            match z3_solver.check()? {
+                Z3_L_TRUE => {}
+                Z3_L_FALSE => break,
+                _ => return Err(ClarirsError::SolverUnknown(z3_solver.reason_unknown())),
             }
 
             let model = z3_solver.model()?;


### PR DESCRIPTION
## Summary

Z3's `check()` can return `Z3_L_UNDEF` (timeout, canceled, incompleteness), which clarirs conflated with unsat: `satisfiable()` returned `False` and `eval` returned no solutions when the solver merely timed out. Silently treating a timeout as unsat is unsound for symbolic execution — feasible paths get dropped without any signal.

## Changes

- New `ClarirsError::SolverUnknown(String)` carrying `Z3_solver_get_reason_unknown()` / `Z3_optimize_get_reason_unknown()` (new `reason_unknown()` on `RcSolver` and `RcOptimize`)
- `Z3_L_UNDEF` mapped to it in `check`, `check_assumptions`, `eval_n`, `make_model`, and the four optimize (min/max) paths
- Surfaced in Python as `claripy.errors.ClaripySolverInterruptError` (matching Python claripy, which raises on unknown)

## Verification

`Solver(timeout=10_000)` on a hard FP formula now raises `ClaripySolverInterruptError('timeout')` from both `satisfiable()` and `eval()` after ~10s instead of returning `False` / `[]`. `cargo test -p clarirs_z3 -p clarirs_core` (472) and the clarirs_py pytest suite (195) pass; clippy clean.

Sibling of #654 (timeout params on the eval path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)