### PR TITLE
solver: add downsize() to Solver

### DIFF
--- a/crates/clarirs-py/src/solver.rs
+++ b/crates/clarirs-py/src/solver.rs
@@ -389,6 +389,13 @@ impl PySolver {
         Ok(())
     }
 
+    /// Free memory associated with the solver by clearing internal caches.
+    ///
+    /// claripy exposes this as a memory-management hint; clarirs manages its
+    /// caches internally, so this is a no-op that exists for API parity (angr
+    /// calls `state.solver.downsize()`). It never affects results.
+    fn downsize(&self) {}
+
     #[pyo3(signature = (extra_constraints = None, exact = None))]
     fn satisfiable<'py>(
         &mut self,

--- a/crates/clarirs-py/tests/test_solver_split.py
+++ b/crates/clarirs-py/tests/test_solver_split.py
@@ -51,3 +51,26 @@ class TestSolverSplit(unittest.TestCase):
         s.add(x > 0)
         s.add(x < 5)
         self.assertEqual(len(s.split()), 1)
+
+
+class TestSolverDownsize(unittest.TestCase):
+    def test_downsize_all_solver_types(self):
+        """downsize exists on every solver type and does not affect results."""
+        for factory in (
+            claripy.Solver,
+            claripy.SolverComposite,
+            claripy.SolverHybrid,
+            claripy.SolverReplacement,
+            claripy.SolverCacheless,
+            claripy.SolverVSA,
+            claripy.SolverConcrete,
+        ):
+            s = factory()
+            s.downsize()  # no-op, must not raise
+
+    def test_downsize_preserves_constraints(self):
+        s = claripy.Solver()
+        x = claripy.BVS("x", 32)
+        s.add(x == 5)
+        s.downsize()
+        self.assertEqual(s.eval(x, 1)[0], 5)


### PR DESCRIPTION
## Summary

claripy exposes `Frontend.downsize()` as a memory-management hint — the base implementation is a no-op, and subclasses clear their caches. angr calls `state.solver.downsize()` (in `SimSolver.downsize`) to free solver memory, so every clarirs solver needs the method or angr raises `AttributeError: 'SolverComposite' object has no attribute 'downsize'`.

Add `downsize()` to `PySolver` (inherited by all solver subclasses). clarirs manages its caches internally, so it is a no-op that exists for API parity and never affects results.

Surfaced by angr/rex CI against the clarirs migration (angr/angr#6550).

## Testing

New tests cover downsize on every solver type and that it preserves constraints/results. clarirs-py suite (203), `cargo fmt --check`, clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)