### PR TITLE
eval: zero-fill unconstrained bits instead of pinning them via an aux var

### DIFF
--- a/crates/clarirs-py/tests/test_eval_unconstrained.py
+++ b/crates/clarirs-py/tests/test_eval_unconstrained.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import unittest
+
+import claripy
+
+
+class TestEvalUnconstrained(unittest.TestCase):
+    """Unconstrained bits of an evaluated expression default to zero.
+
+    Z3's model completion fills variables absent from the model with zero, and
+    eval reads the expression directly so that behavior is preserved (matching
+    claripy). A previous implementation bound the value to an auxiliary
+    variable, which pulled otherwise-free bits into the model with arbitrary
+    values.
+    """
+
+    def test_fully_unconstrained_bv(self):
+        x = claripy.BVS("x", 32)
+        self.assertEqual(claripy.Solver().eval(x, 1)[0], 0)
+
+    def test_partially_constrained_concat(self):
+        b = [claripy.BVS(f"b_{i}", 8) for i in range(5)]
+        expr = claripy.Concat(*b)
+        s = claripy.Solver()
+        s.add(b[0] == 0x41)
+        s.add(b[1] == 0x42)
+        # b[0], b[1] are pinned; b[2..4] are free and must come out as zero.
+        self.assertEqual(s.eval(expr, 1)[0], 0x4142000000)
+
+    def test_free_bits_zero_with_unrelated_constraints(self):
+        # A free variable stays zero even when the solver carries constraints
+        # over other variables.
+        x = claripy.BVS("x", 16)
+        y = claripy.BVS("y", 16)
+        s = claripy.Solver()
+        s.add(y == 0x1234)
+        self.assertEqual(s.eval(x, 1)[0], 0)
+
+    def test_batch_eval_zero_fills(self):
+        b = [claripy.BVS(f"c_{i}", 8) for i in range(3)]
+        expr = claripy.Concat(*b)
+        s = claripy.Solver()
+        s.add(b[1] == 0x7F)
+        row = s.batch_eval([expr], 1)[0]
+        self.assertEqual(row[0], 0x007F00)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/clarirs-z3/src/solver.rs
+++ b/crates/clarirs-z3/src/solver.rs
@@ -293,6 +293,16 @@ impl<'c> Z3Solver<'c> {
     }
 }
 
+/// Whether `expr` contains an `fp.to_ieee_bv` node anywhere in its tree.
+///
+/// Such expressions can evaluate to a non-constant term against a Z3 model
+/// (fp.to_ieee_bv stays uninterpreted), so eval binds them to an auxiliary
+/// variable instead of reading them from the model directly.
+fn contains_fp_to_ieeebv(expr: &AstRef<'_>) -> bool {
+    matches!(expr.op(), AstOp::FpToIEEEBV(_))
+        || expr.child_iter().any(|c| contains_fp_to_ieeebv(&c))
+}
+
 impl<'c> Solver<'c> for Z3Solver<'c> {
     fn add(&mut self, constraint: &AstRef<'c>) -> Result<(), ClarirsError> {
         let idx = self.assertions.len();
@@ -522,38 +532,52 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
 
         let ctx = self.context();
 
-        // Evaluate through a fresh variable asserted equal to the expression.
-        // Z3 keeps some operators (notably fp.to_ieee_bv) uninterpreted in
-        // models even with model completion, so evaluating the expression
-        // directly can return a non-constant term; an asserted equality forces
-        // the model to assign the variable a constant. Floats are bound via
-        // their IEEE bit pattern (fp equality would make the query unsat for
-        // NaN) and converted back after evaluation.
-        let aux_name = format!("__eval_{:x}", expr.hash());
-        let (aux, link, fp_sort) = match expr.ast_type() {
-            AstType::Float(fsort) => {
-                let aux = ctx.bvs(&aux_name, fsort.size())?;
-                let link = ctx.eq_(&aux, &ctx.fp_to_ieeebv(&expr)?)?;
-                (aux, link, Some(fsort))
-            }
-            AstType::Bool => {
-                let aux = ctx.bools(&aux_name)?;
-                let link = ctx.eq_(&aux, &expr)?;
-                (aux, link, None)
-            }
-            AstType::BitVec(width) => {
-                let aux = ctx.bvs(&aux_name, width)?;
-                let link = ctx.eq_(&aux, &expr)?;
-                (aux, link, None)
-            }
-            AstType::String => {
-                let aux = ctx.strings(&aux_name)?;
-                let link = ctx.eq_(&aux, &expr)?;
-                (aux, link, None)
-            }
+        // Most expressions are read straight out of the model. `Z3_model_eval`
+        // is called with model completion, so bits left unconstrained by the
+        // assertions default to zero -- matching claripy, which evaluates the
+        // expression the same way.
+        //
+        // fp.to_ieee_bv is the exception: Z3 keeps it uninterpreted in models
+        // even with completion, so an expression containing it can evaluate to
+        // a non-constant term. For those we bind the value to a fresh auxiliary
+        // bitvector via an asserted equality, which forces the model to assign
+        // it a constant. Floats go through the same path (bound by their IEEE
+        // bit pattern, since fp equality would be unsat for NaN) and are
+        // converted back afterwards. Binding to an auxiliary variable does pull
+        // otherwise-free bits into the model with arbitrary values, so it is
+        // used only when direct evaluation cannot produce a constant.
+        let fp_sort = match expr.ast_type() {
+            AstType::Float(fsort) => Some(fsort),
+            _ => None,
+        };
+        let needs_aux = fp_sort.is_some() || contains_fp_to_ieeebv(&expr);
+
+        let aux = if needs_aux {
+            let aux_name = format!("__eval_{:x}", expr.hash());
+            let (aux, link) = match &fp_sort {
+                Some(fsort) => {
+                    let aux = ctx.bvs(&aux_name, fsort.size())?;
+                    let link = ctx.eq_(&aux, &ctx.fp_to_ieeebv(&expr)?)?;
+                    (aux, link)
+                }
+                None => {
+                    let aux = ctx.bvs(&aux_name, expr.size())?;
+                    let link = ctx.eq_(&aux, &expr)?;
+                    (aux, link)
+                }
+            };
+            Some((aux, link))
+        } else {
+            None
         };
 
-        let z3_aux = aux.to_z3()?;
+        // The expression whose model value we read and exclude between
+        // iterations: the auxiliary variable when one is used, else `expr`.
+        let eval_target = match &aux {
+            Some((aux, _)) => aux.clone(),
+            None => expr.clone(),
+        };
+        let z3_eval_target = eval_target.to_z3()?;
 
         // Create and fill the Z3 solver once, applying this solver's params
         // (timeout in particular) so eval cannot run unbounded.
@@ -563,7 +587,9 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
             let converted = assertion.to_z3()?;
             z3_solver.assert(&converted)?;
         }
-        z3_solver.assert(&link.to_z3()?)?;
+        if let Some((_, link)) = &aux {
+            z3_solver.assert(&link.to_z3()?)?;
+        }
 
         for _ in 0..n {
             match z3_solver.check()? {
@@ -573,12 +599,12 @@ impl<'c> Solver<'c> for Z3Solver<'c> {
             }
 
             let model = z3_solver.model()?;
-            let eval_result = model.eval(&z3_aux)?;
+            let eval_result = model.eval(&z3_eval_target)?;
 
             let solution = AstRef::from_z3(ctx, eval_result)?;
 
             // Add constraint to exclude this solution
-            let neq_constraint = ctx.neq(&aux, &solution)?;
+            let neq_constraint = ctx.neq(&eval_target, &solution)?;
             let z3_neq = neq_constraint.to_z3()?;
             z3_solver.assert(&z3_neq)?;
 


### PR DESCRIPTION
## Summary

`eval`/`eval_n` bound the queried expression to a fresh auxiliary variable via an asserted equality (`aux == expr`) and read `aux` from the model. The equality pulls otherwise-**unconstrained** sub-bits of the expression into the model, where Z3 assigns them arbitrary values. So evaluating, e.g., a `Concat` whose upper bytes are unconstrained returned `0xff..` for those bytes instead of zero.

claripy evaluates the expression directly with model completion (`model.eval(expr, model_completion=True)`), which fills variables absent from the model with **zero**. This matches that:

- read the expression straight from the model (`Z3_model_eval` already runs with completion), so unconstrained bits default to zero;
- only fall back to the auxiliary-variable trick when the expression contains `fp.to_ieee_bv`, which Z3 keeps uninterpreted in models and which can therefore evaluate to a non-constant term;
- floats keep going through the auxiliary path (bound by their IEEE bit pattern, since fp equality is unsat for NaN).

Surfaced by angr's `test_run_getenv_with_symbolic_env` (angr/angr#6550), where a partially-constrained symbolic flag evaluated with 0xff-filled free bytes instead of zeros.

## Testing

New `test_eval_unconstrained.py` covers fully-/partially-unconstrained `eval` and `batch_eval`. `cargo test -p clarirs-z3` (338), clarirs-py suite, `cargo fmt --check`, clippy `-D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)