### PR TITLE
Support approximate_first on SolverHybrid

### DIFF
--- a/crates/clarirs-core/src/solver/hybrid.rs
+++ b/crates/clarirs-core/src/solver/hybrid.rs
@@ -21,16 +21,76 @@ pub struct HybridSolver<'c, A: Solver<'c>, E: Solver<'c>> {
     approximate: A,
     exact: E,
     ctx: &'c Context<'c>,
+    /// When true, `eval_n` for more than two solutions asks the approximate
+    /// backend first and only consults the exact backend when the
+    /// approximation is inexact (claripy's `approximate_first`).
+    approximate_first: bool,
 }
 
 impl<'c, A: Solver<'c>, E: Solver<'c>> HybridSolver<'c, A, E> {
     /// Create a new hybrid solver with the given approximate and exact backends.
     pub fn new(ctx: &'c Context<'c>, approximate: A, exact: E) -> Self {
+        Self::new_with_options(ctx, approximate, exact, false)
+    }
+
+    /// Create a new hybrid solver, optionally preferring approximate results
+    /// for multi-solution `eval_n` queries.
+    pub fn new_with_options(
+        ctx: &'c Context<'c>,
+        approximate: A,
+        exact: E,
+        approximate_first: bool,
+    ) -> Self {
         Self {
             approximate,
             exact,
             ctx,
+            approximate_first,
         }
+    }
+
+    /// Whether this solver prefers approximate results for multi-solution
+    /// `eval_n` queries.
+    pub fn approximate_first(&self) -> bool {
+        self.approximate_first
+    }
+
+    /// claripy's approximate-first heuristic: draw n + 1 solutions from the
+    /// approximate backend; the extra solution tells us whether the
+    /// approximation is exhaustive. If it is (<= n solutions), or no
+    /// constraint mentions the expression's variables (so the approximation
+    /// cannot be refined by solving), use it. Otherwise ask the exact backend
+    /// too and use whichever found fewer solutions.
+    fn eval_n_approximate_first(
+        &mut self,
+        expr: &AstRef<'c>,
+        n: u32,
+    ) -> Result<Vec<AstRef<'c>>, ClarirsError> {
+        let mut approx = match self.approximate.eval_n(expr, n + 1) {
+            Ok(approx) if !approx.is_empty() => approx,
+            _ => return self.exact.eval_n(expr, n),
+        };
+
+        if approx.len() > n as usize
+            && self.constraints_mention(expr)?
+            && let Ok(exact) = self.exact.eval_n(expr, n + 1)
+            && exact.len() < approx.len()
+        {
+            approx = exact;
+        }
+
+        approx.truncate(n as usize);
+        Ok(approx)
+    }
+
+    /// Whether any asserted constraint shares a variable with `expr`.
+    fn constraints_mention(&self, expr: &AstRef<'c>) -> Result<bool, ClarirsError> {
+        let expr_vars = expr.variables();
+        Ok(self
+            .exact
+            .constraints()?
+            .iter()
+            .any(|c| c.variables().iter().any(|v| expr_vars.contains(v))))
     }
 
     /// Get a reference to the approximate solver.
@@ -169,6 +229,9 @@ impl<'c, A: Solver<'c>, E: Solver<'c>> Solver<'c> for HybridSolver<'c, A, E> {
     fn eval_n(&mut self, expr: &AstRef<'c>, n: u32) -> Result<Vec<AstRef<'c>>, ClarirsError> {
         if n == 0 {
             return Ok(Vec::new());
+        }
+        if self.approximate_first && n > 2 {
+            return self.eval_n_approximate_first(expr, n);
         }
         // Try the approximate solver first; verify symbolic results against
         // the exact solver, and fall back to it whenever the approximate

--- a/crates/clarirs-py/src/dynsolver.rs
+++ b/crates/clarirs-py/src/dynsolver.rs
@@ -116,6 +116,16 @@ impl DynSolver {
         }
     }
 
+    /// Whether approximate-first evaluation is enabled (only meaningful for
+    /// the Hybrid solver).
+    pub(crate) fn approximate_first(&self) -> bool {
+        match self {
+            // SimplificationMixin -> ConcreteEarlyResolutionMixin -> HybridSolver
+            DynSolver::Hybrid(solver) => solver.inner().inner().approximate_first(),
+            _ => false,
+        }
+    }
+
     /// Clear all replacements (only supported for Replacement solver)
     pub(crate) fn clear_replacements(&mut self) -> Result<(), ClarirsError> {
         match self {

--- a/crates/clarirs-py/src/solver.rs
+++ b/crates/clarirs-py/src/solver.rs
@@ -116,15 +116,18 @@ impl PySolver {
                     Z3Solver::new_with_options(&GLOBAL_CONTEXT, self.timeout, self.unsat_core),
                 )),
                 DynSolver::Vsa(..) => DynSolver::Vsa(wrap_solver(VSASolver::new(&GLOBAL_CONTEXT))),
-                DynSolver::Hybrid(..) => DynSolver::Hybrid(wrap_solver(HybridSolver::new(
-                    &GLOBAL_CONTEXT,
-                    wrap_solver(VSASolver::new(&GLOBAL_CONTEXT)),
-                    wrap_z3_cached(Z3Solver::new_with_options(
+                DynSolver::Hybrid(..) => {
+                    DynSolver::Hybrid(wrap_solver(HybridSolver::new_with_options(
                         &GLOBAL_CONTEXT,
-                        self.timeout,
-                        self.unsat_core,
-                    )),
-                ))),
+                        wrap_solver(VSASolver::new(&GLOBAL_CONTEXT)),
+                        wrap_z3_cached(Z3Solver::new_with_options(
+                            &GLOBAL_CONTEXT,
+                            self.timeout,
+                            self.unsat_core,
+                        )),
+                        self.inner.approximate_first(),
+                    )))
+                }
                 DynSolver::Replacement(..) => {
                     DynSolver::Replacement(ReplacementSolver::new_with_options(
                         wrap_z3_cached(Z3Solver::new_with_options(
@@ -885,14 +888,19 @@ impl PySolver {
         // Get the constraints
         let constraints = self.constraints(py)?;
 
-        // Return a tuple of (solver_type, constraints, auto_replace). The last
-        // element is only meaningful for the Replacement solver.
+        // Return a tuple of (solver_type, constraints, flag). The last element
+        // is per-type: auto_replace for the Replacement solver,
+        // approximate_first for the Hybrid solver, unused otherwise.
+        let flag = match &self.inner {
+            DynSolver::Hybrid(..) => self.inner.approximate_first(),
+            _ => self.inner.auto_replace(),
+        };
         Ok(PyTuple::new(
             py,
             vec![
                 solver_type.into_bound_py_any(py)?,
                 constraints.into_bound_py_any(py)?,
-                self.inner.auto_replace().into_bound_py_any(py)?,
+                flag.into_bound_py_any(py)?,
             ],
         )?)
     }
@@ -905,12 +913,12 @@ impl PySolver {
         // Extract solver type and constraints from the state tuple
         let solver_type: String = state.get_item(0)?.extract()?;
         let constraints: Vec<Bound<'py, Bool>> = state.get_item(1)?.extract()?;
-        // auto_replace was added later; default to claripy's `True` for older state.
-        let auto_replace: bool = state
-            .get_item(2)
-            .ok()
-            .and_then(|v| v.extract().ok())
-            .unwrap_or(true);
+        // The per-type flag (auto_replace / approximate_first) was added later;
+        // older state tuples lack it.
+        let flag: Option<bool> = state.get_item(2).ok().and_then(|v| v.extract().ok());
+        // Default to claripy's `True` for Replacement, `False` for Hybrid.
+        let auto_replace = flag.unwrap_or(true);
+        let approximate_first = flag.unwrap_or(false);
 
         // Create a new solver based on the type
         self.inner = match solver_type.as_str() {
@@ -924,10 +932,11 @@ impl PySolver {
                 self.timeout,
             ))),
             "Vsa" => DynSolver::Vsa(wrap_solver(VSASolver::new(&GLOBAL_CONTEXT))),
-            "Hybrid" => DynSolver::Hybrid(wrap_solver(HybridSolver::new(
+            "Hybrid" => DynSolver::Hybrid(wrap_solver(HybridSolver::new_with_options(
                 &GLOBAL_CONTEXT,
                 wrap_solver(VSASolver::new(&GLOBAL_CONTEXT)),
                 wrap_z3_cached(Z3Solver::new_with_timeout(&GLOBAL_CONTEXT, self.timeout)),
+                approximate_first,
             ))),
             "Replacement" => DynSolver::Replacement(ReplacementSolver::new_with_options(
                 wrap_z3_cached(Z3Solver::new_with_timeout(&GLOBAL_CONTEXT, self.timeout)),
@@ -1032,13 +1041,18 @@ pub struct PyHybridSolver;
 #[pymethods]
 impl PyHybridSolver {
     #[new]
-    #[pyo3(signature = (timeout = None, track = false))]
-    fn new(timeout: Option<u32>, track: bool) -> Result<PyClassInitializer<Self>, ClaripyError> {
+    #[pyo3(signature = (timeout = None, track = false, approximate_first = false))]
+    fn new(
+        timeout: Option<u32>,
+        track: bool,
+        approximate_first: bool,
+    ) -> Result<PyClassInitializer<Self>, ClaripyError> {
         Ok(PyClassInitializer::from(PySolver {
-            inner: DynSolver::Hybrid(wrap_solver(HybridSolver::new(
+            inner: DynSolver::Hybrid(wrap_solver(HybridSolver::new_with_options(
                 &GLOBAL_CONTEXT,
                 wrap_solver(VSASolver::new(&GLOBAL_CONTEXT)),
                 wrap_z3_cached(Z3Solver::new_with_options(&GLOBAL_CONTEXT, timeout, track)),
+                approximate_first,
             ))),
             timeout,
             unsat_core: track,

--- a/crates/clarirs-py/tests/test_hybrid_approximate_first.py
+++ b/crates/clarirs-py/tests/test_hybrid_approximate_first.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pickle
+import unittest
+
+import claripy
+
+
+class TestHybridApproximateFirst(unittest.TestCase):
+    def test_kwarg_accepted(self):
+        """SolverHybrid accepts approximate_first (default False)."""
+        self.assertIsInstance(claripy.SolverHybrid(), claripy.Solver)
+        self.assertIsInstance(claripy.SolverHybrid(approximate_first=True), claripy.Solver)
+
+    def test_exact_by_default(self):
+        """Without approximate_first, eval results are exact."""
+        s = claripy.SolverHybrid()
+        x = claripy.BVS("x", 8)
+        s.add(claripy.UGT(x, claripy.BVV(253, 8)))
+        self.assertEqual(sorted(s.eval(x, 10)), [254, 255])
+
+    def test_approximate_first_eval(self):
+        """approximate_first eval answers multi-solution queries.
+
+        Like claripy, the results come from the approximate backend when the
+        exact backend cannot narrow them further, so they may be imprecise --
+        only the count is guaranteed.
+        """
+        s = claripy.SolverHybrid(approximate_first=True)
+        x = claripy.BVS("x", 8)
+        s.add(claripy.UGT(x, claripy.BVV(250, 8)))
+        vals = s.eval(x, 4)
+        self.assertEqual(len(vals), 4)
+
+    def test_approximate_first_exhaustive(self):
+        """When the approximation is exhaustive, its solutions are used."""
+        s = claripy.SolverHybrid(approximate_first=True)
+        x = claripy.BVS("x", 8)
+        s.add(claripy.UGT(x, claripy.BVV(252, 8)))
+        self.assertEqual(sorted(s.eval(x, 10)), [253, 254, 255])
+
+    def test_small_n_stays_exact(self):
+        """n <= 2 does not trigger the approximate-first path."""
+        s = claripy.SolverHybrid(approximate_first=True)
+        x = claripy.BVS("x", 8)
+        s.add(x == claripy.BVV(7, 8))
+        self.assertEqual(list(s.eval(x, 1)), [7])
+
+    def test_pickle_roundtrip(self):
+        """approximate_first survives a pickle round-trip."""
+        s = claripy.SolverHybrid(approximate_first=True)
+        x = claripy.BVS("x", 8)
+        s.add(claripy.UGT(x, claripy.BVV(250, 8)))
+        s2 = pickle.loads(pickle.dumps(s))
+        vals = s2.eval(x, 4)
+        self.assertEqual(len(vals), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

angr's `o.APPROXIMATE_FIRST` state option constructs its hybrid solver with `SolverHybrid(approximate_first=True)`, which claripy supports but clarirs rejected with a TypeError — the angr clarirs migration (angr/angr#6550) had to drop the kwarg, a feature regression.

## Semantics (mirrors claripy's HybridFrontend)

When `approximate_first` is set and an eval asks for **more than two** solutions:
- draw n + 1 solutions from the approximate (VSA) backend first;
- if the approximation is exhaustive (≤ n solutions) or no constraint mentions the expression's variables, use it directly;
- otherwise also consult the exact backend and keep whichever produced fewer solutions.

As in claripy, approximate results may be imprecise — that's the deliberate trade of the option. Default remains exact-only behavior.

## Implementation

- `HybridSolver` (clarirs-core) gains an `approximate_first` field + `new_with_options` constructor and implements the heuristic in `eval_n`
- `SolverHybrid.__new__` accepts the kwarg; the flag survives `clone`, `blank_copy`, and pickle (per-type flag slot in the state tuple, defaulting to False for older pickles)
- Python tests cover default-exact, approximate-first, exhaustive-approximation, small-n, and pickle round-trip

## Testing

cargo tests (136 core), clarirs-py pytest suite (201 incl. 6 new), `cargo fmt --check`, clippy `-D warnings` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)