### PR TITLE
z3: cap tactic simplification rounds to dodge Z3 >= 4.14 FP blowup

### DIFF
--- a/crates/clarirs-z3/src/solver.rs
+++ b/crates/clarirs-z3/src/solver.rs
@@ -168,6 +168,13 @@ impl<'c> Z3Solver<'c> {
         if self.unsat_core {
             params.set_bool("unsat_core", true)?;
         }
+        // Z3 >= 4.14 regression: the propagate-values stage of the default
+        // tactic loses DAG sharing on fpa2bv output, and the loss compounds
+        // per round -- a chained-FP-add goal grows ~50x over the default 4
+        // rounds and bit-blasts into an intractable SAT instance (claripy
+        // sidesteps this by pinning z3-solver 4.13). One round keeps the
+        // encoding compact; the same formula then solves faster than on 4.13.
+        params.set_u32("max_rounds", 1)?;
         z3_solver.set_params(params)?;
         Ok(z3_solver)
     }


### PR DESCRIPTION
## Summary

Z3 4.14.0 regressed the `propagate-values` stage of its default tactic: on fpa2bv output it loses DAG sharing, and the loss **compounds per round** (default 4). A 19-double `fpAdd` chain grows from 10k to 544k unique subexpressions and bit-blasts into an 11M-variable / 17GB SAT instance that never finishes. Z3 4.13 stayed at 71k exprs / 230k SAT vars and solved it in ~35s. Python claripy avoids the issue by pinning `z3-solver==4.13.0`; clarirs bundles Z3 4.16 via z3-sys and inherits it.

## Investigation

- Bisected via pip z3-solver on identical input: 4.13.0/4.13.4 sat in ~35s; 4.14.0, 4.14.1, 4.15.3, 4.16.0 all unknown at timeout
- The `qffp` tactic source is identical across versions — a stage implementation regressed
- Stage isolation: `Then(simplify, fpa2bv, bit-blast, sat)` is fast on both 4.13.4 (8.8s) and 4.16 (7.7s); inserting `propagate-values` after `fpa2bv` makes 4.16 time out
- Goal-size measurement on the identical 10,023-expr post-fpa2bv goal: propagate-values yields 71k exprs on 4.13.4 vs **544k on 4.16.0**; with `max_rounds=1` it stays at 27k
- `smt.propagate_values=false` and `rewriter.flat=false` do NOT help; `max_rounds=1` does because solver params forward into the default tactic

## Fix

Set `max_rounds=1` in `new_z3_solver()`. The regressing formula then solves in ~6s on Z3 4.16 — faster than the 4.13 default. Together with #656, angr's previously timing-out `manyfloatsum_symbolic` tests pass in ~22-24s each (claripy baseline: 35-53s), and angr's solver/memory/state/spiller/VSA test battery (100 tests) shows no fallout.

## Caveat

`max_rounds` caps rounds for every tactic stage that reads it, on every solve — a deliberate trade against the encoding blowup, best removed once the regression is fixed upstream in Z3 (to be reported; happy to attach the full analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)