### PR TITLE
Simplify bvToFP(fpToIEEEBV(x)) round-trips to x

### DIFF
--- a/crates/clarirs-core/src/algorithms/simplify.rs
+++ b/crates/clarirs-core/src/algorithms/simplify.rs
@@ -7,6 +7,8 @@ mod string;
 mod test_bool;
 #[cfg(test)]
 mod test_bv;
+#[cfg(test)]
+mod test_float;
 
 use std::collections::BTreeSet;
 use std::sync::{Arc, atomic::Ordering};

--- a/crates/clarirs-core/src/algorithms/simplify/float.rs
+++ b/crates/clarirs-core/src/algorithms/simplify/float.rs
@@ -132,6 +132,13 @@ pub(crate) fn simplify_float<'c>(
                     )?;
                     Ok(ctx.fpv(float)?)
                 }
+                // Reinterpreting a float's own IEEE bit pattern back as a float
+                // of the same sort is the identity: to_fp(to_ieee_bv(x)) = x.
+                // Sound for NaN too -- SMT-LIB FP has a single NaN value, so
+                // whichever NaN bit pattern to_ieee_bv picks converts back to x.
+                AstOp::FpToIEEEBV(inner) if matches!(inner.ast_type(), AstType::Float(inner_fsort) if inner_fsort == *fsort) => {
+                    Ok(inner.clone())
+                }
                 _ => Ok(ctx.bv_to_fp(arc, *fsort)?),
             }
         }

--- a/crates/clarirs-core/src/algorithms/simplify/test_float.rs
+++ b/crates/clarirs-core/src/algorithms/simplify/test_float.rs
@@ -1,0 +1,28 @@
+use crate::prelude::*;
+use anyhow::Result;
+
+#[test]
+fn test_bv_to_fp_of_fp_to_ieeebv_is_identity() -> Result<()> {
+    let ctx = Context::new();
+
+    let x = ctx.fps("x", FSort::f64())?;
+    let round_trip = ctx.bv_to_fp(ctx.fp_to_ieeebv(&x)?, FSort::f64())?;
+
+    assert_eq!(round_trip.simplify()?, x);
+    Ok(())
+}
+
+#[test]
+fn test_bv_to_fp_of_fp_to_ieeebv_different_sort_not_simplified() -> Result<()> {
+    let ctx = Context::new();
+
+    // Reinterpreting an f64's 64-bit pattern as some other 64-bit float sort
+    // is NOT the identity; the round-trip must be preserved.
+    let odd_sort = FSort::new(15, 49);
+    let x = ctx.fps("x", FSort::f64())?;
+    let reinterpret = ctx.bv_to_fp(ctx.fp_to_ieeebv(&x)?, odd_sort)?;
+
+    let simplified = reinterpret.simplify()?;
+    assert!(matches!(simplified.op(), AstOp::BvToFp(..)));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

angr's calling-convention handling moves FP values through registers and memory as IEEE bit patterns, wrapping every FP argument in a `fpToIEEEBV`/`bvToFP` round-trip. Python claripy cancels the round-trip on construction; clarirs kept all the wrappers — angr's `manyfloatsum` result AST came out as 111 nodes (37 `bvToFP` + 37 `fpToIEEEBV`) vs claripy's 37-node pure `fpAdd` chain — and Z3's fpa2bv pays for each one.

## Soundness

Reinterpreting a float's own IEEE bit pattern back at the **same sort** is the identity, including for NaN: SMT-LIB FP has a single NaN value, so whichever NaN bit pattern `to_ieee_bv` picks converts back to the same value. The rule only fires when the inner float sort equals the target sort; a regression test covers the mismatched-sort case staying unsimplified.

## Impact

Together with the Z3 `max_rounds` workaround (separate PR), angr's previously timing-out `manyfloatsum_symbolic` tests pass in ~22-24s each (Python claripy baseline: 35-53s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)