### PR TITLE
batch_eval draws each row from one model instead of re-solving per variable

### DIFF
--- a/crates/clarirs-core/src/solver_mixins/concrete_early_resolution.rs
+++ b/crates/clarirs-core/src/solver_mixins/concrete_early_resolution.rs
@@ -161,6 +161,13 @@ impl<'c, S: Solver<'c>> Solver<'c> for ConcreteEarlyResolutionMixin<'c, S> {
         }
         self.inner.eval_n(expr, n)
     }
+
+    fn batch_eval(&mut self, exprs: &[AstRef<'c>]) -> Result<Vec<AstRef<'c>>, ClarirsError> {
+        // Forward as a batch so the backend can draw every value from a single
+        // model (concrete expressions are handled cheaply there too), rather
+        // than falling back to the per-expression default.
+        self.inner.batch_eval(exprs)
+    }
 }
 
 #[cfg(test)]

--- a/crates/clarirs-core/src/solver_mixins/model_cache.rs
+++ b/crates/clarirs-core/src/solver_mixins/model_cache.rs
@@ -356,6 +356,26 @@ impl<'c, S: Solver<'c>> Solver<'c> for ModelCacheMixin<'c, S> {
         }
         Ok(results)
     }
+
+    fn batch_eval(&mut self, exprs: &[AstRef<'c>]) -> Result<Vec<AstRef<'c>>, ClarirsError> {
+        if self.sat == Some(false) {
+            return Err(ClarirsError::Unsat);
+        }
+        // Forward as a batch so the backend draws every value from one model in
+        // a single solve, rather than the per-expression default (one solve per
+        // expression). Only the satisfiability flag is updated here.
+        match self.inner.batch_eval(exprs) {
+            Ok(results) => {
+                self.sat = Some(true);
+                Ok(results)
+            }
+            Err(ClarirsError::Unsat) => {
+                self.sat = Some(false);
+                Err(ClarirsError::Unsat)
+            }
+            Err(e) => Err(e),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/clarirs-core/src/solver_mixins/simplification.rs
+++ b/crates/clarirs-core/src/solver_mixins/simplification.rs
@@ -98,6 +98,14 @@ impl<'c, S: Solver<'c>> Solver<'c> for SimplificationMixin<'c, S> {
     fn eval_n(&mut self, expr: &AstRef<'c>, n: u32) -> Result<Vec<AstRef<'c>>, ClarirsError> {
         self.inner.eval_n(&expr.simplify()?, n)
     }
+
+    fn batch_eval(&mut self, exprs: &[AstRef<'c>]) -> Result<Vec<AstRef<'c>>, ClarirsError> {
+        let simplified = exprs
+            .iter()
+            .map(|expr| expr.simplify())
+            .collect::<Result<Vec<_>, _>>()?;
+        self.inner.batch_eval(&simplified)
+    }
 }
 
 #[cfg(test)]

--- a/crates/clarirs-py/src/dynsolver.rs
+++ b/crates/clarirs-py/src/dynsolver.rs
@@ -208,4 +208,11 @@ impl Solver<'static> for DynSolver {
     ) -> Result<Vec<AstRef<'static>>, ClarirsError> {
         dispatch!(self, eval_n, expr, n)
     }
+
+    fn batch_eval(
+        &mut self,
+        exprs: &[AstRef<'static>],
+    ) -> Result<Vec<AstRef<'static>>, ClarirsError> {
+        dispatch!(self, batch_eval, exprs)
+    }
 }

--- a/crates/clarirs-py/src/solver.rs
+++ b/crates/clarirs-py/src/solver.rs
@@ -554,34 +554,30 @@ impl PySolver {
 
         let rows: Vec<Vec<AstRef<'static>>> = self
             .with_extra_constraints(extra_constraints, exact, |solver| {
+                // Work on a clone so the blocking clauses that force distinct
+                // rows do not leak into the caller's solver.
+                let mut work = solver.clone();
                 let mut rows = Vec::new();
                 for _ in 0..n {
-                    if !solver.satisfiable().map_err(ClaripyError::from)? {
-                        break;
-                    }
-                    let mut model = solver.clone();
-                    let mut row = Vec::with_capacity(asts.len());
-                    let mut disequalities = Vec::with_capacity(asts.len());
-                    for ast in &asts {
-                        // Evaluate against the current model, pinning the value
-                        // so the remaining expressions stay consistent with it.
-                        let value = model.eval(ast).map_err(ClaripyError::from)?;
-                        let eq = GLOBAL_CONTEXT
-                            .eq_(ast, &value)
-                            .map_err(ClaripyError::from)?;
-                        model.add(&eq).map_err(ClaripyError::from)?;
-                        disequalities.push(
-                            GLOBAL_CONTEXT
-                                .neq(ast, &value)
-                                .map_err(ClaripyError::from)?,
-                        );
-                        row.push(value);
-                    }
+                    // Draw the whole assignment from a single model: one solve
+                    // for all expressions, rather than pinning each expression
+                    // and re-solving (which cost one solve per expression).
+                    let row = match work.batch_eval(&asts) {
+                        Ok(row) => row,
+                        Err(ClarirsError::Unsat) => break,
+                        Err(e) => return Err(ClaripyError::from(e)),
+                    };
                     // Exclude this whole assignment from subsequent models.
+                    let disequalities = asts
+                        .iter()
+                        .zip(&row)
+                        .map(|(ast, value)| GLOBAL_CONTEXT.neq(ast, value))
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(ClaripyError::from)?;
                     let blocker = GLOBAL_CONTEXT
                         .or(disequalities)
                         .map_err(ClaripyError::from)?;
-                    solver.add(&blocker).map_err(ClaripyError::from)?;
+                    work.add(&blocker).map_err(ClaripyError::from)?;
                     rows.push(row);
                 }
                 Ok(rows)


### PR DESCRIPTION
## Summary

`PySolver.batch_eval` evaluated a solution row by, for each expression, calling `eval()` and then pinning the value (`add(expr == value)`) so later expressions stayed consistent. Each pin dirties the solver, so every expression triggered its own check_sat — N+1 solves to read N variables. claripy checks once and reads all values from the single model.

The `Solver` trait already has a `batch_eval` that draws every value from one shared model (Z3 overrides it via `make_model`), but nothing reached it: `DynSolver` and the Simplification/ConcreteEarlyResolution/ModelCache mixins didn't forward `batch_eval`, so it fell back to the per-expression trait default. Forward it through all four layers, and rewrite `PySolver.batch_eval` to call it once per row (on a clone, so the row-exclusion blocking clauses don't leak into the caller's solver).

## Impact

Cuts a symbolic float-sum batch_eval from ~N solves to 1: the N=8 microbenchmark drops 16.5s → 1.7s (~10x), scaling with the number of evaluated variables.

This ports the commit from the angr clarirs-migration branch (angr/angr#6550), where it's currently the main functional delta between the vendored clarirs and upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)